### PR TITLE
[PPML] Change python version to 3.8

### DIFF
--- a/ppml/base/Dockerfile
+++ b/ppml/base/Dockerfile
@@ -37,8 +37,10 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt install software-properties-common -y && \
     add-apt-repository ppa:deadsnakes/ppa -y && \
     apt-get install -y python3.7-minimal build-essential python3.7-distutils python3.7 python3-setuptools python3.7-dev python3-wheel python3-pip libpython3.7 && \
+# Python3.8
+    apt-get install -y python3.8 python3.8-dev python3.8-distutils && \
     rm /usr/bin/python3 && \
-    ln -s /usr/bin/python3.7 /usr/bin/python3 && \
+    ln -s /usr/bin/python3.8 /usr/bin/python3 && \
     pip3 install --upgrade pip && \
     pip3 install --no-cache requests argparse cryptography==3.3.2 urllib3 && \
     pip install setuptools==58.4.0 && \
@@ -69,10 +71,10 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install -y libsm6 make build-essential && \
     apt-get install -y autoconf gawk bison libcurl4-openssl-dev python3-protobuf libprotobuf-c-dev protobuf-c-compiler && \
     apt-get install -y netcat net-tools && \
-    patch /usr/local/lib/python3.7/dist-packages/dill/_dill.py /_dill.py.patch && \
-    patch /usr/lib/python3.7/uuid.py /python-uuid.patch && \
-    patch /usr/local/lib/python3.7/dist-packages/psutil/_pslinux.py /python-pslinux.patch && \
-    cp /usr/lib/x86_64-linux-gnu/libpython3.7m.so.1 /usr/lib/libpython3.7m.so.1 && \
+    patch /usr/local/lib/python3.8/dist-packages/dill/_dill.py /_dill.py.patch && \
+    patch /usr/lib/python3.8/uuid.py /python-uuid.patch && \
+    patch /usr/local/lib/python3.8/dist-packages/psutil/_pslinux.py /python-pslinux.patch && \
+    cp /usr/lib/x86_64-linux-gnu/libpython3.8.so.1 /usr/lib/libpython3.8.so.1 && \
     chmod a+x /ppml/init.sh && \
     chmod a+x /ppml/clean.sh && \
     chmod +x /ppml/verify-attestation-service.sh && \
@@ -117,6 +119,10 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     cp -r /ppml/BigDL/python/ppml/src/ /ppml/bigdl-ppml && \
     rm -rf /ppml/BigDL && \
     cd /ppml
+<<<<<<< HEAD
+=======
+
+>>>>>>> 33935df3c (Change python version to 3.8)
 
 
 ADD ./download_jars.sh /ppml
@@ -126,6 +132,10 @@ ADD ./encrypted-fsd.sh /ppml
 RUN cd /ppml && \
     bash ./download_jars.sh
 
+<<<<<<< HEAD
 ENV PYTHONPATH   /usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages:/ppml/bigdl-ppml/src
+=======
+ENV PYTHONPATH   /usr/lib/python3.8:/usr/lib/python3.8/lib-dynload:/usr/local/lib/python3.8/dist-packages:/usr/lib/python3/dist-packages:/ppml/bigdl-ppml/src
+>>>>>>> 33935df3c (Change python version to 3.8)
 WORKDIR /ppml
 ENTRYPOINT [ "/bin/bash" ]

--- a/ppml/base/Dockerfile
+++ b/ppml/base/Dockerfile
@@ -119,10 +119,6 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     cp -r /ppml/BigDL/python/ppml/src/ /ppml/bigdl-ppml && \
     rm -rf /ppml/BigDL && \
     cd /ppml
-<<<<<<< HEAD
-=======
-
->>>>>>> 33935df3c (Change python version to 3.8)
 
 
 ADD ./download_jars.sh /ppml
@@ -132,10 +128,6 @@ ADD ./encrypted-fsd.sh /ppml
 RUN cd /ppml && \
     bash ./download_jars.sh
 
