### PR TITLE
Orca: update the datatype of sparse features in NCF examples from Int to Long

### DIFF
--- a/python/orca/tutorial/NCF/process_spark_dataframe.py
+++ b/python/orca/tutorial/NCF/process_spark_dataframe.py
@@ -17,7 +17,7 @@ import os.path
 
 from pyspark.ml.feature import StringIndexer, MinMaxScaler, VectorAssembler
 from pyspark.ml import Pipeline
-from pyspark.sql.types import StructField, StructType, IntegerType, ArrayType, StringType
+from pyspark.sql.types import StructField, StructType, LongType, ArrayType, StringType
 from pyspark.sql.functions import udf, lit, collect_list, explode
 
 from bigdl.orca import OrcaContext
@@ -28,20 +28,20 @@ dense_features = ["age"]
 
 def read_data(data_dir):
     spark = OrcaContext.get_spark_session()
-    schema = StructType([StructField("user", IntegerType(), False),
-                         StructField("item", IntegerType(), False)])
+    schema = StructType([StructField("user", LongType(), False),
+                         StructField("item", LongType(), False)])
     schema_user = StructType(
         [
-            StructField("user", IntegerType(), False),
+            StructField("user", LongType(), False),
             StructField("gender", StringType(), False),
-            StructField("age", IntegerType(), False),
-            StructField("occupation", IntegerType(), False),
+            StructField("age", LongType(), False),
+            StructField("occupation", LongType(), False),
             StructField("zipcode", StringType(), False)
         ]
     )
     schema_item = StructType(
         [
-            StructField("item", IntegerType(), False),
+            StructField("item", LongType(), False),
             StructField("title", StringType(), False),
             StructField("category", StringType(), False)
         ]
@@ -71,7 +71,7 @@ def generate_neg_sample(df, item_num, neg_scale):
 
     df = df.withColumn("label", lit(1.0))
 
-    neg_sample_udf = udf(neg_sample, ArrayType(IntegerType(), False))
+    neg_sample_udf = udf(neg_sample, ArrayType(LongType(), False))
     df_neg = df.groupBy("user").agg(neg_sample_udf(collect_list("item")).alias("item_list"))
     df_neg = df_neg.select(df_neg.user, explode(df_neg.item_list))
     df_neg = df_neg.withColumn("label", lit(0.0))

--- a/python/orca/tutorial/NCF/process_spark_dataframe.py
+++ b/python/orca/tutorial/NCF/process_spark_dataframe.py
@@ -17,7 +17,7 @@ import os.path
 
 from pyspark.ml.feature import StringIndexer, MinMaxScaler, VectorAssembler
 from pyspark.ml import Pipeline
-from pyspark.sql.types import StructField, StructType, LongType, ArrayType, StringType
+from pyspark.sql.types import StructField, StructType, IntegerType, LongType, ArrayType, StringType
 from pyspark.sql.functions import udf, lit, collect_list, explode
 
 from bigdl.orca import OrcaContext
@@ -37,7 +37,7 @@ def read_data(data_dir):
         [
             StructField("user", LongType(), False),
             StructField("gender", StringType(), False),
-            StructField("age", LongType(), False),
+            StructField("age", IntegerType(), False),
             StructField("occupation", LongType(), False),
             StructField("zipcode", StringType(), False)
         ]
@@ -92,7 +92,7 @@ def string_index(df, col):
     df = df.drop(col).withColumnRenamed(col + "_index", col)
     # The StringIndexer output is float type.
     # Change to 1-based index with 0 reversed for unknown features.
-    df = df.withColumn(col, df[col].cast("int") + 1)
+    df = df.withColumn(col, df[col].cast("long") + 1)
     embed_dim = df.agg({col: "max"}).collect()[0][f"max({col})"] + 1
     return df, embed_dim
 

--- a/python/orca/tutorial/NCF/process_spark_dataframe.py
+++ b/python/orca/tutorial/NCF/process_spark_dataframe.py
@@ -22,8 +22,8 @@ from pyspark.sql.functions import udf, lit, collect_list, explode
 
 from bigdl.orca import OrcaContext
 
-# user and item ids are converted to LongType to be compatible with lower versions of PyTorch
-# such as 1.7.1.
+# user and item ids and sparse features are converted to LongType to be compatible with
+# lower versions of PyTorch such as 1.7.1.
 
 sparse_features = ["zipcode", "gender", "category", "occupation"]
 dense_features = ["age"]

--- a/python/orca/tutorial/NCF/process_spark_dataframe.py
+++ b/python/orca/tutorial/NCF/process_spark_dataframe.py
@@ -22,7 +22,7 @@ from pyspark.sql.functions import udf, lit, collect_list, explode
 
 from bigdl.orca import OrcaContext
 
-# user and item ids and sparse features are converted to LongType to be compatible with
+# user/item ids and sparse features are converted to LongType to be compatible with
 # lower versions of PyTorch such as 1.7.1.
 
 sparse_features = ["zipcode", "gender", "category", "occupation"]

--- a/python/orca/tutorial/NCF/process_spark_dataframe.py
+++ b/python/orca/tutorial/NCF/process_spark_dataframe.py
@@ -89,7 +89,7 @@ def string_index(df, col):
     df = df.drop(col).withColumnRenamed(col + "_index", col)
     # The StringIndexer output is float type.
     # Change to 1-based index with 0 reversed for unknown features.
-    df = df.withColumn(col, df[col].cast("int") + 1)
+    df = df.withColumn(col, df[col].cast("long") + 1)
     embed_dim = df.agg({col: "max"}).collect()[0][f"max({col})"] + 1
     return df, embed_dim
 

--- a/python/orca/tutorial/NCF/process_spark_dataframe.py
+++ b/python/orca/tutorial/NCF/process_spark_dataframe.py
@@ -22,6 +22,9 @@ from pyspark.sql.functions import udf, lit, collect_list, explode
 
 from bigdl.orca import OrcaContext
 
+# user and item ids are converted to LongType to be compatible with lower versions of PyTorch 
+# such as 1.7.1.
+
 sparse_features = ["zipcode", "gender", "category", "occupation"]
 dense_features = ["age"]
 
@@ -89,7 +92,7 @@ def string_index(df, col):
     df = df.drop(col).withColumnRenamed(col + "_index", col)
     # The StringIndexer output is float type.
     # Change to 1-based index with 0 reversed for unknown features.
-    df = df.withColumn(col, df[col].cast("long") + 1)
+    df = df.withColumn(col, df[col].cast("int") + 1)
     embed_dim = df.agg({col: "max"}).collect()[0][f"max({col})"] + 1
     return df, embed_dim
 

--- a/python/orca/tutorial/NCF/process_spark_dataframe.py
+++ b/python/orca/tutorial/NCF/process_spark_dataframe.py
@@ -22,7 +22,7 @@ from pyspark.sql.functions import udf, lit, collect_list, explode
 
 from bigdl.orca import OrcaContext
 
-# user and item ids are converted to LongType to be compatible with lower versions of PyTorch 
+# user and item ids are converted to LongType to be compatible with lower versions of PyTorch
 # such as 1.7.1.
 
 sparse_features = ["zipcode", "gender", "category", "occupation"]

--- a/python/orca/tutorial/NCF/process_xshards.py
+++ b/python/orca/tutorial/NCF/process_xshards.py
@@ -27,7 +27,7 @@ from sklearn.model_selection import train_test_split
 from bigdl.orca.data.pandas import read_csv
 from bigdl.orca.data.transformer import StringIndexer, MinMaxScaler
 
-# user and item ids are converted to int64 to be compatible with lower versions of PyTorch 
+# user and item ids are converted to int64 to be compatible with lower versions of PyTorch
 # such as 1.7.1.
 
 sparse_features = ["zipcode", "gender", "category", "occupation"]

--- a/python/orca/tutorial/NCF/process_xshards.py
+++ b/python/orca/tutorial/NCF/process_xshards.py
@@ -27,7 +27,7 @@ from sklearn.model_selection import train_test_split
 from bigdl.orca.data.pandas import read_csv
 from bigdl.orca.data.transformer import StringIndexer, MinMaxScaler
 
-# user and item ids and sparse features are converted to int64 to be compatible with
+# user/item ids and sparse features are converted to int64 to be compatible with
 # lower versions of PyTorch such as 1.7.1.
 
 sparse_features = ["zipcode", "gender", "category", "occupation"]
@@ -93,11 +93,12 @@ def prepare_data(dataset_dir, num_ng=4):
 
     print("Processing features...")
 
-    # Categorical encoding
+
     def convert_to_long(shard, col):
         shard[col] = shard[col].astype(np.int64)
         return shard
 
+    # Categorical encoding
     for col in sparse_features[:-1]:  # occupation is already indexed.
         indexer = StringIndexer(inputCol=col)
         if col in users.get_schema()["columns"]:

--- a/python/orca/tutorial/NCF/process_xshards.py
+++ b/python/orca/tutorial/NCF/process_xshards.py
@@ -35,7 +35,7 @@ def ng_sampling(data, user_num, item_num, num_ng):
     data_X = data.values.tolist()
 
     # calculate a dok matrix
-    train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int32)
+    train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int64)
     for row in data_X:
         train_mat[row[0], row[1]] = 1
 
