### PR TITLE
[Nano] Fix import path in API docs

### DIFF
--- a/docs/readthedocs/source/doc/PythonAPI/Nano/hpo_api.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Nano/hpo_api.rst
@@ -19,14 +19,14 @@ HPO for Tensorflow
 bigdl.nano.automl.tf.keras.Model
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autoclass:: bigdl.nano.automl.tf.keras.Model.Model
+.. autoclass:: bigdl.nano.automl.tf.keras.Model
     :members: search, search_summary
 
 
 bigdl.nano.automl.tf.keras.Sequential
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-.. autoclass:: bigdl.nano.automl.tf.keras.Sequential.Sequential
+.. autoclass:: bigdl.nano.automl.tf.keras.Sequential
     :members: search, search_summary
 
 

--- a/docs/readthedocs/source/doc/PythonAPI/Nano/pytorch.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Nano/pytorch.rst
@@ -41,3 +41,4 @@ Patch API
 
 .. autofunction:: bigdl.nano.pytorch.patching.patch_dtype
     
+.. autofunction:: bigdl.nano.pytorch.patching.patch_encryption

--- a/docs/readthedocs/source/doc/PythonAPI/Nano/pytorch.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Nano/pytorch.rst
@@ -10,7 +10,7 @@ bigdl.nano.pytorch.Trainer
     :exclude-members: accelerator_connector, checkpoint_connector, reload_dataloaders_every_n_epochs, limit_val_batches, logger, logger_connector, state
 
 bigdl.nano.pytorch.InferenceOptimizer
----------------------------
+---------------------------------------
 
 .. autoclass:: bigdl.nano.pytorch.InferenceOptimizer
     :members:
@@ -21,23 +21,23 @@ bigdl.nano.pytorch.InferenceOptimizer
 TorchNano API
 ---------------------------
 
-.. automodule:: bigdl.nano.pytorch.torch_nano
+.. autoclass:: bigdl.nano.pytorch.TorchNano
     :members:
     :undoc-members:
     :exclude-members: run
 
+.. autofunction:: bigdl.nano.pytorch.nano
+
 Patch API
 ---------------------------
 
-.. automodule:: bigdl.nano.pytorch.dispatcher
-    :members:
-    :undoc-members:
-    :show-inheritance:
+.. autofunction:: bigdl.nano.pytorch.patch_torch
 
-.. automodule:: bigdl.nano.pytorch.patching.gpu_cpu.gpu_cpu
-    :members: patch_cuda, unpatch_cuda
-    :show-inheritance:
+.. autofunction:: bigdl.nano.pytorch.unpatch_torch
 
-.. automodule:: bigdl.nano.pytorch.patching.dtype_patching.dtype_patching
-    :members: patch_dtype
-    :show-inheritance:
+.. autofunction:: bigdl.nano.pytorch.patching.patch_cuda
+
+.. autofunction:: bigdl.nano.pytorch.patching.unpatch_cuda
+
+.. autofunction:: bigdl.nano.pytorch.patching.patch_dtype
+    

--- a/docs/readthedocs/source/doc/PythonAPI/Nano/tensorflow.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Nano/tensorflow.rst
@@ -31,7 +31,6 @@ bigdl.nano.tf.optimizers
 Patch API
 ---------------------------
 
-.. automodule:: bigdl.nano.tf.dispatcher
-    :members:
-    :undoc-members:
-    :show-inheritance:
+.. autofunction:: bigdl.nano.tf.patch_tensorflow
+
+.. autofunction:: bigdl.nano.tf.unpatch_tensorflow

--- a/docs/readthedocs/source/doc/PythonAPI/Nano/tensorflow.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Nano/tensorflow.rst
@@ -34,3 +34,5 @@ Patch API
 .. autofunction:: bigdl.nano.tf.patch_tensorflow
 
 .. autofunction:: bigdl.nano.tf.unpatch_tensorflow
+
+.. autofunction:: bigdl.nano.tf.keras.nano_bf16

--- a/docs/readthedocs/source/doc/PythonAPI/Nano/tensorflow.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Nano/tensorflow.rst
@@ -13,11 +13,6 @@ bigdl.nano.tf.keras
     :undoc-members:
     :inherited-members: Sequential
 
-.. autoclass:: bigdl.nano.tf.keras.InferenceOptimizer
-    :members:
-    :undoc-members:
-    :exclude-members: ALL_INFERENCE_ACCELERATION_METHOD
-
 .. autoclass:: bigdl.nano.tf.keras.layers.Embedding
     :members:
     :undoc-members:
@@ -27,6 +22,13 @@ bigdl.nano.tf.optimizers
 .. autoclass:: bigdl.nano.tf.optimizers.SparseAdam
     :members: 
     :undoc-members:
+
+bigdl.nano.tf.keras.InferenceOptimizer
+---------------------------------------
+.. autoclass:: bigdl.nano.tf.keras.InferenceOptimizer
+    :members:
+    :undoc-members:
+    :exclude-members: ALL_INFERENCE_ACCELERATION_METHOD
 
 Patch API
 ---------------------------

--- a/python/nano/src/bigdl/nano/automl/hpo/space.py
+++ b/python/nano/src/bigdl/nano/automl/hpo/space.py
@@ -420,10 +420,10 @@ class Categorical(NestedSpace):
         of provided options. The first value in the list of options
         will be the default value that gets tried first during HPO.
 
-        param: data : search space or python built-in objects.
+        :param data: search space or python built-in objects.
             The first value will be the default value tried first during HPO.
             e.g.space.Dict(hp1=space.Int(1,2), hp2=space.Int(4,5))
-        param: prefix: string (optional). This is useful for distinguishing
+        :param prefix: string (optional). This is useful for distinguishing
             the same hyperparameter in the same layer when a layer is
             used more than once in the model. Defaults to None.
         """

--- a/python/nano/src/bigdl/nano/automl/tf/mixin.py
+++ b/python/nano/src/bigdl/nano/automl/tf/mixin.py
@@ -257,11 +257,13 @@ class HPOMixin:
         :param n_parallels: number of parallel processes to run trials.
         :param target_metric_mode: target metric of which epoch to report as the final result,
             possible options are:
-                'max': maximum value of all epochs's results
-                'min': minimum value of all epochs's results
-                'last': result of the last epoch
-                'auto': if direction is maximize, use max mode
+
+            | 'max': maximum value of all epochs's results
+            | 'min': minimum value of all epochs's results
+            | 'last': result of the last epoch
+            | 'auto': if direction is maximize, use max mode
                         if direction is minimize, use min mode
+
         :param kwargs: model.fit arguments (e.g. batch_size, validation_data, etc.)
             and search backend arguments (e.g. n_trials, pruner, etc.)
             are allowed in kwargs.

--- a/python/nano/src/bigdl/nano/pytorch/patching/encryption_patching/encryption_patching.py
+++ b/python/nano/src/bigdl/nano/pytorch/patching/encryption_patching/encryption_patching.py
@@ -30,6 +30,10 @@ def patch_encryption():
 
     A key argument is added to torch.save and torch.load which is used to
     encrypt/decrypt the content before saving/loading it to/from disk.
+
+    .. note::
+
+       Please be noted that the key is only secured in Intel SGX mode.
     """
     global is_encryption_patched
     if is_encryption_patched:

--- a/python/nano/src/bigdl/nano/tf/dispatcher.py
+++ b/python/nano/src/bigdl/nano/tf/dispatcher.py
@@ -65,10 +65,10 @@ def patch_tensorflow(precision='float32'):
       ``bigdl.nano.tf.keras.layers.Embedding``
     | 4. ``tf.optimizers.Adam`` -> ``bigdl.nano.tf.optimizers.SparseAdam``
 
-    :param precision: str, specify the compute and variable dtypes, select from ``'float32'`` 
-                      and ``'mixed_bfloat16'``. Once ``'float32'`` is set, both compute and 
-                      variable dtypes will be float32. When ``'mixed_bfloat16'`` is set, 
-                      the compute dtype is bfloat16 and the variable dtype is float32. 
+    :param precision: str, specify the compute and variable dtypes, select from ``'float32'``
+                      and ``'mixed_bfloat16'``. Once ``'float32'`` is set, both compute and
+                      variable dtypes will be float32. When ``'mixed_bfloat16'`` is set,
+                      the compute dtype is bfloat16 and the variable dtype is float32.
                       Default to be ``'float32'``.
     """
     mapping_tf = _get_patch_map()
@@ -92,10 +92,10 @@ def unpatch_tensorflow(precision='float32'):
 
     Meanwhile, set ``precision`` as global dtype policy.
 
-    :param precision: str, specify the compute and variable dtypes, select from ``'float32'`` 
-                      and ``'mixed_bfloat16'``. Once ``'float32'`` is set, both compute and 
-                      variable dtypes will be float32. When ``'mixed_bfloat16'`` is set, 
-                      the compute dtype is bfloat16 and the variable dtype is float32. 
+    :param precision: str, specify the compute and variable dtypes, select from ``'float32'``
+                      and ``'mixed_bfloat16'``. Once ``'float32'`` is set, both compute and
+                      variable dtypes will be float32. When ``'mixed_bfloat16'`` is set,
+                      the compute dtype is bfloat16 and the variable dtype is float32.
                       Default to be ``'float32'``.
     """
     mapping_tf = _get_patch_map()