-<<<<<<< HEAD
-ENV PYTHONPATH   /usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages:/ppml/bigdl-ppml/src
-=======
 ENV PYTHONPATH   /usr/lib/python3.8:/usr/lib/python3.8/lib-dynload:/usr/local/lib/python3.8/dist-packages:/usr/lib/python3/dist-packages:/ppml/bigdl-ppml/src
->>>>>>> 33935df3c (Change python version to 3.8)
 WORKDIR /ppml
 ENTRYPOINT [ "/bin/bash" ]

--- a/ppml/base/README.md
+++ b/ppml/base/README.md
@@ -24,34 +24,13 @@ All the corresponding files including
 
 are changed accordingly.
 
-### Mount files needed by bash.manifest.template
-
-The following four directories required by the `bash.manifest.template` are no longer added to the image.
-```bash
-  { path = "/root/.kube/", uri = "file:/root/.kube/" },
-  { path = "/root/.keras", uri = "file:/root/.keras" },
-  { path = "/root/.m2", uri = "file:/root/.m2" },
-  { path = "/root/.zinc", uri = "file:/root/.zinc" },
-```
-
-
-To ensure that the `bash.manifest.template` works correctly, add the following block into your image's Dockerfile:
-
-```dockerfile
-RUN  mkdir -p /root/.keras/datasets && \
-     mkdir -p /root/.zinc && \
-     mkdir -p /root/.m2 && \
-     mkdir -p /root/.kube/
-```
-
 ### Set ENV in your image
 
-The image have Python3.7 installed.  If this is what you needed, put the following command into your image:
-```dockerfile
-ENV PYTHONPATH   /usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages
-```
+The image have Python3.7 and python3.8 installed.
 
-Otherwise, install your version of Python and set the `PYTHONPATH` accordingly.
+The `PYTHONPATH` has already been setup for you.  The default python version is 3.8.10
+
+If this is not what you want, install your version of Python and set the `PYTHONPATH` accordingly.
 
 Besides, you may also want to set the `WORKDIR` and the `ENTRYPOINT` in your image.
 
@@ -59,11 +38,11 @@ Besides, you may also want to set the `WORKDIR` and the `ENTRYPOINT` in your ima
 
 The image only contains these important components:
 
-1. Python3.7 and some packages.
+1. Python3.8.10 and some packages.
 2. Gramine.
 3. Three patches applied to the Python source code and its packages.
 4. Package sgxsdk and dcap, required by remote attestation.
-5. Script for register MREnclave and verify remote EHSM (The jars required are not fully provided).
+5. Script for register MREnclave and verify remote EHSM.
 
 
 ## How to use the encryption/decryption function provided by Gramine?

--- a/ppml/base/bash.manifest.template
+++ b/ppml/base/bash.manifest.template
@@ -27,7 +27,7 @@ sgx.isvsvn = 3
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}:/usr/lib/python3.8/lib:/usr/lib:{{ jdk_home }}:{{ jdk_home }}/lib/amd64/jli:/ppml/lib"
 loader.env.PATH = "{{ execdir }}:/usr/lib/python3.8/bin:/:/usr/sbin:/usr/bin:/sbin:/bin:{{ jdk_home }}/bin"
 loader.env.PYTHONHOME = "/usr/lib/python3.8"
-# We can use the same PYTHONPATH in the bash environment
+loader.env.PYTHONPATH = "/usr/lib/python3.8:/usr/lib/python3.8/lib-dynload:/usr/local/lib/python3.8/dist-packages:/usr/lib/python3/dist-packages:/ppml/bigdl-ppml/src"
 loader.env.JAVA_HOME = "{{ jdk_home }}"
 loader.env.JAVA_OPTS = "'-Djava.library.path={{ jdk_home }}/lib -Dsun.boot.library.path={{ jdk_home }}/lib'"
 loader.env.SPARK_LOCAL_IP = "{{ spark_local_ip }}"

--- a/ppml/base/bash.manifest.template
+++ b/ppml/base/bash.manifest.template
@@ -24,9 +24,17 @@ sgx.static_address = 1
 sgx.isvprodid = 1
 sgx.isvsvn = 3
 