@@ -55,7 +55,7 @@ def ng_sampling(data, user_num, item_num, num_ng):
 
     features_fill = features_ps + features_ng
     labels_fill = labels_ps + labels_ng
-    data_XY = pd.DataFrame(data=features_fill, columns=["user", "item"], dtype=np.int32)
+    data_XY = pd.DataFrame(data=features_fill, columns=["user", "item"], dtype=np.int64)
     data_XY["label"] = labels_fill
     return data_XY
 

--- a/python/orca/tutorial/NCF/process_xshards.py
+++ b/python/orca/tutorial/NCF/process_xshards.py
@@ -93,8 +93,10 @@ def prepare_data(dataset_dir, num_ng=4):
         indexer = StringIndexer(inputCol=col)
         if col in users.get_schema()["columns"]:
             users = indexer.fit_transform(users)
+            users[col] = users[col].astype(np.int64)
         else:
             items = indexer.fit_transform(items)
+            items[col] = items[col].astype(np.int64)
 
     # Calculate input_dims for each sparse features
     sparse_feats_input_dims = []

--- a/python/orca/tutorial/NCF/process_xshards.py
+++ b/python/orca/tutorial/NCF/process_xshards.py
@@ -92,6 +92,7 @@ def prepare_data(dataset_dir, num_ng=4):
     item_num = max(item_set) + 1
 
     print("Processing features...")
