### PR TITLE
Nano: support mo kwargs in trace/quantize and support VPU fp16 in quantize

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -84,13 +84,10 @@ class OpenVINOModel:
         if self.additional_config is not None and self._device == 'CPU':
             # TODO: check addition config based on device
             config.update(self.additional_config)
-        if self._device != 'VPUX' or self._precision == 'int8':
-            # For VPU, now only int8 quantizaton model works
-            # fp16 model always meets compilation error
-            self._compiled_model = self._ie.compile_model(model=self.ie_network,
-                                                          device_name=self._device,
-                                                          config=config)
-            self._infer_request = self._compiled_model.create_infer_request()
+        self._compiled_model = self._ie.compile_model(model=self.ie_network,
+                                                      device_name=self._device,
+                                                      config=config)
+        self._infer_request = self._compiled_model.create_infer_request()
         self.final_config = config
         input_names = [t.any_name for t in self._ie_network.inputs]
         self._forward_args = input_names

--- a/python/nano/src/bigdl/nano/deps/openvino/core/utils.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/utils.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 import subprocess
+import re
 import operator
 from pathlib import Path
 from bigdl.nano.utils.log4Error import invalidInputError
@@ -24,23 +25,32 @@ OpenVINO_LESS_2022_3 = compare_version("openvino", operator.lt, "2022.3")
 
 
 def convert_onnx_to_xml(onnx_file_path, xml_path, precision,
-                        logging=True, batch_size=1):
+                        logging=True, batch_size=1, **kwargs):
     xml_path = Path(xml_path)
     model_name, output_dir = str(xml_path.stem), str(xml_path.parent)
     precision_str = "--data_type FP16" if precision == 'fp16' else ""
+    params_str = ""
+    for key, value in kwargs.items():
+        value = str(value)
+        value = value.replace(' ', '')  # remove space in param value
+        params_str += "--" + str(key) + " " + str(value)
     if OpenVINO_LESS_2022_3:
         logging_str = "--silent" if logging is False else ""
-        mo_cmd = "mo -m {} {} {} -n {} -o {}".format(str(onnx_file_path),
-                                                     logging_str,
-                                                     precision_str,
-                                                     model_name,
-                                                     output_dir)
+        mo_cmd = "mo -m {0} {1} {2} {3} -n {4} -o {5}".format(
+            str(onnx_file_path),
+            logging_str,
+            precision_str,
+            params_str,
+            model_name,
+            output_dir)
     else:
-        mo_cmd = "mo -m {} --silent {} {} -n {} -o {}".format(str(onnx_file_path),
-                                                              not logging,
-                                                              precision_str,
-                                                              model_name,
-                                                              output_dir)
+        mo_cmd = "mo -m {0} --silent {1} {2} {3} -n {4} -o {5}".format(
+            str(onnx_file_path),
+            not logging,
+            precision_str,
+            params_str,
+            model_name,
+            output_dir)
 
     p = subprocess.Popen(mo_cmd.split())
     p.communicate()
@@ -49,23 +59,32 @@ def convert_onnx_to_xml(onnx_file_path, xml_path, precision,
 
 
 def convert_pb_to_xml(pb_file_path, xml_path, precision,
-                      logging=True, batch_size=1):
+                      logging=True, batch_size=1, **kwargs):
     xml_path = Path(xml_path)
     model_name, output_dir = str(xml_path.stem), str(xml_path.parent)
     precision_str = "--data_type FP16" if precision == 'fp16' else ""
+    params_str = ""
+    for key, value in kwargs.items():
+        value = str(value)
+        value = value.replace(' ', '')  # remove space in param value
+        params_str += "--" + str(key) + " " + str(value)
     if OpenVINO_LESS_2022_3:
         logging_str = "--silent" if logging is False else ""
-        mo_cmd = "mo --saved_model_dir {} {} {} -n {} -o {}".format(str(pb_file_path),
-                                                                    logging_str,
-                                                                    precision_str,
-                                                                    model_name,
-                                                                    output_dir)
+        mo_cmd = "mo --saved_model_dir {0} {1} {2} {3} -n {4} -o {5}".format(
+            str(pb_file_path),
+            logging_str,
+            precision_str,
+            params_str,
+            model_name,
+            output_dir)
     else:
-        mo_cmd = "mo --saved_model_dir {} --silent {} {} -n {} -o {}".format(str(pb_file_path),
-                                                                             not logging,
-                                                                             precision_str,
-                                                                             model_name,
-                                                                             output_dir)
+        mo_cmd = "mo --saved_model_dir {0} --silent {1} {2} {3} -n {4} -o {5}".format(
+            str(pb_file_path),
+            not logging,
+            precision_str,
+            params_str,
+            model_name,
+            output_dir)
 
     p = subprocess.Popen(mo_cmd.split())
     p.communicate()

--- a/python/nano/src/bigdl/nano/deps/openvino/core/utils.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/utils.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 import subprocess
-import re
 import operator
 from pathlib import Path
 from bigdl.nano.utils.log4Error import invalidInputError

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -19,7 +19,7 @@ from bigdl.nano.utils.log4Error import invalidInputError
 def PytorchOpenVINOModel(model, input_sample=None, precision='fp32',
                          thread_num=None, device='CPU',
                          dynamic_axes=True, logging=True,
-                         config=None, **export_kwargs):
+                         config=None, **kwargs):
     """
     Create a OpenVINO model from pytorch.
 
@@ -49,7 +49,7 @@ def PytorchOpenVINOModel(model, input_sample=None, precision='fp32',
                          If accelerator != 'openvino'/'onnxruntime', it will be ignored.
     :param logging: whether to log detailed information of model conversion. default: True.
     :param config: The config to be inputted in core.compile_model.
-    :param **export_kwargs: will be passed to torch.onnx.export function.
+    :param **kwargs: will be passed to torch.onnx.export function or model optimizer function.
     :return: PytorchOpenVINOModel model for OpenVINO inference.
     """
     from .pytorch.model import PytorchOpenVINOModel
@@ -61,7 +61,7 @@ def PytorchOpenVINOModel(model, input_sample=None, precision='fp32',
                                 dynamic_axes=dynamic_axes,
                                 logging=logging,
                                 config=config,
-                                **export_kwargs)
+                                **kwargs)
 
 
 def load_openvino_model(path, framework='pytorch', device=None):
@@ -87,7 +87,7 @@ def load_openvino_model(path, framework='pytorch', device=None):
 
 def KerasOpenVINOModel(model, input_spec=None, precision='fp32',
                        thread_num=None, device='CPU', config=None,
-                       logging=True):
+                       logging=True, **kwargs):
     """
     Create a OpenVINO model from Keras.
 
@@ -103,6 +103,7 @@ def KerasOpenVINOModel(model, input_spec=None, precision='fp32',
                    'CPU', 'GPU' and 'VPUX' are supported for now.
     :param config: The config to be inputted in core.compile_model.
     :param logging: whether to log detailed information of model conversion. default: True.
+    :param **kwargs: will be passed to model optimizer function.
     :return: KerasOpenVINOModel model for OpenVINO inference.
     """
     from .tf.model import KerasOpenVINOModel
@@ -112,7 +113,8 @@ def KerasOpenVINOModel(model, input_spec=None, precision='fp32',
                               thread_num=thread_num,
                               device=device,
                               config=config,
-                              logging=logging)
+                              logging=logging,
+                              **kwargs)
 
 
 def OpenVINOModel(model, device='CPU'):

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -32,7 +32,7 @@ from bigdl.nano.pytorch.utils import patch_attrs_from_model_to_object
 class PytorchOpenVINOModel(AcceleratedLightningModule):
     def __init__(self, model, input_sample=None, precision='fp32',
                  thread_num=None, device='CPU', dynamic_axes=True,
-                 logging=True, config=None, **export_kwargs):
+                 logging=True, config=None, **kwargs):
         """
         Create a OpenVINO model from pytorch.
 
@@ -63,7 +63,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                              If accelerator != 'openvino'/'onnxruntime', it will be ignored.
         :param logging: whether to log detailed information of model conversion. default: True.
         :param config: The config to be inputted in core.compile_model.
-        :param **export_kwargs: will be passed to torch.onnx.export function.
+        :param **kwargs: will be passed to torch.onnx.export function or model optimizer function.
         """
         ov_model_path = model
         with TemporaryDirectory() as tmpdir:
@@ -74,7 +74,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                     dynamic_axes = False
                 export(model, input_sample, str(tmpdir / 'tmp.xml'),
                        precision=precision, dynamic_axes=dynamic_axes,
-                       logging=logging, **export_kwargs)
+                       logging=logging, **kwargs)
                 ov_model_path = tmpdir / 'tmp.xml'
 
             self.ov_model = OpenVINOModel(ov_model_path,

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/utils.py
@@ -44,7 +44,7 @@ def export(model, input_sample=None, xml_path="model.xml",
         # split kwargs to torch.onnx.export and mo
         export_args = inspect.getfullargspec(torch.onnx.export).args
         export_defaults = inspect.getfullargspec(torch.onnx.export).defaults
-        export_args = export_args[len(export_args)-len(export_defaults):]
+        export_args = export_args[len(export_args) - len(export_defaults):]
         export_kwargs = {}
         mo_kwargs = {}
         for key, value in kwargs.items():

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -29,7 +29,8 @@ import os
 
 class KerasOpenVINOModel(AcceleratedKerasModel):
     def __init__(self, model, input_spec=None, precision='fp32',
-                 thread_num=None, device='CPU', config=None, logging=True):
+                 thread_num=None, device='CPU', config=None,
+                 logging=True, **kwargs):
         """
         Create a OpenVINO model from Keras.
 
@@ -47,6 +48,7 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
                        inference. default: None.
         :param logging: whether to log detailed information of model conversion.
                         default: True.
+        :param **kwargs: will be passed to model optimizer function.
         """
         ov_model_path = model
         with TemporaryDirectory() as dir:
@@ -63,7 +65,8 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
                     model.compute_output_shape(input_shape)
                 export(model, str(dir / 'tmp.xml'),
                        precision=precision,
-                       logging=logging)
+                       logging=logging,
+                       **kwargs)
                 ov_model_path = dir / 'tmp.xml'
             self.ov_model = OpenVINOModel(ov_model_path,
                                           device=device,

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/utils.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/utils.py
@@ -18,7 +18,7 @@ from ..core.utils import convert_pb_to_xml
 from pathlib import Path
 
 
-def export(model, xml_path="model.xml", precision='fp32', logging=True):
+def export(model, xml_path="model.xml", precision='fp32', logging=True, **kwargs):
     '''
     Function to export pytorch model into openvino and save it to local.
     Any instance of torch.nn.Module including Lightning Module is acceptable.
@@ -28,10 +28,11 @@ def export(model, xml_path="model.xml", precision='fp32', logging=True):
     :param precision: Global precision of model, supported type: 'fp32', 'fp16',
                       defaults to 'fp32'.
     :param logging: whether to log detailed information of model conversion. default: True.
+    :param **kwargs: will be passed to model optimizer function.
     '''
     # export a model with dynamic axes to enable IR to accept different batches and resolutions
     with TemporaryDirectory() as folder:
         folder = Path(folder)
         pb_path = str(folder)
         model.save(str(folder))
-        convert_pb_to_xml(pb_path, xml_path, precision=precision, logging=logging)
+        convert_pb_to_xml(pb_path, xml_path, precision=precision, logging=logging, **kwargs)

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -648,6 +648,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                          2. those be passed to model optimizer function of openvino,
                          only valid when accelerator='openvino',
                          otherwise will be ignored.
+                         If you want to quantize with openvino float16 precision on VPUX device,
+                         you must specify mean_value for model optimizer function.
         :return:            A accelerated torch.nn.Module if quantization is sucessful.
         """
         invalidInputError(precision in ['int8', 'fp16', 'bf16'],
@@ -836,6 +838,13 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                               "fp16 is not supported on {} device.".format(device))
             invalidInputError(accelerator == 'openvino',
                               "fp16 is not supported on {} accelerator.".format(accelerator))
+            if device == 'VPUX':
+                # for fp16 on VPUX, must specify mean_value.
+                invalidInputError('mean_value' in kwargs,
+                                  "If you want to quantize with openvino float16 precision on "
+                                  "VPUX device, you must specify mean_value for model optimizer "
+                                  "function. For more details about model optimizer, you can "
+                                  "see mo --help .")
             return PytorchOpenVINOModel(model, input_sample,
                                         precision=precision,
                                         thread_num=thread_num,

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -642,14 +642,24 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                          QConfig.html#torch.quantization.qconfig.QConfig .
                          This parameter only works for native ipex quantization.
         :param **kwargs: Other extra advanced settings include:
-                         1. those be passed to torch.onnx.export function,
+                         1. those be passed to ``torch.onnx.export`` function,
                          only valid when accelerator='onnxruntime'/'openvino',
                          otherwise will be ignored.
-                         2. those be passed to model optimizer function of openvino,
+                         Possible arguments are: input_names, output_names, opset_version, 
+                         et al. For more details, please refer
+                         https://pytorch.org/docs/stable/onnx.html#torch.onnx.export.
+                         2. those be passed to ``model optimizer`` function of openvino,
                          only valid when accelerator='openvino',
                          otherwise will be ignored.
+                         Possible arguments are: mean_values, layout, input, output, et al.
+                         For more details about model optimizer, you can see mo --help .
                          If you want to quantize with openvino float16 precision on VPUX device,
-                         you must specify mean_value for model optimizer function.
+                         you must specify  ``mean_value`` for model optimizer function.
+                         Here ``mean_value`` represents mean values to be used for the input image
+                         per channel. Values to be provided in the (R,G,B) or [R,G,B] format. 
+                         Can be defined for desired input of the model, for example: 
+                         "--mean_values data[255,255,255],info[255,255,255]". The exact meaning 
+                         and order of channels depend on how the original model was trained.
         :return:            A accelerated torch.nn.Module if quantization is sucessful.
         """
         invalidInputError(precision in ['int8', 'fp16', 'bf16'],
@@ -940,9 +950,14 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                          1. those be passed to torch.onnx.export function,
                          only valid when accelerator='onnxruntime'/'openvino',
                          otherwise will be ignored.
+                         Possible arguments are: input_names, output_names, opset_version, 
+                         et al. For more details, please refer
+                         https://pytorch.org/docs/stable/onnx.html#torch.onnx.export.
                          2. those be passed to model optimizer function of openvino,
                          only valid when accelerator='openvino',
                          otherwise will be ignored.
+                         Possible arguments are: mean_values, layout, input, output, et al.
+                         For more details about model optimizer, you can see mo --help .
         :return: Model with different acceleration.
         """
         invalidInputError(

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -645,7 +645,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                          1. those be passed to ``torch.onnx.export`` function,
                          only valid when accelerator='onnxruntime'/'openvino',
                          otherwise will be ignored.
-                         Possible arguments are: input_names, output_names, opset_version, 
+                         Possible arguments are: input_names, output_names, opset_version,
                          et al. For more details, please refer
                          https://pytorch.org/docs/stable/onnx.html#torch.onnx.export.
                          2. those be passed to ``model optimizer`` function of openvino,
@@ -656,9 +656,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                          If you want to quantize with openvino float16 precision on VPUX device,
                          you must specify  ``mean_value`` for model optimizer function.
                          Here ``mean_value`` represents mean values to be used for the input image
-                         per channel. Values to be provided in the (R,G,B) or [R,G,B] format. 
-                         Can be defined for desired input of the model, for example: 
-                         "--mean_values data[255,255,255],info[255,255,255]". The exact meaning 
+                         per channel. Values to be provided in the (R,G,B) or [R,G,B] format.
+                         Can be defined for desired input of the model, for example:
+                         "--mean_values data[255,255,255],info[255,255,255]". The exact meaning
                          and order of channels depend on how the original model was trained.
         :return:            A accelerated torch.nn.Module if quantization is sucessful.
         """
@@ -950,7 +950,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                          1. those be passed to torch.onnx.export function,
                          only valid when accelerator='onnxruntime'/'openvino',
                          otherwise will be ignored.
-                         Possible arguments are: input_names, output_names, opset_version, 
+                         Possible arguments are: input_names, output_names, opset_version,
                          et al. For more details, please refer
                          https://pytorch.org/docs/stable/onnx.html#torch.onnx.export.
                          2. those be passed to model optimizer function of openvino,

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -327,6 +327,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param **kwargs: Other extra advanced settings include those be passed to model optimizer
                          function of openvino, only valid when accelerator='openvino',
                          otherwise will be ignored.
+                         Possible arguments are: mean_values, layout, input, output, et al.
+                         For more details about model optimizer, you can see mo --help .
         :return: Model with different acceleration(OpenVINO/ONNX Runtime).
         """
         # device name might be: CPU, GPU, GPU.0, VPUX ...
@@ -460,11 +462,25 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                 accelerator='openvino', otherwise will be ignored.
         :param logging: whether to log detailed information of model conversion, only valid when
                         accelerator='openvino', otherwise will be ignored. Default: ``True``.
-        :param **kwargs: Other extra advanced settings include those be passed to model optimizer
-                         function of openvino, only valid when accelerator='openvino',
+        :param **kwargs: Other extra advanced settings include:
+                         1. those be passed to ``torch.onnx.export`` function,
+                         only valid when accelerator='onnxruntime'/'openvino',
                          otherwise will be ignored.
+                         Possible arguments are: input_names, output_names, opset_version, 
+                         et al. For more details, please refer
+                         https://pytorch.org/docs/stable/onnx.html#torch.onnx.export.
+                         2. those be passed to ``model optimizer`` function of openvino,
+                         only valid when accelerator='openvino',
+                         otherwise will be ignored.
+                         Possible arguments are: mean_values, layout, input, output, et al.
+                         For more details about model optimizer, you can see mo --help .
                          If you want to quantize with openvino float16 precision on VPUX device,
-                         you must specify mean_value for model optimizer function.
+                         you must specify  ``mean_value`` for model optimizer function.
+                         Here ``mean_value`` represents mean values to be used for the input image
+                         per channel. Values to be provided in the (R,G,B) or [R,G,B] format. 
+                         Can be defined for desired input of the model, for example: 
+                         "--mean_values data[255,255,255],info[255,255,255]". The exact meaning 
+                         and order of channels depend on how the original model was trained.
         :return:            A TensorflowBaseModel. If there is no model found, return None.
         """
         invalidInputError(precision in ['int8', 'fp16', 'bf16'],

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -466,7 +466,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                          1. those be passed to ``torch.onnx.export`` function,
                          only valid when accelerator='onnxruntime'/'openvino',
                          otherwise will be ignored.
-                         Possible arguments are: input_names, output_names, opset_version, 
+                         Possible arguments are: input_names, output_names, opset_version,
                          et al. For more details, please refer
                          https://pytorch.org/docs/stable/onnx.html#torch.onnx.export.
                          2. those be passed to ``model optimizer`` function of openvino,
@@ -477,9 +477,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                          If you want to quantize with openvino float16 precision on VPUX device,
                          you must specify  ``mean_value`` for model optimizer function.
                          Here ``mean_value`` represents mean values to be used for the input image
-                         per channel. Values to be provided in the (R,G,B) or [R,G,B] format. 
-                         Can be defined for desired input of the model, for example: 
-                         "--mean_values data[255,255,255],info[255,255,255]". The exact meaning 
+                         per channel. Values to be provided in the (R,G,B) or [R,G,B] format.
+                         Can be defined for desired input of the model, for example:
+                         "--mean_values data[255,255,255],info[255,255,255]". The exact meaning
                          and order of channels depend on how the original model was trained.
         :return:            A TensorflowBaseModel. If there is no model found, return None.
         """

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -463,6 +463,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param **kwargs: Other extra advanced settings include those be passed to model optimizer
                          function of openvino, only valid when accelerator='openvino',
                          otherwise will be ignored.
+                         If you want to quantize with openvino float16 precision on VPUX device,
+                         you must specify mean_value for model optimizer function.
         :return:            A TensorflowBaseModel. If there is no model found, return None.
         """
         invalidInputError(precision in ['int8', 'fp16', 'bf16'],
@@ -480,6 +482,13 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                               "fp16 is not supported on {} device.".format(device))
             invalidInputError(accelerator == 'openvino',
                               "fp16 is not supported on {} accelerator.".format(accelerator))
+            if device == 'VPUX':
+                # for fp16 on VPUX, must specify mean_value.
+                invalidInputError('mean_value' in kwargs,
+                                  "If you want to quantize with openvino float16 precision on "
+                                  "VPUX device, you must specify mean_value for model optimizer "
+                                  "function. For more details about model optimizer, you can "
+                                  "see mo --help .")
             from bigdl.nano.deps.openvino.tf.model import KerasOpenVINOModel    # type: ignore
             result = KerasOpenVINOModel(model,
                                         input_spec=input_spec,

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -18,6 +18,7 @@ from unittest import TestCase
 from bigdl.nano.pytorch import Trainer
 from bigdl.nano.pytorch import InferenceOptimizer
 from torchvision.models.mobilenetv3 import mobilenet_v3_small
+from torchvision.models import resnet50
 import torch
 import torch.nn as nn
 import numpy as np
@@ -287,3 +288,17 @@ class TestOpenVINO(TestCase):
             InferenceOptimizer.save(openvino_model, tmp_dir_name)
             model = InferenceOptimizer.load(tmp_dir_name)  # GPU model
             model = InferenceOptimizer.load(tmp_dir_name, device='CPU')  # CPU model
+
+    def test_openvino_trace_kwargs(self):
+        # test export kwargs and mo kwargs for openvino
+        model = resnet50()
+        x = torch.randn(1, 3, 224, 224)
+
+        ov_model = InferenceOptimizer.trace(model,
+                                            accelerator="openvino",
+                                            input_sample=x,
+                                            do_constant_folding=False, # onnx export param
+                                            mean_value=[123.68,116.78,103.94]  # ov mo param
+                                            )
+        with InferenceOptimizer.get_context(ov_model):
+            result = ov_model(x)

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -281,6 +281,35 @@ class TestOpenVINO(TestCase):
         # VPU don't support dynamic shape
         with pytest.raises(RuntimeError):
             openvino_model(x2)
+        
+        # test VPU fp16
+        model = resnet50()
+        with pytest.raises(RuntimeError):
+            openvino_model = InferenceOptimizer.quanize(model,
+                                                        input_sample=x,
+                                                        accelerator='openvino',
+                                                        device='VPUX',
+                                                        precision='fp16')
+
+        openvino_model = InferenceOptimizer.quanize(model,
+                                                    input_sample=x,
+                                                    accelerator='openvino',
+                                                    device='VPUX',
+                                                    precision='fp16',
+                                                    mean_value=[123.68,116.78,103.94])  # first type of mean value
+        result = openvino_model(x)
+
+        openvino_model = InferenceOptimizer.quanize(model,
+                                                    input_sample=x,
+                                                    accelerator='openvino',
+                                                    device='VPUX',
+                                                    precision='fp16',
+                                                    mean_value="x[123.68,116.78,103.94]") # the second type of mean value
+        result = openvino_model(x)
+
+        # VPU don't support dynamic shape
+        with pytest.raises(RuntimeError):
+            openvino_model(x2)
 
     def test_openvino_kwargs(self):
         # test export kwargs and mo kwargs for openvino

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -18,6 +18,7 @@ from torchmetrics import F1Score
 from bigdl.nano.pytorch import Trainer
 from bigdl.nano.pytorch import InferenceOptimizer
 from torchvision.models.mobilenetv3 import mobilenet_v3_small
+from torchvision.models import resnet50
 import torch
 from torch import nn
 from torch.utils.data.dataset import TensorDataset
@@ -280,3 +281,18 @@ class TestOpenVINO(TestCase):
         # VPU don't support dynamic shape
         with pytest.raises(RuntimeError):
             openvino_model(x2)
+
+    def test_openvino_kwargs(self):
+        # test export kwargs and mo kwargs for openvino
+        model = resnet50()
+        x = torch.randn(1, 3, 224, 224)
+
+        ov_model = InferenceOptimizer.quantize(model,
+                                               accelerator="openvino",
+                                               input_sample=x,
+                                               calib_data=x,
+                                               do_constant_folding=False, # onnx export param
+                                               mean_value=[123.68,116.78,103.94]  # ov mo param
+                                               )
+        with InferenceOptimizer.get_context(ov_model):
+            result = ov_model(x)

--- a/python/nano/test/openvino/tf/test_openvino.py
+++ b/python/nano/test/openvino/tf/test_openvino.py
@@ -106,3 +106,16 @@ class TestOpenVINO(TestCase):
             InferenceOptimizer.save(openvino_model, tmp_dir_name)
             load_model = InferenceOptimizer.load(tmp_dir_name, model)  # GPU model
             load_model = InferenceOptimizer.load(tmp_dir_name, model, device='CPU')  # CPU model
+
+    def test_model_trace_openvino_kwargs(self):
+        model = MobileNetV2(weights=None, input_shape=[40, 40, 3], classes=10)
+        model = Model(inputs=model.inputs, outputs=model.outputs)
+        train_examples = np.random.random((100, 40, 40, 3))
+        train_labels = np.random.randint(0, 10, size=(100,))
+        train_dataset = tf.data.Dataset.from_tensor_slices((train_examples, train_labels)).batch(2)
+
+        # trace a Keras model
+        openvino_model = InferenceOptimizer.trace(model, accelerator='openvino', thread_num=4,
+                                                  mean_value=[123.68,116.78,103.94]) # mo param
+        y_hat = openvino_model(train_examples[:10])
+        assert y_hat.shape == (10, 10)

--- a/python/nano/test/openvino/tf/test_openvino_quantize.py
+++ b/python/nano/test/openvino/tf/test_openvino_quantize.py
@@ -15,6 +15,7 @@
 #
 from unittest import TestCase
 import tensorflow as tf
+import pytest
 from tensorflow.keras.applications.mobilenet_v2 import MobileNetV2
 import numpy as np
 from bigdl.nano.tf.keras import Model, InferenceOptimizer
@@ -194,5 +195,51 @@ class TestOpenVINO(TestCase):
                                                                thread_num=8,
                                                                mean_value=[123.68,116.78,103.94]) # mo param
 
+        y_hat = openvino_quantized_model(train_examples[:10])
+        assert y_hat.shape == (10, 10)
+    
+    def test_model_quantize_openvino_vpu(self):
+        # test whether contains VPU
+        from openvino.runtime import Core
+        core = Core()
+        devices = core.available_devices
+        vpu_avaliable = any('VPUX' in x for x in devices)
+        
+        if vpu_avaliable is False:
+            return
+        
+        # test VPUX int8
+        model = MobileNetV2(weights=None, input_shape=[40, 40, 3], classes=10)
+        model = Model(inputs=model.inputs, outputs=model.outputs)
+        train_examples = np.random.random((100, 40, 40, 3))
+        train_labels = np.random.randint(0, 10, size=(100,))
+        train_dataset = tf.data.Dataset.from_tensor_slices((train_examples, train_labels))
+
+        openvino_model = model.trace(accelerator='openvino')
+        openvino_quantized_model = InferenceOptimizer.quantize(openvino_model,
+                                                               accelerator='openvino',
+                                                               x=train_dataset,
+                                                               thread_num=8,
+                                                               device='VPUX',
+                                                               precision='int8')
+        y_hat = openvino_quantized_model(train_examples[:10])
+        assert y_hat.shape == (10, 10)
+        
+        # test VPUX fp16
+        with pytest.raises(RuntimeError):
+            openvino_quantized_model = InferenceOptimizer.quantize(openvino_model,
+                                                                   accelerator='openvino',
+                                                                   x=train_dataset,
+                                                                   thread_num=8,
+                                                                   device='VPUX',
+                                                                   precision='fp16')
+        
+        openvino_quantized_model = InferenceOptimizer.quantize(openvino_model,
+                                                               accelerator='openvino',
+                                                               x=train_dataset,
+                                                               thread_num=8,
+                                                               device='VPUX',
+                                                               precision='fp16',
+                                                               mean_value=[127.5, 127.5, 127.5])
         y_hat = openvino_quantized_model(train_examples[:10])
         assert y_hat.shape == (10, 10)


### PR DESCRIPTION
## Description

In this PR, try to expose kwargs of model optimizer to user, and support VPU fp16 precision by forcibly reminding user to pass in `mean_value` parameter to model optimizer.

### 1. Why the change?

After my debugging, I found VPU fp16 works only if we pass `mean_value` paramater to model optimizer.
At the same time, model optimizer has many other params, and user maybe want to specify some of them, I think we should expose these kwargs to user and on the PyTorch side, distinguish between `torch.onnx.export` and `model optimizer`'s kwargs.

### 2. User API changes

Now user can pass in kwargs for `torch.onnx.export` function and `model optimizer` function, for example:
```python
ov_model = InferenceOptimizer.quantize(model,
                                       accelerator="openvino",
                                       input_sample=x,
                                       calib_data=x,
                                       precision='int8',
                                       do_constant_folding=False,  # pass to torch.onnx.export
                                       mean_value=[123.68,116.78,103.94]  # pass to model optimizer
                                       )
```
At the same time, we have supported VPUX fp16, the API looks like (**mean_value is necessary for VPU fp16**) :
```python
openvino_model = InferenceOptimizer.quanize(model,
                                            input_sample=x,
                                            accelerator='openvino',
                                            device='VPUX',
                                            precision='fp16',
                                            mean_value=[123.68,116.78,103.94])
```
For TensorFlow, the usage is similar.

### 3. Summary of the change 

- export kwargs of model optimizer to user
- on PyTorch side, distinguish between `torch.onnx.export` and `model optimizer`'s kwargs.
- related ut for this kwargs
- support VPUX fp16 by forcibly reminding user to pass in `mean_value` parameter to model optimizer.
- related ut for this

### 4. How to test?
- [x] Unit test