--- a/python/nano/src/bigdl/nano/tf/dispatcher.py
+++ b/python/nano/src/bigdl/nano/tf/dispatcher.py
@@ -61,14 +61,15 @@ def patch_tensorflow(precision='float32'):
 
     | 1. ``tf.keras.Model``/``keras.Model`` -> ``bigdl.nano.tf.keras.Model``
     | 2. ``tf.keras.Sequential``/``keras.Sequential`` -> ``bigdl.nano.tf.keras.Sequential``
-    | 3. ``tf.keras.layers.Embedding``/``keras.layers.Embedding`` -> 
+    | 3. ``tf.keras.layers.Embedding``/``keras.layers.Embedding`` ->
       ``bigdl.nano.tf.keras.layers.Embedding``
     | 4. ``tf.optimizers.Adam`` -> ``bigdl.nano.tf.optimizers.SparseAdam``
 
-    :param precision: str, specify the compute and variable dtypes, select from ``'float32'`` and
-                      ``'mixed_bfloat16'``. Once ``'float32'`` is set, both compute and variable dtypes
-                      will be float32. When ``'mixed_bfloat16'`` is set, the compute dtype is bfloat16
-                      and the variable dtype is float32. Default to be ``'float32'``.
+    :param precision: str, specify the compute and variable dtypes, select from ``'float32'`` 
+                      and ``'mixed_bfloat16'``. Once ``'float32'`` is set, both compute and 
+                      variable dtypes will be float32. When ``'mixed_bfloat16'`` is set, 
+                      the compute dtype is bfloat16 and the variable dtype is float32. 
+                      Default to be ``'float32'``.
     """
     mapping_tf = _get_patch_map()
 
@@ -91,10 +92,11 @@ def unpatch_tensorflow(precision='float32'):
 
     Meanwhile, set ``precision`` as global dtype policy.
 
-    :param precision: str, specify the compute and variable dtypes, select from ``'float32'`` and
-                      ``'mixed_bfloat16'``. Once ``'float32'`` is set, both compute and variable dtypes
-                      will be float32. When ``'mixed_bfloat16'`` is set, the compute dtype is bfloat16
-                      and the variable dtype is float32. Default to be ``'float32'``.
+    :param precision: str, specify the compute and variable dtypes, select from ``'float32'`` 
+                      and ``'mixed_bfloat16'``. Once ``'float32'`` is set, both compute and 
+                      variable dtypes will be float32. When ``'mixed_bfloat16'`` is set, 
+                      the compute dtype is bfloat16 and the variable dtype is float32. 
+                      Default to be ``'float32'``.
     """
     mapping_tf = _get_patch_map()
 

--- a/python/nano/src/bigdl/nano/tf/dispatcher.py
+++ b/python/nano/src/bigdl/nano/tf/dispatcher.py
@@ -53,21 +53,22 @@ def _get_patch_map():
 
 def patch_tensorflow(precision='float32'):
     """
-    patch_tensorflow is used to patch optimized tensorflow classes to replace original ones.
+    ``patch_tensorflow`` is used to patch optimized tensorflow classes to replace original ones.
 
-    Meanwhile, set `precision` as global dtype policy.
+    Meanwhile, set ``precision`` as global dtype policy.
 
     Optimized classes include:
 
-    | 1. tf.keras.Model/keras.Model -> bigdl.nano.tf.keras.Model
-    | 2. tf.keras.Sequential/keras.Sequential -> bigdl.nano.tf.keras.Sequential
-    | 3. tf.keras.layers.Embedding/keras.layers.Embedding -> bigdl.nano.tf.keras.layers.Embedding
-    | 4. tf.optimizers.Adam -> bigdl.nano.tf.optimizers.SparseAdam
+    | 1. ``tf.keras.Model``/``keras.Model`` -> ``bigdl.nano.tf.keras.Model``
+    | 2. ``tf.keras.Sequential``/``keras.Sequential`` -> ``bigdl.nano.tf.keras.Sequential``
+    | 3. ``tf.keras.layers.Embedding``/``keras.layers.Embedding`` -> 
+      ``bigdl.nano.tf.keras.layers.Embedding``
+    | 4. ``tf.optimizers.Adam`` -> ``bigdl.nano.tf.optimizers.SparseAdam``
 
-    :param precision: str, specify the compute and variable dtypes, select from 'float32' and
-                      'mixed_bfloat16'. Once set 'float32', both compute and variable dtypes
-                      will be float32. When 'mixed_bfloat16' is set, the compute dtype is bfloat16
-                      and the variable dtype is float32. Default to be 'float32'.
+    :param precision: str, specify the compute and variable dtypes, select from ``'float32'`` and
+                      ``'mixed_bfloat16'``. Once ``'float32'`` is set, both compute and variable dtypes
+                      will be float32. When ``'mixed_bfloat16'`` is set, the compute dtype is bfloat16
+                      and the variable dtype is float32. Default to be ``'float32'``.
     """
     mapping_tf = _get_patch_map()
 