+
     # Categorical encoding
     def convert_to_long(shard, col):
         shard[col] = shard[col].astype(np.int64)

--- a/python/orca/tutorial/NCF/process_xshards.py
+++ b/python/orca/tutorial/NCF/process_xshards.py
@@ -12,138 +12,138 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# ==============================================================================
+# Some of the code is adapted from
+# https://github.com/guoyang9/NCF/blob/master/data_utils.py
 #
-import os.path
 
-from pyspark.ml.feature import StringIndexer, MinMaxScaler, VectorAssembler
-from pyspark.ml import Pipeline
-from pyspark.sql.types import StructField, StructType, IntegerType, LongType, ArrayType, StringType
-from pyspark.sql.functions import udf, lit, collect_list, explode
+import os
+import numpy as np
+import pandas as pd
+import scipy.sparse as sp
 
-from bigdl.orca import OrcaContext
+from sklearn.model_selection import train_test_split
 
-# user and item ids are converted to LongType to be compatible with lower versions of PyTorch
+from bigdl.orca.data.pandas import read_csv
+from bigdl.orca.data.transformer import StringIndexer, MinMaxScaler
+
+# user and item ids are converted to int64 to be compatible with lower versions of PyTorch
 # such as 1.7.1.
 
 sparse_features = ["zipcode", "gender", "category", "occupation"]
 dense_features = ["age"]
 
 
-def read_data(data_dir):
-    spark = OrcaContext.get_spark_session()
-    schema = StructType([StructField("user", LongType(), False),
-                         StructField("item", LongType(), False)])
-    schema_user = StructType(
-        [
-            StructField("user", LongType(), False),
-            StructField("gender", StringType(), False),
-            StructField("age", IntegerType(), False),
-            StructField("occupation", LongType(), False),
-            StructField("zipcode", StringType(), False)
-        ]
-    )
-    schema_item = StructType(
-        [
-            StructField("item", LongType(), False),
-            StructField("title", StringType(), False),
-            StructField("category", StringType(), False)
-        ]
-    )
+def ng_sampling(data, user_num, item_num, num_ng):
+    data_X = data.values.tolist()
+
+    # calculate a dok matrix
+    train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int64)
+    for row in data_X:
+        train_mat[row[0], row[1]] = 1
+
+    # negative sampling
+    features_ps = data_X
+    features_ng = []
+    for x in features_ps:
+        u = x[0]
+        for t in range(num_ng):
+            j = np.random.randint(item_num)
+            while (u, j) in train_mat:
+                j = np.random.randint(item_num)
+            features_ng.append([u, j])
+
+    labels_ps = [1.0 for _ in range(len(features_ps))]
+    labels_ng = [0.0 for _ in range(len(features_ng))]
+
+    features_fill = features_ps + features_ng
+    labels_fill = labels_ps + labels_ng
+    data_XY = pd.DataFrame(data=features_fill, columns=["user", "item"], dtype=np.int64)
+    data_XY["label"] = labels_fill
+    return data_XY
+
+
+def split_dataset(data):
+    train_data, test_data = train_test_split(data, test_size=0.2, random_state=100)
+    return train_data, test_data
+
+
+def prepare_data(dataset_dir, num_ng=4):
     print("Loading data...")
     # Need spark3 to support delimiter with more than one character.
-    df_rating = spark.read.csv(os.path.join(data_dir, "ratings.dat"),
-                               sep="::", schema=schema, header=False)
-    df_user = spark.read.csv(os.path.join(data_dir, "users.dat"),
-                             sep="::", schema=schema_user, header=False)
-    df_item = spark.read.csv(os.path.join(data_dir, "movies.dat"),
-                             sep="::", schema=schema_item, header=False)
-    return df_rating, df_user, df_item
+    users = read_csv(
+        os.path.join(dataset_dir, "users.dat"),
+        sep="::", header=None, names=["user", "gender", "age", "occupation", "zipcode"],
+        usecols=[0, 1, 2, 3, 4],
+        dtype={0: np.int64, 1: str, 2: np.int32, 3: np.int64, 4: str})
+    ratings = read_csv(
+        os.path.join(dataset_dir, "ratings.dat"),
+        sep="::", header=None, names=["user", "item"],
+        usecols=[0, 1], dtype={0: np.int64, 1: np.int64})
+    items = read_csv(
+        os.path.join(dataset_dir, "movies.dat"),
+        sep="::", header=None, names=["item", "category"],
+        usecols=[0, 2], dtype={0: np.int64, 2: str})
 
