### PR TITLE
Chronos: solve overhead caused by context_manager

### DIFF
--- a/python/chronos/example/inference-acceleration/cpu_inference_acceleration.py
+++ b/python/chronos/example/inference-acceleration/cpu_inference_acceleration.py
@@ -43,7 +43,7 @@ def gen_dataloader():
     return tsdata_traindataloader, tsdata_valdataloader, tsdata_testdataloader
 
 def predict_wraper(model, input_sample):
-    with InferenceOptimizer.get_context(model):
+    with torch.no_grad():
         model(input_sample)
 
 if __name__ == '__main__':

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -685,7 +685,7 @@ class BasePytorchForecaster(Forecaster):
         from bigdl.chronos.pytorch.utils import _pytorch_fashion_inference
         from bigdl.nano.utils.log4Error import invalidInputError
 
-        if quantize or not acceleration:
+        if quantize or acceleration:
             self.thread_num = set_pytorch_thread(self.optimized_model_thread_num, self.thread_num)
 
         if isinstance(data, TSDataset):

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -685,10 +685,8 @@ class BasePytorchForecaster(Forecaster):
         from bigdl.chronos.pytorch.utils import _pytorch_fashion_inference
         from bigdl.nano.utils.log4Error import invalidInputError
 
-        if self.optimized_model_thread_num is not None and \
-        self.optimized_model_thread_num != self.thread_num:
-            self.thread_num = self.optimized_model_thread_num
-            torch.set_num_threads(self.thread_num)
+        if quantize or not acceleration:
+            self.thread_num = set_pytorch_thread(self.optimized_model_thread_num, self.thread_num)
 
         if isinstance(data, TSDataset):
             _rolled = data.numpy_x is None
@@ -794,10 +792,7 @@ class BasePytorchForecaster(Forecaster):
             invalidInputError(False,
                               "You must call fit or restore first before calling predict!")
 
-        if self.optimized_model_thread_num is not None and \
-        self.optimized_model_thread_num != self.thread_num:
-            self.thread_num = self.optimized_model_thread_num
-            torch.set_num_threads(self.thread_num)
+        self.thread_num = set_pytorch_thread(self.optimized_model_thread_num, self.thread_num)
 
         if isinstance(data, TSDataset):
             _rolled = data.numpy_x is None
@@ -819,6 +814,8 @@ class BasePytorchForecaster(Forecaster):
         else:
             if self.accelerate_method != "onnxruntime_fp32":
                 self.build_onnx()
+                self.thread_num = set_pytorch_thread(self.optimized_model_thread_num,
+                                                     self.thread_num)
             return _pytorch_fashion_inference(model=self.accelerated_model,
                                               input_data=data,
                                               batch_size=batch_size)
@@ -870,10 +867,7 @@ class BasePytorchForecaster(Forecaster):
             invalidInputError(False,
                               "You must call fit or restore first before calling predict!")
 
-        if self.optimized_model_thread_num is not None and \
-        self.optimized_model_thread_num != self.thread_num:
-            self.thread_num = self.optimized_model_thread_num
-            torch.set_num_threads(self.thread_num)
+        self.thread_num = set_pytorch_thread(self.optimized_model_thread_num, self.thread_num)
 
         if isinstance(data, TSDataset):
             _rolled = data.numpy_x is None
@@ -896,6 +890,8 @@ class BasePytorchForecaster(Forecaster):
         else:
             if self.accelerate_method != "openvino_fp32":
                 self.build_openvino()
+                self.thread_num = set_pytorch_thread(self.optimized_model_thread_num,
+                                                     self.thread_num)
             return _pytorch_fashion_inference(model=self.accelerated_model,
                                               input_data=data,
                                               batch_size=batch_size)
@@ -947,10 +943,7 @@ class BasePytorchForecaster(Forecaster):
             invalidInputError(False,
                               "You must call fit or restore first before calling predict!")
 
-        if self.optimized_model_thread_num is not None and \
-        self.optimized_model_thread_num != self.thread_num:
-            self.thread_num = self.optimized_model_thread_num
-            torch.set_num_threads(self.thread_num)
+        self.thread_num = set_pytorch_thread(self.optimized_model_thread_num, self.thread_num)
 
         if isinstance(data, TSDataset):
             _rolled = data.numpy_x is None