+<<<<<<< HEAD
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}:/usr/lib/python3.7/lib:/usr/lib:{{ jdk_home }}:{{ jdk_home }}/lib/amd64/jli:/ppml/lib"
 loader.env.PATH = "{{ execdir }}:/usr/lib/python3.7/bin:/:/usr/sbin:/usr/bin:/sbin:/bin:{{ jdk_home }}/bin"
 loader.env.PYTHONHOME = "/usr/lib/python3.7"
+=======
+loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}:/usr/lib/python3.8/lib:/usr/lib:{{ jdk_home }}:{{ jdk_home }}/lib/amd64/jli:/ppml/lib"
+loader.env.PATH = "{{ execdir }}:/usr/lib/python3.8/bin:/:/usr/sbin:/usr/bin:/sbin:/bin:{{ jdk_home }}/bin"
+loader.env.PYTHONHOME = "/usr/lib/python3.8"
+# We can use the same PYTHONPATH in the bash environment
+#loader.env.PYTHONPATH = "/usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages"
+>>>>>>> 33935df3c (Change python version to 3.8)
 loader.env.JAVA_HOME = "{{ jdk_home }}"
 loader.env.JAVA_OPTS = "'-Djava.library.path={{ jdk_home }}/lib -Dsun.boot.library.path={{ jdk_home }}/lib'"
 loader.env.SPARK_LOCAL_IP = "{{ spark_local_ip }}"
@@ -56,7 +64,7 @@ fs.mounts = [
   { path = "/opt", uri = "file:/opt" },
   { path = "/bin", uri = "file:/bin" },
   { path = "/tmp", uri = "file:/tmp" },
-  { path = "/usr/lib/python3.7", uri = "file:/usr/lib/python3.7" },
+  { path = "/usr/lib/python3.8", uri = "file:/usr/lib/python3.8" },
   { path = "/usr/lib/python3/dist-packages", uri = "file:/usr/lib/python3/dist-packages" },
   { path = "/root/.kube/", uri = "file:/root/.kube/" },
   { path = "/root/.keras", uri = "file:/root/.keras" },
@@ -87,7 +95,7 @@ sgx.allowed_files = [
   "file:{{ jdk_home }}",
   "file:/ppml",
   "file:{{ python_home }}",
-  "file:/usr/local/lib/python3.7/dist-packages",
+  "file:/usr/local/lib/python3.8/dist-packages",
   "file:/root/.keras",
   "file:/root/.m2",
   "file:/root/.zinc",

--- a/ppml/base/bash.manifest.template
+++ b/ppml/base/bash.manifest.template
@@ -28,7 +28,6 @@ loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}:/usr/
 loader.env.PATH = "{{ execdir }}:/usr/lib/python3.8/bin:/:/usr/sbin:/usr/bin:/sbin:/bin:{{ jdk_home }}/bin"
 loader.env.PYTHONHOME = "/usr/lib/python3.8"
 # We can use the same PYTHONPATH in the bash environment
-#loader.env.PYTHONPATH = "/usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages"
 loader.env.JAVA_HOME = "{{ jdk_home }}"
 loader.env.JAVA_OPTS = "'-Djava.library.path={{ jdk_home }}/lib -Dsun.boot.library.path={{ jdk_home }}/lib'"
 loader.env.SPARK_LOCAL_IP = "{{ spark_local_ip }}"

--- a/ppml/base/bash.manifest.template
+++ b/ppml/base/bash.manifest.template
@@ -24,17 +24,11 @@ sgx.static_address = 1
 sgx.isvprodid = 1
 sgx.isvsvn = 3
 
-<<<<<<< HEAD
-loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}:/usr/lib/python3.7/lib:/usr/lib:{{ jdk_home }}:{{ jdk_home }}/lib/amd64/jli:/ppml/lib"
-loader.env.PATH = "{{ execdir }}:/usr/lib/python3.7/bin:/:/usr/sbin:/usr/bin:/sbin:/bin:{{ jdk_home }}/bin"
-loader.env.PYTHONHOME = "/usr/lib/python3.7"
-=======
 loader.env.LD_LIBRARY_PATH = "/lib:{{ arch_libdir }}:/usr{{ arch_libdir }}:/usr/lib/python3.8/lib:/usr/lib:{{ jdk_home }}:{{ jdk_home }}/lib/amd64/jli:/ppml/lib"
 loader.env.PATH = "{{ execdir }}:/usr/lib/python3.8/bin:/:/usr/sbin:/usr/bin:/sbin:/bin:{{ jdk_home }}/bin"
 loader.env.PYTHONHOME = "/usr/lib/python3.8"
 # We can use the same PYTHONPATH in the bash environment
 #loader.env.PYTHONPATH = "/usr/lib/python3.7:/usr/lib/python3.7/lib-dynload:/usr/local/lib/python3.7/dist-packages:/usr/lib/python3/dist-packages"
