### PR TITLE
Chronos: upgrade pandas version

### DIFF
--- a/python/chronos/src/bigdl/chronos/data/utils/impute.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/impute.py
@@ -44,7 +44,7 @@ def impute_timeseries_dataframe(df,
     if mode == "const":
         res_df = _const_impute_timeseries_dataframe(df, const_num)
     if mode == "linear":
-        res_df = _linear_impute_timeseries_dataframe(df)
+        res_df = _linear_impute_timeseries_dataframe(df, dt_col)
 
     return res_df
 
@@ -61,6 +61,9 @@ def _const_impute_timeseries_dataframe(df, const_num):
     return res_df
 
 
-def _linear_impute_timeseries_dataframe(df):
-    res_df = df.interpolate(axis=0, limit_direction='both')
+def _linear_impute_timeseries_dataframe(df, dt_col):
+    res_df = df.copy()
+    res_df[dt_col] = 0
+    res_df = res_df.interpolate(method='linear', axis=0, limit_direction='both')
+    res_df[dt_col] = df[dt_col]
     return res_df

--- a/python/chronos/src/bigdl/chronos/data/utils/quality_inspection.py
+++ b/python/chronos/src/bigdl/chronos/data/utils/quality_inspection.py
@@ -63,7 +63,7 @@ def quality_check_timeseries_dataframe(df, dt_col, id_col=None, repair=True):
     # 3. missing value check
     if _missing_value_check(df, dt_col) is False:
         if repair is True:
-            flag = flag and _missing_value_repair(df)
+            flag = flag and _missing_value_repair(df, dt_col)
         else:
             flag = False
 
@@ -201,13 +201,16 @@ def _missing_value_check(df, dt_col, threshold=0):
     return True
 
 
-def _missing_value_repair(df):
+def _missing_value_repair(df, dt_col):
     '''
     This repair is used to fill missing value with impute by linear interpolation.
     '''
     try:
         # interpolate for most cases
-        df.interpolate(axis=0, limit_direction='both', inplace=True)
+        temp_col = df[dt_col]
+        df[dt_col] = 0
+        df.interpolate(method='linear', axis=0, limit_direction='both', inplace=True)
+        df[dt_col] = temp_col
         # fillna with 0 for cases when the whole column is missing
         df.fillna(0, inplace=True)
     except:

--- a/python/chronos/src/setup.py
+++ b/python/chronos/src/setup.py
@@ -61,7 +61,7 @@ def setup_package():
         license='Apache License, Version 2.0',
         url='https://github.com/intel-analytics/BigDL',
         packages=get_bigdl_packages(),
-        install_requires=['pandas>=1.0.5, <1.3.0', 'scikit-learn>=0.22.0, <=1.0.2',
+        install_requires=['pandas>=1.0.5, <=1.3.5', 'scikit-learn>=0.22.0, <=1.0.2',
                           'bigdl-nano==' + VERSION, 'numpy<=1.23.5'],
         extras_require={'pytorch': ['bigdl-nano[pytorch]==' + VERSION],
                         'tensorflow': ['bigdl-nano[tensorflow_27]=='+VERSION],

--- a/python/chronos/test/bigdl/chronos/data/utils/test_impute.py
+++ b/python/chronos/test/bigdl/chronos/data/utils/test_impute.py
@@ -85,8 +85,9 @@ class TestImputeTimeSeries(TestCase):
         assert res_df['data'][2] == 1
 
     def test_linear_timeseries_dataframe(self):
-        data = {'data': [np.nan, 1, np.nan, 2, 3]}
+        data = {'data': [np.nan, 1, np.nan, 2, 3],
+                'datetime': pd.date_range('1/1/2019', periods=5)}
         df = pd.DataFrame(data)
-        res_df = _linear_impute_timeseries_dataframe(df)
+        res_df = _linear_impute_timeseries_dataframe(df, dt_col="datetime")
         assert res_df['data'][0] == 1
         assert res_df['data'][2] == 1.5


### PR DESCRIPTION
## Description

Nano upgrade openvino to `2022.3.0` in https://github.com/intel-analytics/BigDL/pull/7091.
But openvino-dev 2022.3.0 depends on pandas~=1.3.5 while bigdl-chronos depends on pandas<1.3.0 and >=1.0.5. This causes installation problem of nightly version.

In this pr, upgrade pandas to `1.3.5` and fix problems caused by new version.

### 2. User API changes

None

### 4. How to test?
- [x] Unit test
- [ ] Application test