+    # calculate numbers of user and item
+    user_set = set(users["user"].unique())
+    item_set = set(items["item"].unique())
+    user_num = max(user_set) + 1
+    item_num = max(item_set) + 1
 
-def generate_neg_sample(df, item_num, neg_scale):
-    def neg_sample(x):
-        import random
-        neg_res = []
-        for _ in x:
-            for i in range(neg_scale):
-                neg_item_index = random.randint(1, item_num - 1)
-                while neg_item_index in x:
-                    neg_item_index = random.randint(1, item_num - 1)
-                neg_res.append(neg_item_index)
-        return neg_res
+    print("Processing features...")
+    # Categorical encoding
+    def convert_datatype(shard, col):
+        shard[col] = shard[col].astype(np.int64)
+        return shard
 
-    df = df.withColumn("label", lit(1.0))
+    for col in sparse_features[:-1]:  # occupation is already indexed.
+        indexer = StringIndexer(inputCol=col)
+        if col in users.get_schema()["columns"]:
+            users = indexer.fit_transform(users)
+            users = users.transform_shard(lambda shard: convert_datatype(shard, col))
+        else:
+            items = indexer.fit_transform(items)
+            items = items.transform_shard(lambda shard: convert_datatype(shard, col))
 
-    neg_sample_udf = udf(neg_sample, ArrayType(LongType(), False))
-    df_neg = df.groupBy("user").agg(neg_sample_udf(collect_list("item")).alias("item_list"))
-    df_neg = df_neg.select(df_neg.user, explode(df_neg.item_list))
-    df_neg = df_neg.withColumn("label", lit(0.0))
-    df_neg = df_neg.withColumnRenamed("col", "item")
-
-    df = df.unionByName(df_neg)
-    df = df.repartition(df.rdd.getNumPartitions())
-
-    return df
-
-
-def string_index(df, col):
-    indexer = StringIndexer(inputCol=col, outputCol=col + "_index").fit(df)
-    df = indexer.transform(df)
-    df = df.drop(col).withColumnRenamed(col + "_index", col)
-    # The StringIndexer output is float type.
-    # Change to 1-based index with 0 reversed for unknown features.
-    df = df.withColumn(col, df[col].cast("long") + 1)
-    embed_dim = df.agg({col: "max"}).collect()[0][f"max({col})"] + 1
-    return df, embed_dim
-
-
-def min_max_scale(df, col):
-    assembler = VectorAssembler(inputCols=[col], outputCol=col + "_vec")
-    scaler = MinMaxScaler(inputCol=col + "_vec", outputCol=col + "_scaled")
-    pipeline = Pipeline(stages=[assembler, scaler])
-    scalerModel = pipeline.fit(df)
-    df = scalerModel.transform(df)
-    df = df.drop(col, col + "_vec").withColumnRenamed(col + "_scaled", col)
-    return df
-
-
-def merge_features(df, df_user, df_item, sparse_features, dense_features):
+    # Calculate input_dims for each sparse features
     sparse_feats_input_dims = []
-    for i in sparse_features:
-        if i in df_user.columns:
-            df_user, embed_dim = string_index(df_user, i)
+    for col in sparse_features:
+        data = users if col in users.get_schema()["columns"] else items
+        sparse_feat_set = set(data[col].unique())
+        sparse_feats_input_dims.append(max(sparse_feat_set) + 1)
+
+    # scale dense features
+    def rename(shard, col):
+        shard = shard.drop(columns=[col]).rename(columns={col + "_scaled": col})
+        return shard
+
+    for col in dense_features:
+        scaler = MinMaxScaler(inputCol=[col], outputCol=col + "_scaled")
+        if col in users.get_schema()["columns"]:
+            users = scaler.fit_transform(users)
+            users = users.transform_shard(lambda shard: rename(shard, col))
         else:
-            df_item, embed_dim = string_index(df_item, i)
-        sparse_feats_input_dims.append(embed_dim)
-    for i in dense_features:
-        if i in df_user.columns:
-            df_user = min_max_scale(df_user, i)
-        else:
-            df_item = min_max_scale(df_item, i)
-    df_feat = df.join(df_user, "user", "inner")
-    df_feat = df_feat.join(df_item, "item", "inner")
-    return df_feat, sparse_feats_input_dims
+            items = scaler.fit_transform(items)
+            items = items.transform_shard(lambda shard: rename(shard, col))
 
+    # Negative sampling
+    print("Negative sampling...")
+    ratings = ratings.partition_by("user")
+    ratings = ratings.transform_shard(lambda shard: ng_sampling(shard, user_num, item_num, num_ng))
 
-def prepare_data(data_dir, neg_scale=4):
-    df_rating, df_user, df_item = read_data(data_dir)
+    # Merge XShards
+    print("Merge data...")
+    data = users.merge(ratings, on="user")
+    data = data.merge(items, on="item")
 
