### PR TITLE
[PPML] Add overloaded csv method for EncryptedDataFrameWriter

### DIFF
--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/dataframe/EncryptedDataFrameWriter.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/dataframe/EncryptedDataFrameWriter.scala
@@ -77,6 +77,24 @@ class EncryptedDataFrameWriter(
     }
   }
 
+  def csv(path: String, key: String): Unit = {
+    encryptMode match {
+      case PLAIN_TEXT =>
+        df.write.options(extraOptions).mode(mode).csv(path)
+      case AES_CBC_PKCS5PADDING =>
+        sparkSession.sparkContext.hadoopConfiguration
+          .set("hadoop.io.compression.codecs",
+          "com.intel.analytics.bigdl.ppml.crypto.CryptoCodec")
+        sparkSession.sparkContext.hadoopConfiguration
+          .set("bigdl.kms.data.key", key)
+        df.write
+          .option("compression", "com.intel.analytics.bigdl.ppml.crypto.CryptoCodec")
+          .options(extraOptions).mode(mode).csv(path)
+      case _ =>
+        Log4Error.invalidOperationError(false, "unknown EncryptMode " + CryptoMode.toString)
+    }
+  }
+
   def json(path: String): Unit = {
     encryptMode match {
       case PLAIN_TEXT =>


### PR DESCRIPTION
## Description

add an overloaded `csv` method, which could accept a key from parameter and add this key into `sparkSession.sparkContext.hadoopConfiguration`, so that dataframe could get this key easily.