->>>>>>> 33935df3c (Change python version to 3.8)
 loader.env.JAVA_HOME = "{{ jdk_home }}"
 loader.env.JAVA_OPTS = "'-Djava.library.path={{ jdk_home }}/lib -Dsun.boot.library.path={{ jdk_home }}/lib'"
 loader.env.SPARK_LOCAL_IP = "{{ spark_local_ip }}"

--- a/ppml/trusted-bigdata/Dockerfile
+++ b/ppml/trusted-bigdata/Dockerfile
@@ -195,11 +195,9 @@ RUN rm $SPARK_HOME/jars/okhttp-*.jar && \
     chmod +x /usr/local/bin/gosu && \
     chmod +x /opt/flink-entrypoint.sh && \
     chmod -R 777 ${FLINK_HOME} && \
-    chown -R flink:flink ${FLINK_HOME} && \
-    unzip /ppml/spark-3.1.3/python/lib/py4j-0.10.9-src.zip
+    chown -R flink:flink ${FLINK_HOME}
 
 RUN cp /ppml/jars/*.jar ${SPARK_HOME}/jars
 
-ENV PYTHONPATH $PYTHONPATH:/ppml/spark-3.1.3/python:/ppml/spark-3.1.3/python/lib/py4j
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/ppml/trusted-bigdata/Dockerfile
+++ b/ppml/trusted-bigdata/Dockerfile
@@ -195,9 +195,11 @@ RUN rm $SPARK_HOME/jars/okhttp-*.jar && \
     chmod +x /usr/local/bin/gosu && \
     chmod +x /opt/flink-entrypoint.sh && \
     chmod -R 777 ${FLINK_HOME} && \
-    chown -R flink:flink ${FLINK_HOME}
+    chown -R flink:flink ${FLINK_HOME} && \
+    unzip /ppml/spark-3.1.3/python/lib/py4j-0.10.9-src.zip
 
 RUN cp /ppml/jars/*.jar ${SPARK_HOME}/jars
 
+ENV PYTHONPATH $PYTHONPATH:/ppml/spark-3.1.3/python:/ppml/spark-3.1.3/python/lib/py4j
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/ppml/trusted-deep-learning/base/Dockerfile
+++ b/ppml/trusted-deep-learning/base/Dockerfile
@@ -32,7 +32,7 @@ ENV JDK_HOME                            /opt/jdk${JDK_VERSION}
 ENV JAVA_HOME                           /opt/jdk${JDK_VERSION}
 # Environment used for build pytorch
 ARG USE_CUDA=0 USE_CUDNN=0 USE_MKLDNN=1 USE_DISTRIBUTED=1 USE_GLOO=1 USE_GLOO_WITH_OPENSSL=1 USE_MKL=1 BUILD_TEST=0 BLAS=MKL
-ARG CMAKE_PREFIX_PATH="/usr/local/lib/python3.7/dist-packages/:/usr/local/lib/"
+ARG CMAKE_PREFIX_PATH="/usr/local/lib/python3.8/dist-packages/:/usr/local/lib/"
 
 RUN mkdir /ppml/examples && \
     mkdir /ppml/torchserve
@@ -76,6 +76,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install -y openjdk-${JDK_VERSION}-jdk && \
     mkdir -p ${JAVA_HOME} && \
     cp -r /usr/lib/jvm/java-${JDK_VERSION}-openjdk-amd64/* ${JAVA_HOME} && \
+<<<<<<< HEAD
     sed -i '/MAX_FAILURE_THRESHOLD = 5/ios.environ\[\"MPLCONFIGDIR\"\]=\"\/tmp\/matplotlib\"' /usr/local/lib/python3.7/dist-packages/ts/model_service_worker.py && \
     sed -i '/import abc/iimport sys' /usr/local/lib/python3.7/dist-packages/ts/torch_handler/base_handler.py && \
     sed -i '/module = importlib.import_module/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.7/dist-packages/ts/torch_handler/base_handler.py && \
@@ -83,11 +84,20 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     sed -i '/os.path.join/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.7/dist-packages/ts/model_loader.py && \
     sed -i '/import json/iimport sys' /usr/local/lib/python3.7/dist-packages/ts/model_loader.py && \
     cp /usr/local/lib/python3.7/dist-packages/ts/configs/metrics.yaml /ppml && \
+=======
+    sed -i '/MAX_FAILURE_THRESHOLD = 5/ios.environ\[\"MPLCONFIGDIR\"\]=\"\/tmp\/matplotlib\"' /usr/local/lib/python3.8/dist-packages/ts/model_service_worker.py && \
+    sed -i '/import abc/iimport sys' /usr/local/lib/python3.8/dist-packages/ts/torch_handler/base_handler.py && \
+    sed -i '/module = importlib.import_module/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.8/dist-packages/ts/torch_handler/base_handler.py && \
+    sed -i 's/SOCKET_ACCEPT_TIMEOUT = 30.0/SOCKET_ACCEPT_TIMEOUT = 3000.0/' /usr/local/lib/python3.8/dist-packages/ts/model_service_worker.py && \
+    sed -i '/os.path.join/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.8/dist-packages/ts/model_loader.py && \
+    sed -i '/import json/iimport sys' /usr/local/lib/python3.8/dist-packages/ts/model_loader.py && \
+    cp /usr/local/lib/python3.8/dist-packages/ts/configs/metrics.yaml /ppml && \
+>>>>>>> 33935df3c (Change python version to 3.8)
     chmod +x /ppml/torchserve/start-backend-sgx.sh && \
     chmod +x /ppml/torchserve/start-frontend-sgx.sh && \
     chmod +x /ppml/torchserve/start-torchserve-sgx.sh && \
 # PyTorch
-    rm -rf /usr/local/lib/python3.7/dist-packages/torch && \
+    rm -rf /usr/local/lib/python3.8/dist-packages/torch && \
     git clone https://github.com/analytics-zoo/pytorch /pytorch && \
     cd /pytorch && git checkout devel-v1.13.0-2022-11-16 && \
     git submodule sync && git submodule update --init --recursive --jobs 0 && \
@@ -105,7 +115,11 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     cp /sbin/tini /usr/bin/tini && \
 # We need to downgrade markupsafe, the markupsafe required by bigdl-nano removed `soft_unicode`
 # which is then required by our third-layer gramine make command
+<<<<<<< HEAD
     patch /usr/local/lib/python3.7/dist-packages/datasets/utils/filelock.py /filelock.patch && \
+=======
+    patch /usr/local/lib/python3.8/dist-packages/datasets/utils/filelock.py /filelock.patch && \
+>>>>>>> 33935df3c (Change python version to 3.8)
     pip3 install --no-cache markupsafe==2.0.1 pyarrow==6.0.1
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/ppml/trusted-deep-learning/base/Dockerfile
+++ b/ppml/trusted-deep-learning/base/Dockerfile
@@ -76,15 +76,6 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install -y openjdk-${JDK_VERSION}-jdk && \
     mkdir -p ${JAVA_HOME} && \
     cp -r /usr/lib/jvm/java-${JDK_VERSION}-openjdk-amd64/* ${JAVA_HOME} && \
-<<<<<<< HEAD
-    sed -i '/MAX_FAILURE_THRESHOLD = 5/ios.environ\[\"MPLCONFIGDIR\"\]=\"\/tmp\/matplotlib\"' /usr/local/lib/python3.7/dist-packages/ts/model_service_worker.py && \
-    sed -i '/import abc/iimport sys' /usr/local/lib/python3.7/dist-packages/ts/torch_handler/base_handler.py && \
-    sed -i '/module = importlib.import_module/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.7/dist-packages/ts/torch_handler/base_handler.py && \
-    sed -i 's/SOCKET_ACCEPT_TIMEOUT = 30.0/SOCKET_ACCEPT_TIMEOUT = 3000.0/' /usr/local/lib/python3.7/dist-packages/ts/model_service_worker.py && \
-    sed -i '/os.path.join/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.7/dist-packages/ts/model_loader.py && \
-    sed -i '/import json/iimport sys' /usr/local/lib/python3.7/dist-packages/ts/model_loader.py && \
-    cp /usr/local/lib/python3.7/dist-packages/ts/configs/metrics.yaml /ppml && \
-=======
     sed -i '/MAX_FAILURE_THRESHOLD = 5/ios.environ\[\"MPLCONFIGDIR\"\]=\"\/tmp\/matplotlib\"' /usr/local/lib/python3.8/dist-packages/ts/model_service_worker.py && \
     sed -i '/import abc/iimport sys' /usr/local/lib/python3.8/dist-packages/ts/torch_handler/base_handler.py && \
     sed -i '/module = importlib.import_module/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.8/dist-packages/ts/torch_handler/base_handler.py && \
@@ -92,7 +83,6 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     sed -i '/os.path.join/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.8/dist-packages/ts/model_loader.py && \
     sed -i '/import json/iimport sys' /usr/local/lib/python3.8/dist-packages/ts/model_loader.py && \
     cp /usr/local/lib/python3.8/dist-packages/ts/configs/metrics.yaml /ppml && \
->>>>>>> 33935df3c (Change python version to 3.8)
     chmod +x /ppml/torchserve/start-backend-sgx.sh && \
     chmod +x /ppml/torchserve/start-frontend-sgx.sh && \
     chmod +x /ppml/torchserve/start-torchserve-sgx.sh && \

--- a/ppml/trusted-deep-learning/base/Dockerfile
+++ b/ppml/trusted-deep-learning/base/Dockerfile
@@ -105,11 +105,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     cp /sbin/tini /usr/bin/tini && \
 # We need to downgrade markupsafe, the markupsafe required by bigdl-nano removed `soft_unicode`
 # which is then required by our third-layer gramine make command
-<<<<<<< HEAD
-    patch /usr/local/lib/python3.7/dist-packages/datasets/utils/filelock.py /filelock.patch && \
-=======
     patch /usr/local/lib/python3.8/dist-packages/datasets/utils/filelock.py /filelock.patch && \
->>>>>>> 33935df3c (Change python version to 3.8)
     pip3 install --no-cache markupsafe==2.0.1 pyarrow==6.0.1
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]


### PR DESCRIPTION
## Description
Move from python3.7 to python3.8

### 1. Why the change?
Python3.7 will be deprecated

### 2. User API changes
None

### 3. Summary of the change 
Change python version from 3.7 to 3.8

### 4. How to test?
- [x] Manually test in trusted-deep-learning
- [x] trusted-big-data will be later tested by hanyu, after applying a PR fix a issue in it


### 5. TODO
- [x] Please do not re-set PYTHONPATH in second-layer or third layer images, use append `ENV PYTHONPATH $PYTHONPATH:your_path`
- [x] Duplicate torchserve installed in python toolkit, will be later fixed by hanyu
- [x] The python3.7 in start-frontend.sh and start-backend.sh will be fixed by hanyu's PR later in two images
- [x] Error occurs in trusted-bigdata PySpark application, need fix.



### Error message

> This error only occurs in SGX environment.
> This error only occurs with non-local execution mode for Spark

23-01-28 04:07:37 ERROR Executor:94 - Exception in task 0.0 in stage 0.0 (TID 0)
org.apache.spark.SparkException: Python worker failed to connect back.