-    user_num = df_rating.agg({"user": "max"}).collect()[0]["max(user)"] + 1
-    item_num = df_rating.agg({"item": "max"}).collect()[0]["max(item)"] + 1
+    # Split dataset
+    print("Split data...")
+    train_data, test_data = data.transform_shard(split_dataset).split()
 
-    df_rating = generate_neg_sample(df_rating, item_num, neg_scale=neg_scale)
-    # occupation is already indexed.
-    df, sparse_feats_input_dims = \
-        merge_features(df_rating, df_user, df_item, sparse_features[:-1], dense_features)
-
-    occupation_num = df.agg({"occupation": "max"}).collect()[0]["max(occupation)"] + 1
-    sparse_feats_input_dims.append(occupation_num)
     feature_cols = get_feature_cols()
     label_cols = ["label"]
-
-    train_df, val_df = df.randomSplit([0.8, 0.2], seed=100)
-
-    return train_df, val_df, user_num, item_num, \
+    return train_data, test_data, user_num, item_num, \
         sparse_feats_input_dims, len(dense_features), feature_cols, label_cols
 
 
@@ -156,8 +156,8 @@ if __name__ == "__main__":
     from bigdl.orca import init_orca_context, stop_orca_context
 
     sc = init_orca_context()
-    train_df, test_df, user_num, item_num, sparse_feats_input_dims, num_dense_feats, \
+    train_data, test_data, user_num, item_num, sparse_feats_input_dims, num_dense_feats, \
         feature_cols, label_cols = prepare_data("./ml-1m")
-    train_df.write.parquet("./train_processed.parquet", mode="overwrite")
-    test_df.write.parquet("./test_processed.parquet", mode="overwrite")
+    train_data.save_pickle("./train_processed_xshards")
+    test_data.save_pickle("./test_processed_xshards")
     stop_orca_context()

--- a/python/orca/tutorial/NCF/process_xshards.py
+++ b/python/orca/tutorial/NCF/process_xshards.py
@@ -12,138 +12,138 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-# ==============================================================================
-# Some of the code is adapted from
-# https://github.com/guoyang9/NCF/blob/master/data_utils.py
 #
+import os.path
 
-import os
-import numpy as np
-import pandas as pd
-import scipy.sparse as sp
+from pyspark.ml.feature import StringIndexer, MinMaxScaler, VectorAssembler
+from pyspark.ml import Pipeline
+from pyspark.sql.types import StructField, StructType, IntegerType, LongType, ArrayType, StringType
+from pyspark.sql.functions import udf, lit, collect_list, explode
 
-from sklearn.model_selection import train_test_split
+from bigdl.orca import OrcaContext
 
-from bigdl.orca.data.pandas import read_csv
-from bigdl.orca.data.transformer import StringIndexer, MinMaxScaler
-
-# user and item ids are converted to int64 to be compatible with lower versions of PyTorch
+# user and item ids are converted to LongType to be compatible with lower versions of PyTorch
 # such as 1.7.1.
 
 sparse_features = ["zipcode", "gender", "category", "occupation"]
 dense_features = ["age"]
 
 
-def ng_sampling(data, user_num, item_num, num_ng):
-    data_X = data.values.tolist()
-
-    # calculate a dok matrix
-    train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int64)
-    for row in data_X:
-        train_mat[row[0], row[1]] = 1
-
-    # negative sampling
-    features_ps = data_X
-    features_ng = []
-    for x in features_ps:
-        u = x[0]
-        for t in range(num_ng):
-            j = np.random.randint(item_num)
-            while (u, j) in train_mat:
-                j = np.random.randint(item_num)
-            features_ng.append([u, j])
-
-    labels_ps = [1.0 for _ in range(len(features_ps))]
-    labels_ng = [0.0 for _ in range(len(features_ng))]
-
-    features_fill = features_ps + features_ng
-    labels_fill = labels_ps + labels_ng
-    data_XY = pd.DataFrame(data=features_fill, columns=["user", "item"], dtype=np.int64)
-    data_XY["label"] = labels_fill
-    return data_XY
-
-
-def split_dataset(data):
-    train_data, test_data = train_test_split(data, test_size=0.2, random_state=100)
-    return train_data, test_data
-
-
-def prepare_data(dataset_dir, num_ng=4):
+def read_data(data_dir):
+    spark = OrcaContext.get_spark_session()
+    schema = StructType([StructField("user", LongType(), False),
+                         StructField("item", LongType(), False)])
+    schema_user = StructType(
+        [
+            StructField("user", LongType(), False),
+            StructField("gender", StringType(), False),
+            StructField("age", IntegerType(), False),
+            StructField("occupation", LongType(), False),
+            StructField("zipcode", StringType(), False)
+        ]
+    )
+    schema_item = StructType(
+        [
+            StructField("item", LongType(), False),
+            StructField("title", StringType(), False),
+            StructField("category", StringType(), False)
+        ]
+    )
     print("Loading data...")
     # Need spark3 to support delimiter with more than one character.