@@ -973,6 +966,8 @@ class BasePytorchForecaster(Forecaster):
         else:
             if self.accelerate_method != "jit_fp32":
                 self.build_jit()
+                self.thread_num = set_pytorch_thread(self.optimized_model_thread_num,
+                                                     self.thread_num)
             return _pytorch_fashion_inference(model=self.accelerated_model,
                                               input_data=data,
                                               batch_size=batch_size)
@@ -1275,10 +1270,7 @@ class BasePytorchForecaster(Forecaster):
             invalidInputError(False,
                               "You must call fit or restore first before calling predict_interval!")
 
-        if self.optimized_model_thread_num is not None and \
-        self.optimized_model_thread_num != self.thread_num:
-            self.thread_num = self.optimized_model_thread_num
-            torch.set_num_threads(self.thread_num)
+        self.thread_num = set_pytorch_thread(self.optimized_model_thread_num, self.thread_num)
 
         # step1, according to validation dataset, calculate inherent noise
         if not hasattr(self, "data_noise"):
@@ -1742,7 +1734,6 @@ class BasePytorchForecaster(Forecaster):
         """
         from bigdl.nano.pytorch import InferenceOptimizer
         from bigdl.nano.utils.log4Error import invalidInputError
-        from .utils import get_exported_module
         from pathlib import Path
         if self.distributed:
             invalidInputError(False,

--- a/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
@@ -149,6 +149,8 @@ class LSTMForecaster(BasePytorchForecaster):
 
         # nano setting
         current_num_threads = torch.get_num_threads()
+        self.thread_num = current_num_threads
+        self.optimized_model_thread_num = current_num_threads
         if current_num_threads >= 24:
             self.num_processes = max(1, current_num_threads//8)  # 8 is a magic num
         else:

--- a/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
@@ -157,6 +157,8 @@ class NBeatsForecaster(BasePytorchForecaster):
 
         # nano settings
         current_num_threads = torch.get_num_threads()
+        self.thread_num = current_num_threads
+        self.optimized_model_thread_num = current_num_threads
         if current_num_threads >= 24:
             self.num_processes = max(1, current_num_threads//8)  # 8 is a magic num
         else:

--- a/python/chronos/src/bigdl/chronos/forecaster/seq2seq_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/seq2seq_forecaster.py
@@ -153,6 +153,8 @@ class Seq2SeqForecaster(BasePytorchForecaster):
 
         # nano setting
         current_num_threads = torch.get_num_threads()
+        self.thread_num = current_num_threads
+        self.optimized_model_thread_num = current_num_threads
         if current_num_threads >= 24:
             self.num_processes = max(1, current_num_threads//8)  # 8 is a magic num
         else:

--- a/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
@@ -173,6 +173,8 @@ class TCNForecaster(BasePytorchForecaster):
 
         # nano setting
         current_num_threads = torch.get_num_threads()
+        self.thread_num = current_num_threads
+        self.optimized_model_thread_num = current_num_threads
         if current_num_threads >= 24:
             self.num_processes = max(1, current_num_threads//8)  # 8 is a magic num
         else:

--- a/python/chronos/src/bigdl/chronos/forecaster/utils.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/utils.py
@@ -223,10 +223,8 @@ def get_exported_module(tsdata, forecaster_path, drop_dtcol):
 
 
 def set_pytorch_thread(optimized_model_thread_num, thread_num):
-    if optimized_model_thread_num is None:
-        from bigdl.nano.common.cpu_schedule import get_cpu_info
-        optimized_model_thread_num = len(get_cpu_info()[0])
-    if optimized_model_thread_num != thread_num:
+    # optimized_model_thread_num is None means no limit is set, just keep current thread num
+    if optimized_model_thread_num is not None and optimized_model_thread_num != thread_num:
         thread_num = optimized_model_thread_num
         torch.set_num_threads(thread_num)
     return thread_num

--- a/python/chronos/src/bigdl/chronos/forecaster/utils.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/utils.py
@@ -35,7 +35,9 @@ __all__ = ['loader_to_creator',
            'read_csv',
            'delete_folder',
            'is_main_process',
-           'xshard_expand_dim']
+           'xshard_expand_dim',
+           'get_exported_module',
+           'set_pytorch_thread']
 
 
 def loader_to_creator(loader):
@@ -218,3 +220,13 @@ def get_exported_module(tsdata, forecaster_path, drop_dtcol):
     inference = torch.jit.load(forecaster_path)
 
     return torch.jit.script(ExportForecastingPipeline(preprocess, inference, postprocess))
+
+
+def set_pytorch_thread(optimized_model_thread_num, thread_num):
+    if optimized_model_thread_num is None:
+        from bigdl.nano.common.cpu_schedule import get_cpu_info
+        optimized_model_thread_num = len(get_cpu_info()[0])
+    if optimized_model_thread_num != thread_num:
+        thread_num = optimized_model_thread_num
+        torch.set_num_threads(thread_num)
+    return thread_num

--- a/python/chronos/src/bigdl/chronos/pytorch/utils.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/utils.py
@@ -17,7 +17,6 @@ import math
 import torch
 import numpy as np
 from torch.utils.data.dataloader import DataLoader
-from bigdl.chronos.pytorch import TSInferenceOptimizer as InferenceOptimizer
 
 
 def _inference(model, input_sample_list, batch_size):
@@ -48,7 +47,7 @@ def _pytorch_fashion_inference(model, input_data, batch_size=None):
 
     :return: numpy ndarray
     '''
-    with InferenceOptimizer.get_context(model):
+    with torch.no_grad():
         if isinstance(input_data, list):
             input_sample_list = list(map(lambda x: torch.from_numpy(x), input_data))
         elif isinstance(input_data, DataLoader):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -824,7 +824,7 @@ class TestChronosModelLSTMForecaster(TestCase):
         assert forecaster.optimized_model_thread_num == 1
 
         num = max(1, original_thread//2)
-        forecaster.quantize(test_data, thread_num=num)
+        forecaster.quantize(train_data, thread_num=num)
         pred = forecaster.predict(test_data[0], quantize=True)
         current_thread = torch.get_num_threads()
         assert current_thread == num
@@ -833,8 +833,11 @@ class TestChronosModelLSTMForecaster(TestCase):
 
         # if set `optimize=False`, keep the current thread num
         num = max(1, current_thread//2)
-        forecaster.optimize(test_data, thread_num=num, acceleration=False)
-        pred = forecaster.predict(test_data[0])
+        forecaster.optimize(train_data=train_data,
+                            validation_data=val_data,
+                            batch_size=32,
+                            thread_num=num)
+        pred = forecaster.predict(test_data[0], acceleration=False)
         new_current_thread = torch.get_num_threads()
         assert new_current_thread == current_thread
         assert forecaster.thread_num == current_thread

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -833,7 +833,7 @@ class TestChronosModelLSTMForecaster(TestCase):
 
         # if set `optimize=False`, keep the current thread num
         num = max(1, current_thread//2)
-        forecaster.optimize(test_data, thread_num=num)
+        forecaster.optimize(test_data, thread_num=num, acceleration=False)
         pred = forecaster.predict(test_data[0])
         new_current_thread = torch.get_num_threads()
         assert new_current_thread == current_thread

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -804,3 +804,23 @@ class TestChronosModelLSTMForecaster(TestCase):
 
         if os.path.exists(temp_dir):
             shutil.rmtree(temp_dir)
+
+    @op_inference
+    def test_lstm_forecaster_set_thread_num(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = LSTMForecaster(past_seq_len=24,
+                                    input_feature_num=2,
+                                    output_feature_num=2,
+                                    loss="mse",
+                                    lr=0.01)
+        forecaster.fit(train_data, epochs=1)
+        original_thread = torch.get_num_threads()
+        assert forecaster.thread_num == original_thread
+        
+        num = max(1, original_thread//2)
+        forecaster.build_onnx(num)
+        pred = forecaster.predict_with_onnx(test_data[0])
+        current_thread = torch.get_num_threads()
+        assert current_thread == num
+        assert forecaster.thread_num == num
+        assert forecaster.optimized_model_thread_num == num

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -752,7 +752,7 @@ class TestChronosNBeatsForecaster(TestCase):
         assert forecaster.optimized_model_thread_num == 1
 
         num = max(1, original_thread//2)
-        forecaster.quantize(test_data, thread_num=num)
+        forecaster.quantize(train_data, thread_num=num)
         pred = forecaster.predict(test_data[0], quantize=True)
         current_thread = torch.get_num_threads()
         assert current_thread == num
@@ -761,8 +761,11 @@ class TestChronosNBeatsForecaster(TestCase):
 
         # if set `optimize=False`, keep the current thread num
         num = max(1, current_thread//2)
-        forecaster.optimize(test_data, thread_num=num, acceleration=False)
-        pred = forecaster.predict(test_data[0])
+        forecaster.optimize(train_data=train_data,
+                            validation_data=val_data,
+                            batch_size=32,
+                            thread_num=num)
+        pred = forecaster.predict(test_data[0], acceleration=False)
         new_current_thread = torch.get_num_threads()
         assert new_current_thread == current_thread
         assert forecaster.thread_num == current_thread

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -744,11 +744,26 @@ class TestChronosNBeatsForecaster(TestCase):
         forecaster.fit(train_data, epochs=1)
         original_thread = torch.get_num_threads()
         assert forecaster.thread_num == original_thread
-        
-        num = max(1, original_thread//2)
-        forecaster.build_onnx(num)
+
         pred = forecaster.predict_with_onnx(test_data[0])
+        current_thread = torch.get_num_threads()
+        assert current_thread == 1
+        assert forecaster.thread_num == 1
+        assert forecaster.optimized_model_thread_num == 1
+
+        num = max(1, original_thread//2)
+        forecaster.quantize(test_data, thread_num=num)
+        pred = forecaster.predict(test_data[0], quantize=True)
         current_thread = torch.get_num_threads()
         assert current_thread == num
         assert forecaster.thread_num == num
+        assert forecaster.optimized_model_thread_num == num
+
+        # if set `optimize=False`, keep the current thread num
+        num = max(1, current_thread//2)
+        forecaster.optimize(test_data, thread_num=num)
+        pred = forecaster.predict(test_data[0])
+        new_current_thread = torch.get_num_threads()
+        assert new_current_thread == current_thread
+        assert forecaster.thread_num == current_thread
         assert forecaster.optimized_model_thread_num == num

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -761,7 +761,7 @@ class TestChronosNBeatsForecaster(TestCase):
 
         # if set `optimize=False`, keep the current thread num
         num = max(1, current_thread//2)
-        forecaster.optimize(test_data, thread_num=num)
+        forecaster.optimize(test_data, thread_num=num, acceleration=False)
         pred = forecaster.predict(test_data[0])
         new_current_thread = torch.get_num_threads()
         assert new_current_thread == current_thread

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -733,3 +733,22 @@ class TestChronosNBeatsForecaster(TestCase):
 
         if os.path.exists(temp_dir):
             shutil.rmtree(temp_dir)
+
+    @op_inference
+    def test_nbeats_forecaster_set_thread_num(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = NBeatsForecaster(past_seq_len=24,
+                                      future_seq_len=5,
+                                      loss='mse',
+                                      lr=0.01)
+        forecaster.fit(train_data, epochs=1)
+        original_thread = torch.get_num_threads()
+        assert forecaster.thread_num == original_thread
+        
+        num = max(1, original_thread//2)
+        forecaster.build_onnx(num)
+        pred = forecaster.predict_with_onnx(test_data[0])
+        current_thread = torch.get_num_threads()
+        assert current_thread == num
+        assert forecaster.thread_num == num
+        assert forecaster.optimized_model_thread_num == num

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -717,7 +717,7 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
 
         # if set `optimize=False`, keep the current thread num
         num = max(1, current_thread//2)
-        forecaster.optimize(test_data, thread_num=num)
+        forecaster.optimize(test_data, thread_num=num, acceleration=False)
         pred = forecaster.predict(test_data[0])
         new_current_thread = torch.get_num_threads()
         assert new_current_thread == current_thread

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -700,11 +700,26 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         forecaster.fit(train_data, epochs=1)
         original_thread = torch.get_num_threads()
         assert forecaster.thread_num == original_thread
-        
-        num = max(1, original_thread//2)
-        forecaster.build_onnx(num)
+
         pred = forecaster.predict_with_onnx(test_data[0])
+        current_thread = torch.get_num_threads()
+        assert current_thread == 1
+        assert forecaster.thread_num == 1
+        assert forecaster.optimized_model_thread_num == 1
+
+        num = max(1, original_thread//2)
+        forecaster.quantize(test_data, thread_num=num)
+        pred = forecaster.predict(test_data[0], quantize=True)
         current_thread = torch.get_num_threads()
         assert current_thread == num
         assert forecaster.thread_num == num
+        assert forecaster.optimized_model_thread_num == num
+
+        # if set `optimize=False`, keep the current thread num
+        num = max(1, current_thread//2)
+        forecaster.optimize(test_data, thread_num=num)
+        pred = forecaster.predict(test_data[0])
+        new_current_thread = torch.get_num_threads()
+        assert new_current_thread == current_thread
+        assert forecaster.thread_num == current_thread
         assert forecaster.optimized_model_thread_num == num

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -708,8 +708,8 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         assert forecaster.optimized_model_thread_num == 1
 
         num = max(1, original_thread//2)
-        forecaster.quantize(train_data, thread_num=num)
-        pred = forecaster.predict(test_data[0], quantize=True)
+        forecaster.build_onnx(thread_num=num)
+        pred = forecaster.predict(test_data[0])
         current_thread = torch.get_num_threads()
         assert current_thread == num
         assert forecaster.thread_num == num

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -708,7 +708,7 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         assert forecaster.optimized_model_thread_num == 1
 
         num = max(1, original_thread//2)
-        forecaster.quantize(test_data, thread_num=num)
+        forecaster.quantize(train_data, thread_num=num)
         pred = forecaster.predict(test_data[0], quantize=True)
         current_thread = torch.get_num_threads()
         assert current_thread == num
@@ -717,8 +717,11 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
 
         # if set `optimize=False`, keep the current thread num
         num = max(1, current_thread//2)
-        forecaster.optimize(test_data, thread_num=num, acceleration=False)
-        pred = forecaster.predict(test_data[0])
+        forecaster.optimize(train_data=train_data,
+                            validation_data=val_data,
+                            batch_size=32,
+                            thread_num=num)
+        pred = forecaster.predict(test_data[0], acceleration=False)
         new_current_thread = torch.get_num_threads()
         assert new_current_thread == current_thread
         assert forecaster.thread_num == current_thread

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -1471,7 +1471,7 @@ class TestChronosModelTCNForecaster(TestCase):
 
         # if set `optimize=False`, keep the current thread num
         num = max(1, current_thread//2)
-        forecaster.optimize(test_data, thread_num=num)
+        forecaster.optimize(test_data, thread_num=num, acceleration=False)
         pred = forecaster.predict(test_data[0])
         new_current_thread = torch.get_num_threads()
         assert new_current_thread == current_thread

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -1462,7 +1462,7 @@ class TestChronosModelTCNForecaster(TestCase):
         assert forecaster.optimized_model_thread_num == 1
 
         num = max(1, original_thread//2)
-        forecaster.quantize(test_data, thread_num=num)
+        forecaster.quantize(train_data, thread_num=num)
         pred = forecaster.predict(test_data[0], quantize=True)
         current_thread = torch.get_num_threads()
         assert current_thread == num
@@ -1471,8 +1471,11 @@ class TestChronosModelTCNForecaster(TestCase):
 
         # if set `optimize=False`, keep the current thread num
         num = max(1, current_thread//2)
-        forecaster.optimize(test_data, thread_num=num, acceleration=False)
-        pred = forecaster.predict(test_data[0])
+        forecaster.optimize(train_data=train_data,
+                            validation_data=val_data,
+                            batch_size=32,
+                            thread_num=num)
+        pred = forecaster.predict(test_data[0], acceleration=False)
         new_current_thread = torch.get_num_threads()
         assert new_current_thread == current_thread
         assert forecaster.thread_num == current_thread

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -1454,11 +1454,26 @@ class TestChronosModelTCNForecaster(TestCase):
         forecaster.fit(train_data, epochs=1)
         original_thread = torch.get_num_threads()
         assert forecaster.thread_num == original_thread
-        
-        num = max(1, original_thread//2)
-        forecaster.build_onnx(num)
+
         pred = forecaster.predict_with_onnx(test_data[0])
+        current_thread = torch.get_num_threads()
+        assert current_thread == 1
+        assert forecaster.thread_num == 1
+        assert forecaster.optimized_model_thread_num == 1
+
+        num = max(1, original_thread//2)
+        forecaster.quantize(test_data, thread_num=num)
+        pred = forecaster.predict(test_data[0], quantize=True)
         current_thread = torch.get_num_threads()
         assert current_thread == num
         assert forecaster.thread_num == num
+        assert forecaster.optimized_model_thread_num == num
+
+        # if set `optimize=False`, keep the current thread num
+        num = max(1, current_thread//2)
+        forecaster.optimize(test_data, thread_num=num)
+        pred = forecaster.predict(test_data[0])
+        new_current_thread = torch.get_num_threads()
+        assert new_current_thread == current_thread
+        assert forecaster.thread_num == current_thread
         assert forecaster.optimized_model_thread_num == num

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -1440,3 +1440,25 @@ class TestChronosModelTCNForecaster(TestCase):
 
         if os.path.exists(temp_dir):
             shutil.rmtree(temp_dir)
+
+    @op_inference
+    def test_tcn_forecaster_set_thread_num(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=1,
+                                   output_feature_num=1,
+                                   kernel_size=4,
+                                   num_channels=[16, 16],
+                                   lr=0.01)
+        forecaster.fit(train_data, epochs=1)
+        original_thread = torch.get_num_threads()
+        assert forecaster.thread_num == original_thread
+        
+        num = max(1, original_thread//2)
+        forecaster.build_onnx(num)
+        pred = forecaster.predict_with_onnx(test_data[0])
+        current_thread = torch.get_num_threads()
+        assert current_thread == num
+        assert forecaster.thread_num == num
+        assert forecaster.optimized_model_thread_num == num


### PR DESCRIPTION
## Description

In https://github.com/intel-analytics/BigDL/pull/6886, we try to use `InferenceOptimizer.get_context()` to replace `torch._no_grad` and realize thread control during inference. This make the context manager inside the inference loop.
But during recent performance tests, I found that every time calling `predict`, `torch.set_num_threads()` is called with quite large time cost and inference latency becomes >20ms.
```python
for x, y in test_loader:
    st = time.time()
    yhat = forecaster.predict(x.numpy(), quantize=True)
    latency.append(time.time()-st)
```

Maybe it's not a good idea to explicitly use `InferenceOptimizer.get_context()` in `predict`. It's better to avoid calling `torch.set_num_threads()` over and over again during inference.

We workaround this issue by no using the context manger to reduce overhead. Later, we will try new method to use context manager more friendly with no overhead.


### 2. User API changes

None

### 3. Summary of the change 

1. remove `InferenceOptimizer.get_context()` to `torch._no_grad`
2. implement of thread control (mainly through two attr `thread_num` and `optimized_model_thread_num`)
**first**, during initialization of forecaster, set the two attr according to current thread num;
**then**, if users call `build_onnx/openvino/jit` or `quantize` or `optimize`, update `optimized_model_thread_num` according to input parameter `thread_num`;
**next**, when users call `predict` or `predict_with_onnx/openvino/jit`, check the two attr, modify `thread_num` to be same as `optimized_model_thread_num` and call `torch.set_num_threads`
(Notice: especially for `predict`, if uses choose `acceleration=False`, keep `thread_num`)

Therefore, `torch.set_num_threads` will be called at most one time during inference loop.

3. uts

### 4. How to test?
- [x] Unit test

