### PR TITLE
Nano: fix bug of openvino pot and device check

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -63,8 +63,8 @@ class OpenVINOModel:
             # GPU is equivalent to GPU.0
             return True
         invalidInputError(device in devices,
-                          "Your machine don't have {} device, please modify the incoming "
-                          "device value.".format(device))
+                          "Your machine don't have {} device (only have {}), please modify "
+                          "the incoming device value.".format(device, ",".join(list(devices))))
 
     @property
     def forward_args(self):

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -59,6 +59,9 @@ class OpenVINOModel:
 
     def _check_device(self, ie, device):
         devices = ie.available_devices
+        if device == 'GPU' and 'GPU.0' in devices:
+            # GPU is equivalent to GPU.0
+            return True
         invalidInputError(device in devices,
                           "Your machine don't have {} device, please modify the incoming "
                           "device value.".format(device))

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -82,8 +82,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                                           precision=precision,
                                           thread_num=thread_num,
                                           config=config)
-
-        super().__init__(None)
+            super().__init__(None)
         self._nano_context_manager = generate_context_manager(accelerator="openvino",
                                                               precision="fp32",
                                                               thread_num=thread_num)

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -76,14 +76,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                        precision=precision, dynamic_axes=dynamic_axes,
                        logging=logging, **kwargs)
                 ov_model_path = tmpdir / 'tmp.xml'
-            self.dynamic_axes = dynamic_axes
-            self.ov_model = OpenVINOModel(ov_model_path,
-                                          device=device,
-                                          precision=precision,
-                                          thread_num=thread_num,
-                                          config=config)
 
-        if not isinstance(model, torch.nn.Module):
             self.ov_model = OpenVINOModel(ov_model_path,
                                           device=device,
                                           precision=precision,
@@ -176,8 +169,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                       device=self.ov_model._device,
                       thread_num=thread_num,
                       precision='int8',
-                      config=config,
-                      dynamic_axes=self.dynamic_axes)
+                      config=config)
         return self
 
     def _save_model(self, path):

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -77,12 +77,19 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                        logging=logging, **kwargs)
                 ov_model_path = tmpdir / 'tmp.xml'
             self.dynamic_axes = dynamic_axes
+            self.ov_model = OpenVINOModel(ov_model_path,
+                                          device=device,
+                                          precision=precision,
+                                          thread_num=thread_num,
+                                          config=config)
 
-        self.ov_model = OpenVINOModel(ov_model_path,
-                                      device=device,
-                                      precision=precision,
-                                      thread_num=thread_num,
-                                      config=config)
+        if not isinstance(model, torch.nn.Module):
+            self.ov_model = OpenVINOModel(ov_model_path,
+                                          device=device,
+                                          precision=precision,
+                                          thread_num=thread_num,
+                                          config=config)
+
         super().__init__(None)
         self._nano_context_manager = generate_context_manager(accelerator="openvino",
                                                               precision="fp32",

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -76,13 +76,14 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                        precision=precision, dynamic_axes=dynamic_axes,
                        logging=logging, **kwargs)
                 ov_model_path = tmpdir / 'tmp.xml'
+            self.dynamic_axes = dynamic_axes
 
-            self.ov_model = OpenVINOModel(ov_model_path,
-                                          device=device,
-                                          precision=precision,
-                                          thread_num=thread_num,
-                                          config=config)
-            super().__init__(None)
+        self.ov_model = OpenVINOModel(ov_model_path,
+                                      device=device,
+                                      precision=precision,
+                                      thread_num=thread_num,
+                                      config=config)
+        super().__init__(None)
         self._nano_context_manager = generate_context_manager(accelerator="openvino",
                                                               precision="fp32",
                                                               thread_num=thread_num)
@@ -165,9 +166,11 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         # below code will re-define a new object, and original attrs will be lost.
         # return PytorchOpenVINOModel(model, thread_num=thread_num, config=config)
         self.__init__(model,
+                      device=self.ov_model._device,
                       thread_num=thread_num,
                       precision='int8',
-                      config=config)
+                      config=config,
+                      dynamic_axes=self.dynamic_axes)
         return self
 
     def _save_model(self, path):

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -119,7 +119,8 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
                                   maximal_drop=maximal_drop, max_iter_num=max_iter_num,
                                   n_requests=n_requests, sample_size=sample_size)
         return KerasOpenVINOModel(model, precision='int8',
-                                  config=config, thread_num=thread_num)
+                                  config=config, thread_num=thread_num,
+                                  device=self.ov_model._device)
 
     @staticmethod
     def _load(path, device=None):

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -806,6 +806,13 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                         input_sample = calib_dataloader
                     # For CPU: fp32 -> int8, for GPU/VPUX: fp16 -> int8
                     _precision = 'fp16' if device != 'CPU' else 'fp32'