-    users = read_csv(
-        os.path.join(dataset_dir, "users.dat"),
-        sep="::", header=None, names=["user", "gender", "age", "occupation", "zipcode"],
-        usecols=[0, 1, 2, 3, 4],
-        dtype={0: np.int64, 1: str, 2: np.int32, 3: np.int64, 4: str})
-    ratings = read_csv(
-        os.path.join(dataset_dir, "ratings.dat"),
-        sep="::", header=None, names=["user", "item"],
-        usecols=[0, 1], dtype={0: np.int64, 1: np.int64})
-    items = read_csv(
-        os.path.join(dataset_dir, "movies.dat"),
-        sep="::", header=None, names=["item", "category"],
-        usecols=[0, 2], dtype={0: np.int64, 2: str})
+    df_rating = spark.read.csv(os.path.join(data_dir, "ratings.dat"),
+                               sep="::", schema=schema, header=False)
+    df_user = spark.read.csv(os.path.join(data_dir, "users.dat"),
+                             sep="::", schema=schema_user, header=False)
+    df_item = spark.read.csv(os.path.join(data_dir, "movies.dat"),
+                             sep="::", schema=schema_item, header=False)
+    return df_rating, df_user, df_item
 
-    # calculate numbers of user and item
-    user_set = set(users["user"].unique())
-    item_set = set(items["item"].unique())
-    user_num = max(user_set) + 1
-    item_num = max(item_set) + 1
 
-    print("Processing features...")
-    # Categorical encoding
-    def convert_datatype(shard, col):
-        shard[col] = shard[col].astype(np.int64)
-        return shard
+def generate_neg_sample(df, item_num, neg_scale):
+    def neg_sample(x):
+        import random
+        neg_res = []
+        for _ in x:
+            for i in range(neg_scale):
+                neg_item_index = random.randint(1, item_num - 1)
+                while neg_item_index in x:
+                    neg_item_index = random.randint(1, item_num - 1)
+                neg_res.append(neg_item_index)
+        return neg_res
 
-    for col in sparse_features[:-1]:  # occupation is already indexed.
-        indexer = StringIndexer(inputCol=col)
-        if col in users.get_schema()["columns"]:
-            users = indexer.fit_transform(users)
-            users = users.transform_shard(lambda shard: convert_datatype(shard, col))
-        else:
-            items = indexer.fit_transform(items)
-            items = items.transform_shard(lambda shard: convert_datatype(shard, col))
+    df = df.withColumn("label", lit(1.0))
 
-    # Calculate input_dims for each sparse features
+    neg_sample_udf = udf(neg_sample, ArrayType(LongType(), False))
+    df_neg = df.groupBy("user").agg(neg_sample_udf(collect_list("item")).alias("item_list"))
+    df_neg = df_neg.select(df_neg.user, explode(df_neg.item_list))
+    df_neg = df_neg.withColumn("label", lit(0.0))
+    df_neg = df_neg.withColumnRenamed("col", "item")
+
+    df = df.unionByName(df_neg)
+    df = df.repartition(df.rdd.getNumPartitions())
+
+    return df
+
+
+def string_index(df, col):
+    indexer = StringIndexer(inputCol=col, outputCol=col + "_index").fit(df)
+    df = indexer.transform(df)
+    df = df.drop(col).withColumnRenamed(col + "_index", col)
+    # The StringIndexer output is float type.
+    # Change to 1-based index with 0 reversed for unknown features.
+    df = df.withColumn(col, df[col].cast("long") + 1)
+    embed_dim = df.agg({col: "max"}).collect()[0][f"max({col})"] + 1
+    return df, embed_dim
+
+
+def min_max_scale(df, col):
+    assembler = VectorAssembler(inputCols=[col], outputCol=col + "_vec")
+    scaler = MinMaxScaler(inputCol=col + "_vec", outputCol=col + "_scaled")
+    pipeline = Pipeline(stages=[assembler, scaler])
+    scalerModel = pipeline.fit(df)
+    df = scalerModel.transform(df)
+    df = df.drop(col, col + "_vec").withColumnRenamed(col + "_scaled", col)
+    return df
+
+
+def merge_features(df, df_user, df_item, sparse_features, dense_features):
     sparse_feats_input_dims = []
-    for col in sparse_features:
-        data = users if col in users.get_schema()["columns"] else items
-        sparse_feat_set = set(data[col].unique())
-        sparse_feats_input_dims.append(max(sparse_feat_set) + 1)
-
-    # scale dense features
-    def rename(shard, col):
-        shard = shard.drop(columns=[col]).rename(columns={col + "_scaled": col})
-        return shard
-
-    for col in dense_features:
-        scaler = MinMaxScaler(inputCol=[col], outputCol=col + "_scaled")
-        if col in users.get_schema()["columns"]:
-            users = scaler.fit_transform(users)
-            users = users.transform_shard(lambda shard: rename(shard, col))
+    for i in sparse_features:
+        if i in df_user.columns:
+            df_user, embed_dim = string_index(df_user, i)
         else:
-            items = scaler.fit_transform(items)
-            items = items.transform_shard(lambda shard: rename(shard, col))
+            df_item, embed_dim = string_index(df_item, i)
+        sparse_feats_input_dims.append(embed_dim)
+    for i in dense_features:
+        if i in df_user.columns:
+            df_user = min_max_scale(df_user, i)
+        else:
+            df_item = min_max_scale(df_item, i)
+    df_feat = df.join(df_user, "user", "inner")
+    df_feat = df_feat.join(df_item, "item", "inner")
+    return df_feat, sparse_feats_input_dims
 
-    # Negative sampling
-    print("Negative sampling...")
-    ratings = ratings.partition_by("user")
-    ratings = ratings.transform_shard(lambda shard: ng_sampling(shard, user_num, item_num, num_ng))
 
-    # Merge XShards
-    print("Merge data...")
-    data = users.merge(ratings, on="user")
-    data = data.merge(items, on="item")
+def prepare_data(data_dir, neg_scale=4):
+    df_rating, df_user, df_item = read_data(data_dir)
 
-    # Split dataset
-    print("Split data...")
-    train_data, test_data = data.transform_shard(split_dataset).split()
+    user_num = df_rating.agg({"user": "max"}).collect()[0]["max(user)"] + 1
+    item_num = df_rating.agg({"item": "max"}).collect()[0]["max(item)"] + 1
 
+    df_rating = generate_neg_sample(df_rating, item_num, neg_scale=neg_scale)
+    # occupation is already indexed.
+    df, sparse_feats_input_dims = \
+        merge_features(df_rating, df_user, df_item, sparse_features[:-1], dense_features)
+
+    occupation_num = df.agg({"occupation": "max"}).collect()[0]["max(occupation)"] + 1
+    sparse_feats_input_dims.append(occupation_num)
     feature_cols = get_feature_cols()
     label_cols = ["label"]
-    return train_data, test_data, user_num, item_num, \
+
+    train_df, val_df = df.randomSplit([0.8, 0.2], seed=100)
+
+    return train_df, val_df, user_num, item_num, \
         sparse_feats_input_dims, len(dense_features), feature_cols, label_cols
 
 
@@ -156,8 +156,8 @@ if __name__ == "__main__":
     from bigdl.orca import init_orca_context, stop_orca_context
 
     sc = init_orca_context()
-    train_data, test_data, user_num, item_num, sparse_feats_input_dims, num_dense_feats, \
+    train_df, test_df, user_num, item_num, sparse_feats_input_dims, num_dense_feats, \
         feature_cols, label_cols = prepare_data("./ml-1m")
-    train_data.save_pickle("./train_processed_xshards")
-    test_data.save_pickle("./test_processed_xshards")
+    train_df.write.parquet("./train_processed.parquet", mode="overwrite")
+    test_df.write.parquet("./test_processed.parquet", mode="overwrite")
     stop_orca_context()

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -59,7 +59,7 @@ class NCFData(data.Dataset):
         self.labels = labels_ps + labels_ng
 
     def merge_features(self, users, items, feature_cols=None):
-        df = pd.DataFrame(self.features, columns=["user", "item"], dtype=np.int32)
+        df = pd.DataFrame(self.features, columns=["user", "item"], dtype=np.int64)
         df["labels"] = self.labels
         df = users.merge(df, on="user")
         df = df.merge(items, on="item")
@@ -90,11 +90,11 @@ def process_users_items(dataset_dir):
         os.path.join(dataset_dir, "users.dat"),
         sep="::", header=None, names=["user", "gender", "age", "occupation", "zipcode"],
         usecols=[0, 1, 2, 3, 4],
-        dtype={0: np.int32, 1: str, 2: np.int32, 3: np.int32, 4: str})
+        dtype={0: np.int64, 1: str, 2: np.int64, 3: np.int64, 4: str})
     items = pd.read_csv(
         os.path.join(dataset_dir, "movies.dat"),
         sep="::", header=None, names=["item", "category"],
-        usecols=[0, 2], dtype={0: np.int32, 1: str}, encoding="latin-1")
+        usecols=[0, 2], dtype={0: np.int64, 1: str}, encoding="latin-1")
 
     user_num = users["user"].max() + 1
     item_num = items["item"].max() + 1
@@ -136,10 +136,10 @@ def process_ratings(dataset_dir, user_num, item_num):
     ratings = pd.read_csv(
         os.path.join(dataset_dir, "ratings.dat"),
         sep="::", header=None, names=["user", "item"],
-        usecols=[0, 1], dtype={0: np.int32, 1: np.int32})
+        usecols=[0, 1], dtype={0: np.int64, 1: np.int64})
 
     # load ratings as a dok matrix
-    train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int32)
+    train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int64)
     for x in ratings.values.tolist():
         train_mat[x[0], x[1]] = 1
     return ratings, train_mat

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -26,6 +26,9 @@ import torch.utils.data as data
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import MinMaxScaler
 
