### PR TITLE
Remove redundant version comparison in Ray

### DIFF
--- a/python/orca/src/bigdl/orca/data/ray_xshards.py
+++ b/python/orca/src/bigdl/orca/data/ray_xshards.py
@@ -108,7 +108,7 @@ def init_ray_if_not(redis_address, redis_password):
         init_params = dict(
             address=redis_address,
             ignore_reinit_error=True,
-            namespace="az"
+            namespace="bigdl"
         )
         if redis_password:
             init_params["_redis_password"] = redis_password

--- a/python/orca/src/bigdl/orca/data/ray_xshards.py
+++ b/python/orca/src/bigdl/orca/data/ray_xshards.py
@@ -107,12 +107,11 @@ def init_ray_if_not(redis_address, redis_password):
     if not ray.is_initialized():
         init_params = dict(
             address=redis_address,
-            ignore_reinit_error=True
+            ignore_reinit_error=True,
+            namespace="az"
         )
         if redis_password:
             init_params["_redis_password"] = redis_password
-        if version.parse(ray.__version__) >= version.parse("1.4.0"):
-            init_params["namespace"] = "az"
         ray.init(**init_params)
 
 
@@ -399,7 +398,6 @@ class RayXShards(XShards):
     def from_partition_refs(ip2part_id: DefaultDict[str, List[int]],
                             part_id2ref: Dict[int, "ObjectRef"],
                             old_rdd: "RDD[Any]") -> "RayXShards":
-        ray_ctx = OrcaRayContext.get()
         uuid_str = str(uuid.uuid4())
         id2store_name = {}
         partition_stores = {}
@@ -445,25 +443,14 @@ class RayXShards(XShards):
         partition_stores = {}
         for node in nodes:
             name = f"partition:{uuid_str}:{node}"
-            if version.parse(ray.__version__) >= version.parse("1.4.0"):
-                store = ray.remote(num_cpus=0, resources={node: 1e-4})(LocalStore)\
-                    .options(name=name, lifetime="detached").remote()
-            else:
-                store = ray.remote(num_cpus=0, resources={node: 1e-4})(LocalStore) \
-                    .options(name=name).remote()
+            store = ray.remote(num_cpus=0, resources={node: 1e-4})(LocalStore)\
+                .options(name=name, lifetime="detached").remote()
             partition_stores[name] = store
 
-        # actor creation is aync, this is to make sure they all have been started
+        # actor creation is async, this is to make sure they all have been started
         ray.get([v.get_partitions_refs.remote() for v in partition_stores.values()])
         partition_store_names = list(partition_stores.keys())
         result_rdd = spark_xshards.rdd.mapPartitionsWithIndex(lambda idx, part: write_to_ray(
             idx, part, address, password, partition_store_names)).cache()
-        result = result_rdd.collect()
-
-        id2ip = {}
-        id2store_name = {}
-        for idx, ip, local_store_name in result:
-            id2ip[idx] = ip
-            id2store_name[idx] = local_store_name
 
         return RayXShards(uuid_str, result_rdd, partition_stores)

--- a/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
+++ b/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
@@ -584,13 +584,12 @@ class RayOnSparkContext(object):
                     object_store_memory=self.object_store_memory,
                     include_dashboard=self.include_webui,
                     dashboard_host="0.0.0.0",
-                    _system_config=self.system_config
+                    _system_config=self.system_config,
+                    namespace="az"
                 )
                 if self.redis_password:
                     init_params["_redis_password"] = self.redis_password
                 init_params.update(kwargs)
-                if version.parse(ray.__version__) >= version.parse("1.4.0"):
-                    init_params["namespace"] = "az"
                 self._address_info = ray.init(**init_params)
             else:
                 self.cluster_ips = self._gather_cluster_ips()
@@ -676,10 +675,9 @@ class RayOnSparkContext(object):
         ray.shutdown()
         init_params = dict(
             address=redis_address,
-            _node_ip_address=node_ip
+            _node_ip_address=node_ip,
+            namespace="az"
         )
         if self.redis_password:
             init_params["_redis_password"] = self.redis_password
-        if version.parse(ray.__version__) >= version.parse("1.4.0"):
-            init_params["namespace"] = "az"
         return ray.init(**init_params)

--- a/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
+++ b/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
@@ -585,7 +585,7 @@ class RayOnSparkContext(object):
                     include_dashboard=self.include_webui,
                     dashboard_host="0.0.0.0",
                     _system_config=self.system_config,
-                    namespace="az"
+                    namespace="bigdl"
                 )
                 if self.redis_password:
                     init_params["_redis_password"] = self.redis_password
@@ -676,7 +676,7 @@ class RayOnSparkContext(object):
         init_params = dict(
             address=redis_address,
             _node_ip_address=node_ip,
-            namespace="az"
+            namespace="bigdl"
         )
         if self.redis_password:
             init_params["_redis_password"] = self.redis_password


### PR DESCRIPTION
A PR separated from https://github.com/intel-analytics/BigDL/pull/7069

- Ray versions lower than 1.4.0 are no longer supported, and thus remove the version comparison.
- Change az to bigdl
- Remove the code not used in RayXShards.