### PR TITLE
Chronos: realize thread control through `--cores` in benchmark tool

### DIFF
--- a/python/chronos/src/bigdl/chronos/benchmark/benchmark_chronos.py
+++ b/python/chronos/src/bigdl/chronos/benchmark/benchmark_chronos.py
@@ -254,6 +254,9 @@ def experiment(args, records):
     model_path = os.path.join(path, args.ckpt)
 
     if args.framework == "tensorflow":
+        import tensorflow as tf
+        tf.config.threading.set_inter_op_parallelism_threads(1)
+        tf.config.threading.set_intra_op_parallelism_threads(args.cores)
         if not os.path.exists(model_path):
             os.makedirs(model_path, exist_ok=True)
 


### PR DESCRIPTION
## Description

During performance tests using chronos benchmark tool, it is found that setting `-c/--cores` does not work. We have to use `taskset -c` (such as `taskset -c 0-3 benchmark-chronos -l 96 -o 720 -c 4`) to realize thread control and obtain correct results.

In this PR, the problem is solved.


### 2. User API changes

don't have to use `taskset -c`, explicitly specify the number of cores through `-c/--cores`

### 3. Summary of the change 

If framework is pytorch, call `torch.set_num_threads(args.cores)`
If framework is tensorflow, use `spawn_new_process` (https://github.com/intel-analytics/BigDL/pull/7025)

### 4. How to test?
- [x] Unit test
- [x] Local test on icx-5
4.1 use previous version
```bash
taskset -c 0-3 benchmark-chronos -l 96 -o 720 -s train -c 4 --training_batchsize 128
# result
avg throughput: 424.64894439303805
```

```bash
benchmark-chronos -l 96 -o 720 -s train -c 4 --training_batchsize 128
# result (CPU usage is much larger than 400% during fitting)
avg throughput: 655.2500892812021
```
4.2 use modified version
```bash
benchmark-chronos -l 96 -o 720 -s train -c 4
# result
avg throughput: 398.91744136761673
```
