### PR TITLE
Nano: fix two missing patch_compiled by new patch_compiled_and_attrs function

### DIFF
--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -514,6 +514,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                         config=openvino_config,
                                         logging=logging,
                                         **kwargs)
+            patch_compiled(result, model)
             return patch_attrs(result, model)
 
         elif precision == 'bf16':
@@ -533,6 +534,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                         config=final_openvino_option,
                                         logging=logging,
                                         **kwargs)
+            patch_compiled(result, model)
             return patch_attrs(result, model)
 
         invalidInputError(approach == 'static', "Only 'static' approach is supported now.")

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -26,7 +26,7 @@ from bigdl.nano.utils.inference.common.base_optimizer import BaseInferenceOptimi
 from bigdl.nano.utils.inference.common.checker import available_acceleration_combination
 from bigdl.nano.utils.inference.common.utils import AccelerationOption,\
     throughput_calculate_helper, format_optimize_result
-from bigdl.nano.tf.utils import patch_compiled, patch_attrs
+from bigdl.nano.tf.utils import patch_compiled_and_attrs, patch_attrs
 from bigdl.nano.utils.log4Error import invalidInputError
 from tensorflow.keras import Model as Model
 from tensorflow.data import Dataset
@@ -360,8 +360,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             result = KerasONNXRuntimeModel(model, input_spec, onnxruntime_session_options)
         else:
             invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
-        patch_compiled(result, model)
-        return patch_attrs(result, model)
+        return patch_compiled_and_attrs(result, model)
 
     @staticmethod
     def quantize(model: Model,
@@ -514,8 +513,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                         config=openvino_config,
                                         logging=logging,
                                         **kwargs)
-            patch_compiled(result, model)
-            return patch_attrs(result, model)
+            return patch_compiled_and_attrs(result, model)
 
         elif precision == 'bf16':
             invalidInputError(accelerator == 'openvino',
@@ -534,8 +532,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                         config=final_openvino_option,
                                         logging=logging,
                                         **kwargs)
-            patch_compiled(result, model)
-            return patch_attrs(result, model)
+            return patch_compiled_and_attrs(result, model)
 
         invalidInputError(approach == 'static', "Only 'static' approach is supported now.")
 
@@ -647,8 +644,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             result._call_fn_args_backup = onnx_model._call_fn_args_backup
         else:
             invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
-        patch_compiled(result, model)
-        return patch_attrs(result, model)
+        return patch_compiled_and_attrs(result, model)
 
     @staticmethod
     def save(model: Model, path):

--- a/python/nano/src/bigdl/nano/tf/utils.py
+++ b/python/nano/src/bigdl/nano/tf/utils.py
@@ -99,6 +99,18 @@ def patch_compiled(target_model: Model, source_model: Model):
     return target_model
 
 
+def patch_compiled_and_attrs(target_obj: object, source_obj: object) -> object:
+    """
+    Patch compile attributes and other attributes of `source_obj` to `target_obj`.
+
+    :param target_obj: target object
+    :param source_obj: source object
+    :return: `target_obj`
+    """
+    patch_compiled(target_obj, source_obj)
+    return patch_attrs(target_obj, source_obj)
+
+
 def fake_tensor_from_spec(tensor_spec: tf.TensorSpec):
     """Fake a `Tensor` from `TensorSpec`."""
     shape = tensor_spec.shape


### PR DESCRIPTION
## Description

- fix two missing patch_compiled in keras InferenceOptimizer's quantize
- provide new `patch_compiled_and_attrs` function which contains `patch_compiled` and `patch_attrs`

### How to test?
- [x] Unit test