+                    if device == 'VPUX':
+                        # for fp16 on VPUX, must specify mean_value.
+                        invalidInputError('mean_value' in kwargs,
+                                          "If you want to quantize with openvino on VPUX device, "
+                                          "you must specify mean_value for model optimizer function. "
+                                          "For more details about model optimizer, you can see "
+                                          "mo --help .")
                     model = PytorchOpenVINOModel(model, input_sample,
                                                  precision=_precision,
                                                  thread_num=thread_num,

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -810,9 +810,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                         # for fp16 on VPUX, must specify mean_value.
                         invalidInputError('mean_value' in kwargs,
                                           "If you want to quantize with openvino on VPUX device, "
-                                          "you must specify mean_value for model optimizer function. "
-                                          "For more details about model optimizer, you can see "
-                                          "mo --help .")
+                                          "you must specify mean_value for model optimizer "
+                                          "function. For more details about model optimizer, you "
+                                          "can see mo --help .")
                     model = PytorchOpenVINOModel(model, input_sample,
                                                  precision=_precision,
                                                  thread_num=thread_num,

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -653,7 +653,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                          otherwise will be ignored.
                          Possible arguments are: mean_values, layout, input, output, et al.
                          For more details about model optimizer, you can see mo --help .
-                         If you want to quantize with openvino float16 precision on VPUX device,
+                         If you want to quantize with openvino on VPUX device,
                          you must specify  ``mean_value`` for model optimizer function.
                          Here ``mean_value`` represents mean values to be used for the input image
                          per channel. Values to be provided in the (R,G,B) or [R,G,B] format.

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -474,7 +474,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                          otherwise will be ignored.
                          Possible arguments are: mean_values, layout, input, output, et al.
                          For more details about model optimizer, you can see mo --help .
-                         If you want to quantize with openvino float16 precision on VPUX device,
+                         If you want to quantize with openvino on VPUX device,
                          you must specify  ``mean_value`` for model optimizer function.
                          Here ``mean_value`` represents mean values to be used for the input image
                          per channel. Values to be provided in the (R,G,B) or [R,G,B] format.
@@ -574,6 +574,13 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             else:
                 # For CPU: fp32 -> int8, for GPU: fp16 -> int8
                 _precision = 'fp16' if device != 'CPU' else 'fp32'
+                if device == 'VPUX':
+                    # for fp16 on VPUX, must specify mean_value.
+                    invalidInputError('mean_value' in kwargs,
+                                      "If you want to quantize with openvino on VPUX device, "
+                                      "you must specify mean_value for model optimizer function. "
+                                      "For more details about model optimizer, you can see "
+                                      "mo --help .")
                 openvino_model = KerasOpenVINOModel(model,
                                                     input_spec=input_spec,
                                                     precision=_precision,

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -578,9 +578,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                     # for fp16 on VPUX, must specify mean_value.
                     invalidInputError('mean_value' in kwargs,
                                       "If you want to quantize with openvino on VPUX device, "
-                                      "you must specify mean_value for model optimizer function. "
-                                      "For more details about model optimizer, you can see "
-                                      "mo --help .")
+                                      "you must specify mean_value for model optimizer "
+                                      "function. For more details about model optimizer, you "
+                                      "can see mo --help .")
                 openvino_model = KerasOpenVINOModel(model,
                                                     input_spec=input_spec,
                                                     precision=_precision,


### PR DESCRIPTION
## Description

During demo test, find two openvino related bugs :
- openvino pot don't set device param, so device param don't work for int8 model, which will always use CPU device
- openvino device will raise error when input is 'GPU' and ie.available_devices are ['GPU.0', 'GPU.1', ...], actually GPU is quivalent to GPU.0 in openvino

### 1. Why the change?

Bug fix.

### 2. User API changes

No change.

### 3. Summary of the change 

Fix above two openvino related bugs and make the device check error message more detailed.

### 4. How to test?
- [x] Unit test
