### PR TITLE
[PPML] Refine PPML services

### DIFF
--- a/ppml/services/bigdl-kms/docker/README.md
+++ b/ppml/services/bigdl-kms/docker/README.md
@@ -3,7 +3,7 @@
 Download image as below:
 
 ```bash
-docker pull intelanalytics/bkeywhiz:2.2.0-SNAPSHOT
+docker pull intelanalytics/bigdl-kms:2.2.0-SNAPSHOT
 ```
 
 Or you are allowed to build the image manually:

--- a/ppml/services/bigdl-kms/kubernetes/README.md
+++ b/ppml/services/bigdl-kms/kubernetes/README.md
@@ -14,7 +14,7 @@
 
 - Make sure you have a workable **Kubernetes cluster/machine**
 - Make sure you have a reachable **NFS**
-- Prepare [bigdl-keywhiz image](https://github.com/intel-analytics/BigDL/tree/main/ppml/services/BKeywhiz/docker#pullbuild-container-image)
+- Prepare [bigdl-kms image](https://github.com/intel-analytics/BigDL/tree/main/ppml/services/bigdl-kms/docker#pullbuild-container-image)
 
 ## Start BigDL KMS on Kubernetes
 Modify parameters in script `install-bigdl-kms.sh`:

--- a/ppml/services/ehsm/kubernetes/bigdl-ehsm-kms.yaml
+++ b/ppml/services/ehsm/kubernetes/bigdl-ehsm-kms.yaml
@@ -77,7 +77,7 @@ spec:
         securityContext:
           privileged: true
         imagePullPolicy: IfNotPresent
-        command: ['sh' , '-c','if [ -c "/dev/sgx/enclave" ]; then echo "/dev/sgx/enclave is ready";elif [ -c "/dev/sgx_enclave" ]; then echo "/dev/sgx/enclave not ready, try to link to /dev/sgx_enclave"; mkdir -p /dev/sgx; ln -s /dev/sgx_enclave /dev/sgx/enclave; else echo "both /dev/sgx/enclave /dev/sgx_enclave are not ready, please check the kernel and driver";fi; if [ -c "/dev/sgx/provision" ]; then echo "/dev/sgx/provision is ready";elif [ -c "/dev/sgx_provision" ]; then echo "/dev/sgx/provision not ready, try to link to /dev/sgx_provision";mkdir -p /dev/sgx;ln -s /dev/sgx_provision /dev/sgx/provision;else echo "both /dev/sgx/provision /dev/sgx_provision are not ready, please check the kernel and driver";fi;sleep 30; curl -v -k -G -w "%{http_code}" "https://$pccsIP:18081/sgx/certification/v3/rootcacrl";  bash /home/start_dkeyserver.sh']
+        command: ['sh' , '-c','if [ -c "/dev/sgx/enclave" ]; then echo "/dev/sgx/enclave is ready";elif [ -c "/dev/sgx_enclave" ]; then echo "/dev/sgx/enclave not ready, try to link to /dev/sgx_enclave"; mkdir -p /dev/sgx; ln -s /dev/sgx_enclave /dev/sgx/enclave; else echo "both /dev/sgx/enclave /dev/sgx_enclave are not ready, please check the kernel and driver";fi; if [ -c "/dev/sgx/provision" ]; then echo "/dev/sgx/provision is ready";elif [ -c "/dev/sgx_provision" ]; then echo "/dev/sgx/provision not ready, try to link to /dev/sgx_provision";mkdir -p /dev/sgx;ln -s /dev/sgx_provision /dev/sgx/provision;else echo "both /dev/sgx/provision /dev/sgx_provision are not ready, please check the kernel and driver";fi;sleep 30; curl -v -k -G -w "%{http_code}" "$pccsURL/sgx/certification/v3/rootcacrl";  bash /home/start_dkeyserver.sh']
         volumeMounts:
         - mountPath: /dev/sgx/enclave
           name: dev-enclave
@@ -91,7 +91,7 @@ spec:
           name: runtime-folder
         env:
         - name: PCCS_URL
-          value: "https://$pccsIP:18081"
+          value: "$pccsURL"
         - name: DKEYSERVER_ROLE
           value: root
         ports:
@@ -122,7 +122,7 @@ data:
   database_name: "ehsm_kms_db"
   dkeyserver_ip: "dkeyserver-0.dkeyserver"
   dkeyserver_port: "8888"
-  pccs_url: "https://$pccsIP:18081"
+  pccs_url: "$pccsURL"
 ---
 # bigdl-ehsm-kms PersistentVolume used by couchdb
 apiVersion: v1

--- a/ppml/services/ehsm/kubernetes/install-bigdl-ehsm-kms.sh
+++ b/ppml/services/ehsm/kubernetes/install-bigdl-ehsm-kms.sh
@@ -8,7 +8,7 @@ export dkeyserverImageName=intelccc/ehsm_dkeyserver-dev:0.3.2
 export couchdbImageName=couchdb:3.2
 export dkeycacheImageName=intelccc/ehsm_dkeycache-dev:0.3.2
 export ehsmKmsImageName=intelccc/ehsm_kms_service-dev:0.3.2
-export pccsIP=your_pccs_IP
+export pccsURL=your_pccs_URL_like_https://xxxx:yyyy
 export kmsIP=your_kms_ip_to_use_as
 export dkeyserverNodeName=the_fixed_node_you_want_to_assign_dkeyserver_to #kubectl get nodes, and choose one
 


### PR DESCRIPTION
## Description

Convert PCCS in EHSM dependency from IP to URL.
By the way, fix bigdl-kms invalid link.

### 1. Why the change?

Some customers have their custom PCCS service, which is specified by an URL rather constructing from an PCCS pod IP.
This change allows users to configure in a more flexible way.

### 2. User API changes

In EHSM configuration, turn from specifying a PCCS IP to URL.

### 3. Summary of the change 

Refine PPML services.

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...