### PR TITLE
[Nano] Small typo fix for tf bf16 training how-to guide

### DIFF
--- a/python/nano/tutorial/notebook/training/tensorflow/tensorflow_training_bf16.ipynb
+++ b/python/nano/tutorial/notebook/training/tensorflow/tensorflow_training_bf16.ipynb
@@ -354,7 +354,7 @@
    "source": [
     "> 📝 **Note**\n",
     ">\n",
-    "> The model created after the `unpatch_tensorflow` function will have `'float32'` as its global dtype policy. However, the model created before, under `patch_tensorflow(precision='mixed_bfloat32')`, will still has layers with `'mixed_bfloat32'` as dtype policy."
+    "> The model created after the `unpatch_tensorflow` function will have `'float32'` as its global dtype policy. However, the model created before, under `patch_tensorflow(precision='mixed_bfloat16')`, will still has layers with `'mixed_bfloat16'` as dtype policy."
    ]
   },
   {


### PR DESCRIPTION
Small typo fix for tf bf16 training how-to guide

Document test: https://yuwentestdocs.readthedocs.io/en/nano-tf-bf16-training-smallfix/doc/Nano/Howto/Training/TensorFlow/tensorflow_training_bf16.html#(Optional)-Unpatch-TensorFlow