### PR TITLE
Nano: add tensorflow bf16 inference support for "model transformation" style

### DIFF
--- a/python/nano/src/bigdl/nano/tf/keras/amp/__init__.py
+++ b/python/nano/src/bigdl/nano/tf/keras/amp/__init__.py
@@ -1,0 +1,16 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from .amp_api import *

--- a/python/nano/src/bigdl/nano/tf/keras/amp/amp_api.py
+++ b/python/nano/src/bigdl/nano/tf/keras/amp/amp_api.py
@@ -14,11 +14,12 @@
 # limitations under the License.
 #
 
+
 def BF16Model(*args, **kwargs):
     from .bfloat16 import BF16Model
     return BF16Model(*args, **kwargs)
 
 
-def load_bf16_model(path, model):
+def load_bf16_model(path):
     from .bfloat16 import BF16Model
     return BF16Model._load(path)

--- a/python/nano/src/bigdl/nano/tf/keras/amp/amp_api.py
+++ b/python/nano/src/bigdl/nano/tf/keras/amp/amp_api.py
@@ -1,0 +1,24 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+def BF16Model(*args, **kwargs):
+    from .bfloat16 import BF16Model
+    return BF16Model(*args, **kwargs)
+
+
+def load_bf16_model(path, model):
+    from .bfloat16 import BF16Model
+    return BF16Model._load(path)

--- a/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
@@ -18,6 +18,7 @@ from tensorflow.keras import mixed_precision
 from tempfile import TemporaryDirectory
 import tensorflow as tf
 
+
 class BF16Model(AcceleratedKerasModel):
     def __init__(self, model, **kwargs):
         super().__init__(model, precision=tf.bfloat16)
@@ -39,7 +40,7 @@ class BF16Model(AcceleratedKerasModel):
         status.update({"ModelType": type(self.target_obj).__name__,
                        "precision": "bfloat16"})
         return status
-    
+
     def _save_model(self, path):
         self.model.save(path)
 

--- a/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
@@ -28,8 +28,8 @@ class BF16Model(AcceleratedKerasModel):
             layer._dtype_policy = policy_bf16
         with TemporaryDirectory() as temp_dir:
             model.save(temp_dir)
-            model = tf.keras.models.load_model(temp_dir)
-        self.model = model
+            bf16_model = tf.keras.models.load_model(temp_dir)
+        self.model = bf16_model
 
     def forward_step(self, *inputs):
         return self.model(*inputs)

--- a/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
@@ -1,0 +1,48 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+from bigdl.nano.utils.inference.tf.model import AcceleratedKerasModel
+from tensorflow.keras import mixed_precision
+from tempfile import TemporaryDirectory
+import tensorflow as tf
+
+class BF16Model(AcceleratedKerasModel):
+    def __init__(self, model, **kwargs):
+        super().__init__(model, precision=tf.bfloat16)
+        # TODO: check bf16 isa
+        policy_bf16 = mixed_precision.Policy('mixed_bfloat16')
+        for layer in model.layers:
+            layer._dtype_policy = policy_bf16
+        with TemporaryDirectory() as temp_dir:
+            model.save(temp_dir)
+            model = tf.keras.models.load_model(temp_dir)
+        self.model = model
+
+    def forward_step(self, *inputs):
+        return self.model(*inputs)
+
+    @property
+    def status(self):
+        status = super().status
+        status.update({"ModelType": type(self.target_obj).__name__,
+                       "precision": "bfloat16"})
+        return status
+    
+    def _save_model(self, path):
+        self.model.save(path)
+
+    @staticmethod
+    def _load(path):
+        return BF16Model(tf.keras.models.load_model(path))

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -37,7 +37,7 @@ from bigdl.nano.deps.onnxruntime.onnxruntime_api import KerasONNXRuntimeModel
 from bigdl.nano.deps.openvino.openvino_api import load_openvino_model
 from bigdl.nano.deps.onnxruntime.onnxruntime_api import load_onnxruntime_model
 from bigdl.nano.deps.neural_compressor.inc_api import load_inc_model
-from bigdl.nano.tf.keras.amp import BF16Model
+from bigdl.nano.tf.keras.amp import BF16Model, load_bf16_model
 
 
 class TFAccelerationOption(AccelerationOption):