@@ -86,14 +87,14 @@ def patch_tensorflow(precision='float32'):
 
 def unpatch_tensorflow(precision='float32'):
     """
-    unpatch_tensorflow is used to unpatch optimized tensorflow classes to original ones.
+    ``unpatch_tensorflow`` is used to unpatch optimized tensorflow classes to original ones.
 
-    Meanwhile, set `precision` as global dtype policy.
+    Meanwhile, set ``precision`` as global dtype policy.
 
-    :param precision: str, specify the compute and variable dtypes, select from 'float32' and
-                      'mixed_bfloat16'. Once set 'float32', both compute and variable dtypes
-                      will be float32. When 'mixed_bfloat16' is set, the compute dtype is bfloat16
-                      and the variable dtype is float32. Default to be 'float32'.
+    :param precision: str, specify the compute and variable dtypes, select from ``'float32'`` and
+                      ``'mixed_bfloat16'``. Once ``'float32'`` is set, both compute and variable dtypes
+                      will be float32. When ``'mixed_bfloat16'`` is set, the compute dtype is bfloat16
+                      and the variable dtype is float32. Default to be ``'float32'``.
     """
     mapping_tf = _get_patch_map()
 


### PR DESCRIPTION
## Description

Fix import path in API docs to make it clear for users that how we suggest to import. 

Example change:
- before: although it is not a wrong way here to import, it shows the original path where this function is placed in source code and it is not the recommended way for user
  ![image](https://user-images.githubusercontent.com/54161268/211280043-82253beb-6d96-491f-b160-a78d0d6f1893.png)
- after:
  ![image](https://user-images.githubusercontent.com/54161268/211280232-430f7416-b731-4da2-b001-4cfc1dc74eb9.png)

### Summary of the change 
- [x] Review and (if have problems) fix import path in API docs
   - Nano PyTorch API
     - [x] ~bigdl.nano.pytorch.Trainer~
     - [x] ~bigdl.nano.pytorch.InferenceOptimizer~
     - [x] TorchNano API
     - [x] Patch API
   - Nano Tensorflow API
     - [x] ~bigdl.nano.tf.keras~
     - [x] ~bigdl.nano.tf.optimizers~
     - [x] ~bigdl.nano.tf.keras.InferenceOptimizer~
     - [x] Patch API
   - Nano HPO API
     - [x] ~Search Space~
     - HPO for Tensorflow
       - [x] bigdl.nano.automl.tf.keras.Model
       - [x] bigdl.nano.automl.tf.keras.Sequential
     - HPO for PyTorch
       - [x] ~bigdl.nano.pytorch.Trainer~
- [x] Add api doc for nano_bf16 decorator
- [x] Small fixes to PyTorch Patch API doc strings
- [x] Move api doc for `bigdl.nano.tf.keras.InferenceOptimizer` out of `bigdl.nano.tf.keras` for clearer navigation
- [x] Add api doc for `bigdl.nano.pytorch.patching.patch_encryption`
- [x] Small doc string fixes in  `bigdl.nano.automl.hpo.space.Categorical` and `bigdl.nano.automl.tf.keras.Model/Sequential.search`

### How to test?
- [x] Document test: https://yuwentestdocs.readthedocs.io/en/nano-api-path-fixes/doc/PythonAPI/Nano/index.html