+# user and item ids are converted to int64 to be compatible with lower versions of PyTorch 
+# such as 1.7.1.
+
 
 class NCFData(data.Dataset):
     def __init__(self, features, labels=None,

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -26,8 +26,8 @@ import torch.utils.data as data
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import MinMaxScaler
 
-# user and item ids are converted to int64 to be compatible with lower versions of PyTorch
-# such as 1.7.1.
+# user and item ids and sparse features are converted to int64 to be compatible with
+# lower versions of PyTorch such as 1.7.1.
 
 
 class NCFData(data.Dataset):
@@ -93,11 +93,13 @@ def process_users_items(dataset_dir):
         os.path.join(dataset_dir, "users.dat"),
         sep="::", header=None, names=["user", "gender", "age", "occupation", "zipcode"],
         usecols=[0, 1, 2, 3, 4],
-        dtype={0: np.int64, 1: str, 2: np.int32, 3: np.int64, 4: str})
+        dtype={0: np.int64, 1: str, 2: np.int32, 3: np.int64, 4: str},
+        engine="python")
     items = pd.read_csv(
         os.path.join(dataset_dir, "movies.dat"),
         sep="::", header=None, names=["item", "category"],
-        usecols=[0, 2], dtype={0: np.int64, 1: str}, encoding="latin-1")
+        usecols=[0, 2], dtype={0: np.int64, 1: str},
+        engine="python", encoding="latin-1")
 
     user_num = users["user"].max() + 1
     item_num = items["item"].max() + 1
@@ -138,10 +140,11 @@ def process_ratings(dataset_dir, user_num, item_num):
     ratings = pd.read_csv(
         os.path.join(dataset_dir, "ratings.dat"),
         sep="::", header=None, names=["user", "item"],
-        usecols=[0, 1], dtype={0: np.int64, 1: np.int64})
+        usecols=[0, 1], dtype={0: np.int64, 1: np.int64},
+        engine="python")
 
     # load ratings as a dok matrix
-    train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int64)
+    train_mat = sp.dok_matrix((user_num, item_num), dtype=np.int32)
     for x in ratings.values.tolist():
         train_mat[x[0], x[1]] = 1
     return ratings, train_mat

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -86,14 +86,14 @@ class NCFData(data.Dataset):
 
 
 def process_users_items(dataset_dir):
-    sparse_features = ["gender", "zipcode", "category"]
+    sparse_features = ["gender", "zipcode", "category", "occupation"]
     dense_features = ["age"]
 
     users = pd.read_csv(
         os.path.join(dataset_dir, "users.dat"),
         sep="::", header=None, names=["user", "gender", "age", "occupation", "zipcode"],
         usecols=[0, 1, 2, 3, 4],
-        dtype={0: np.int64, 1: str, 2: np.int64, 3: np.int64, 4: str})
+        dtype={0: np.int64, 1: str, 2: np.int32, 3: np.int64, 4: str})
     items = pd.read_csv(
         os.path.join(dataset_dir, "movies.dat"),
         sep="::", header=None, names=["item", "category"],
@@ -103,10 +103,9 @@ def process_users_items(dataset_dir):
     item_num = items["item"].max() + 1
 
     # categorical encoding
-    for i in sparse_features:
+    for i in sparse_features[:-1]:  # occupation is already indexed.
         df = users if i in users.columns else items
         df[i], _ = pd.Series(df[i]).factorize()
-    sparse_features.append("occupation")  # occupation is already indexed.
 
     # scale dense features
     for i in dense_features:

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -26,7 +26,7 @@ import torch.utils.data as data
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import MinMaxScaler
 
-# user and item ids are converted to int64 to be compatible with lower versions of PyTorch 
+# user and item ids are converted to int64 to be compatible with lower versions of PyTorch
 # such as 1.7.1.
 
 

--- a/python/orca/tutorial/NCF/pytorch_dataset.py
+++ b/python/orca/tutorial/NCF/pytorch_dataset.py
@@ -26,7 +26,7 @@ import torch.utils.data as data
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import MinMaxScaler
 
-# user and item ids and sparse features are converted to int64 to be compatible with
+# user/item ids and sparse features are converted to int64 to be compatible with
 # lower versions of PyTorch such as 1.7.1.
 
 


### PR DESCRIPTION
1. Why the change?
To be compatible with `nn.embedding` in both [torch==1.7.1](https://pytorch.org/docs/1.7.1/generated/torch.nn.Embedding.html#embedding) and [torch==1.13.1](https://pytorch.org/docs/1.13/generated/torch.nn.Embedding.html?highlight=nn+embedding#torch.nn.Embedding)

![image](https://user-images.githubusercontent.com/42887453/211256141-3f9b3e51-9a30-45d1-b24e-4d8ad01d1e6a.png)

![image](https://user-images.githubusercontent.com/42887453/211256207-94ddfd7e-341a-4a01-ace6-d0322f262d8d.png)