@@ -706,6 +706,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             return patch_attrs(result, model)
         if model_type == 'KerasQuantizedModel':
             result = load_inc_model(path, model, framework='tensorflow')
+            return patch_attrs(result, model)
+        if model_type == 'BF16Model':
+            result = load_bf16_model(path)
             return patch_attrs(result, model)
         if isinstance(model, Model):
             # typically for keras Model

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -37,6 +37,7 @@ from bigdl.nano.deps.onnxruntime.onnxruntime_api import KerasONNXRuntimeModel
 from bigdl.nano.deps.openvino.openvino_api import load_openvino_model
 from bigdl.nano.deps.onnxruntime.onnxruntime_api import load_onnxruntime_model
 from bigdl.nano.deps.neural_compressor.inc_api import load_inc_model
+from bigdl.nano.tf.keras.amp import BF16Model
 
 
 class TFAccelerationOption(AccelerationOption):
@@ -516,23 +517,27 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             return patch_compiled_and_attrs(result, model)
 
         elif precision == 'bf16':
-            invalidInputError(accelerator == 'openvino',
+            invalidInputError(accelerator == 'openvino' or accelerator is None,
                               "Accelerator {} is invalid for BF16.".format(accelerator))
             invalidInputError(device == 'CPU',
                               "Device {} don't support bfloat16.".format(device))
-            final_openvino_option = {"INFERENCE_PRECISION_HINT": "bf16"}
-            if openvino_config is not None:
-                final_openvino_option.update(openvino_config)
-            from bigdl.nano.deps.openvino.tf.model import KerasOpenVINOModel    # type: ignore
-            result = KerasOpenVINOModel(model,
-                                        input_spec=input_spec,
-                                        precision=precision,
-                                        thread_num=thread_num,
-                                        device=device,
-                                        config=final_openvino_option,
-                                        logging=logging,
-                                        **kwargs)
-            return patch_compiled_and_attrs(result, model)
+            if accelerator == 'openvino':
+                final_openvino_option = {"INFERENCE_PRECISION_HINT": "bf16"}
+                if openvino_config is not None:
+                    final_openvino_option.update(openvino_config)
+                from bigdl.nano.deps.openvino.tf.model import KerasOpenVINOModel    # type: ignore
+                result = KerasOpenVINOModel(model,
+                                            input_spec=input_spec,
+                                            precision=precision,
+                                            thread_num=thread_num,
+                                            device=device,
+                                            config=final_openvino_option,
+                                            logging=logging,
+                                            **kwargs)
+                return patch_compiled_and_attrs(result, model)
+            elif accelerator is None:
+                result = BF16Model(model)
+                return patch_compiled_and_attrs(result, model)
 
         invalidInputError(approach == 'static', "Only 'static' approach is supported now.")
 

--- a/python/nano/src/bigdl/nano/utils/inference/tf/model.py
+++ b/python/nano/src/bigdl/nano/utils/inference/tf/model.py
@@ -28,9 +28,10 @@ except ImportError:
 class AcceleratedKerasModel(AcceleratedModel, tf.keras.Model):
     """A wrapper class for tf.keras.Model with accelerators."""
 
-    def __init__(self, model):
+    def __init__(self, model, precision=tf.float32):
         super().__init__()
         self.model = model
+        self.precision = precision
 
     def __call__(self, *args, **kwds):
         invalidInputError(
@@ -41,7 +42,7 @@ class AcceleratedKerasModel(AcceleratedModel, tf.keras.Model):
         return super().__call__(*args, **kwds)
 
     def call(self, *inputs):
-        return tf.py_function(self.forward, inputs, Tout=tf.float32)
+        return tf.py_function(self.forward, inputs, Tout=self.precision)
 
     def forward(self, *inputs):
         inputs = self.on_forward_start(inputs)

--- a/python/nano/test/mypy.ini
+++ b/python/nano/test/mypy.ini
@@ -45,3 +45,6 @@ ignore_errors = True
 
 [mypy-bigdl.nano.pytorch.encryption.*]
 ignore_errors = True
+
+[mypy-bigdl.nano.tf.keras.amp.*]
+ignore_errors = True

--- a/python/nano/test/tf/keras/test_trace_and_quantize.py
+++ b/python/nano/test/tf/keras/test_trace_and_quantize.py
@@ -177,3 +177,19 @@ class TestTraceAndQuantize(TestCase):
                                                       input_spec=tf.TensorSpec(shape=(None, 4)), x=x)
         outputs = quantized_model(x)
         assert isinstance(outputs, list) and isinstance(outputs[0], tf.Tensor)
+
+    def test_quantize_bf16(self):
+        model = MyModel(100)
+        model.compile(loss='mse', metrics=MeanSquaredError())
+        x = np.random.random((100, 4))
+        model(x)
+
+        traced_model = InferenceOptimizer.quantize(model, precision="bf16")
+
+        from bigdl.nano.utils import CPUInfo
+        cpuinfo = CPUInfo()
+        if cpuinfo.has_bf16:
+            model(x)
+
+        InferenceOptimizer.save(model, "save_bf16")
+        model = InferenceOptimizer.load("save_bf16", model)


### PR DESCRIPTION
## Description

### 1. Why the change?
We have now support a easy wrapper for `mixed_precision.set_global_policy(policy)`  in `patch_tensorflow`, while it has quite a few limitation, for the most important one, **it can not support a easy model transformation between fp32 -> bf16**, i.e.,
```python
model = tf.keras.models.load_model(...)  # a model defined and trained in fp32 environment
opt_model = transform_model_fp32_to_bf16(model)
opt_model(data) # here we are using bf16 for calculation, fp32 for weight saving (i.e., amp)
```

In this PR, an implementation is added and verified as proposed by @yangw1234 . We change the `dtype` key of the config (got by `model.get_config`) and set back with a save-and-load trick.

### 2. User API changes
Add a new method in `bigdl.nano.tf.keras.InferenceOptimizer.quantize`
```python
model = tf.keras.models.load_model(...)  # a model defined and trained in fp32 environment

from bigdl.nano.tf.keras import InferenceOptimizer
opt_model = InferenceOptimizer.quantize(model, precision="bf16")

opt_model(data) # here we are using bf16 for calculation, fp32 for weight saving (i.e., amp)
```
**There is even no need to call `patch_tensorflow(precision='mixed_bfloat16')`**

A quick usage example:
```python
import tensorflow as tf
from bigdl.nano.tf.keras import Sequential
import numpy as np

x_train = np.random.rand(1000,3,224,224)

model = Sequential([
  tf.keras.layers.Conv2D(256, 1, activation='relu', input_shape=(3,224,224)),
  tf.keras.layers.Flatten(),
  tf.keras.layers.Dense(512, activation='relu'),
  tf.keras.layers.Dense(10, activation='softmax')
])

model.compile(optimizer='adam',
              loss='sparse_categorical_crossentropy',
              metrics=['accuracy'])

from bigdl.nano.tf.keras import InferenceOptimizer

model = InferenceOptimizer.quantize(model, precision="bf16")

import time

st = time.time()
for _ in range(10):
    model(x_train)
print(time.time() - st)
```
BF16 is **37.5% faster** than FP32 in this example.

It has been verified by setting `ONEDNN_VERBOSE=1`
bf16 model log is as following
```bash
...
onednn_verbose,exec,cpu,convolution,brgconv_1x1:avx512_core_bf16,forward_training,src_bf16::blocked:acdb:f wei_bf16::blocked:AcdB64a2b:f bia_undef::undef::f dst_bf16::blocked:acdb:f,attr-scratchpad:user ,alg:convolution_direct,mb,53.0029
...
```
it shows that the quantization and model transformation works.

### 3. Summary of the change 
When users call `InferenceOptimizer.quantize(model, precision="bf16")` a few procedures are carried out.
1. get layers by `model.layers`
2. set `_dtype_policy` for these layer
3. save and load the model

Some downside:
1. save-and-load trick is necessary
2. bf16 isa check to be added late
3. a good question is "which layer needs to be transformed to bf16", make all of them bf16 is clearly not the best way (but a good start for now :)
4. some of the implementation is a little bit hacking, the most problematic one is the usage of `_dtype_policy`.

### 4. How to test?
- [ ] Unit test
