### PR TITLE
Nano: support ONEDNN fusion for jit inside context manager

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -65,7 +65,7 @@ def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
            this knob overwrites the configuration set by level knob. Only valid when
            ``use_ipex=True``, otherwise will be ignored.
     :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph
-           API, which provides a flexible API for aggressive fusion. Default to 
+           API, which provides a flexible API for aggressive fusion. Default to
            ``True``, only valid when use_jit is ``True``, otherwise will be ignored.
     '''
     from .ipex_inference_model import PytorchIPEXJITModel
@@ -97,7 +97,7 @@ def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
            this knob overwrites the configuration set by level knob. Only valid when
            ``use_ipex=True``, otherwise will be ignored.
     :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph
-           API, which provides a flexible API for aggressive fusion. Default to 
+           API, which provides a flexible API for aggressive fusion. Default to
            ``True``, only valid when use_jit is ``True``, otherwise will be ignored.
     '''
     from .ipex_inference_bf16_model import PytorchIPEXJITBF16Model

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -47,7 +47,7 @@ def ipex_optimize(model: Any, optimizers: Any = None, dtype: Any = None,
 def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
                         use_jit=False, channels_last=None, thread_num=None,
                         inplace=False, jit_strict=True, jit_method=None,
-                        weights_prepack=None):
+                        weights_prepack=None, enable_onednn=True):
     '''
     :param model: the model(nn.module) to be transform.
     :param input_sample: torch tensor indicate the data sample to be used
@@ -64,18 +64,22 @@ def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
            to avoid oneDNN weights reorder. The default value is None. Explicitly setting
            this knob overwrites the configuration set by level knob. Only valid when
            ``use_ipex=True``, otherwise will be ignored.
+    :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph
+           API, which provides a flexible API for aggressive fusion. Default to 
+           ``True``, only valid when use_jit is ``True``, otherwise will be ignored.
     '''
     from .ipex_inference_model import PytorchIPEXJITModel
     return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
                                use_jit=use_jit, channels_last=channels_last,
                                thread_num=thread_num, inplace=inplace, jit_strict=jit_strict,
-                               jit_method=jit_method, weights_prepack=weights_prepack)
+                               jit_method=jit_method, weights_prepack=weights_prepack,
+                               enable_onednn=enable_onednn)
 
 
 def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
                             use_jit=False, channels_last=None, thread_num=None,
                             inplace=False, jit_strict=True, jit_method=None,
-                            weights_prepack=None):
+                            weights_prepack=None, enable_onednn=True):
     '''
     :param model: the model(nn.module) to be transform.
     :param input_sample: torch tensor indicate the data sample to be used
@@ -92,12 +96,16 @@ def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
            to avoid oneDNN weights reorder. The default value is None. Explicitly setting
            this knob overwrites the configuration set by level knob. Only valid when
            ``use_ipex=True``, otherwise will be ignored.
+    :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph
+           API, which provides a flexible API for aggressive fusion. Default to 
+           ``True``, only valid when use_jit is ``True``, otherwise will be ignored.
     '''
     from .ipex_inference_bf16_model import PytorchIPEXJITBF16Model
     return PytorchIPEXJITBF16Model(model, input_sample=input_sample, use_ipex=use_ipex,
                                    use_jit=use_jit, channels_last=channels_last,
                                    thread_num=thread_num, inplace=inplace, jit_strict=jit_strict,
-                                   jit_method=jit_method, weights_prepack=weights_prepack)
+                                   jit_method=jit_method, weights_prepack=weights_prepack,
+                                   enable_onednn=enable_onednn)
 
 
 def PytorchIPEXQuantizationModel(model, calib_data, q_config=None,

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -25,9 +25,9 @@ import torch
 
 class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
     def __init__(self, model, input_sample=None, use_ipex=False,
-                 use_jit=False, channels_last=None, channels_last_available=[], thread_num=None,
-                 from_load=False, inplace=False, jit_strict=True, jit_method=None,
-                 weights_prepack=None):
+                 use_jit=False, channels_last=None, channels_last_available=[],
+                 thread_num=None, from_load=False, inplace=False, jit_strict=True,
+                 jit_method=None, weights_prepack=None, enable_onednn=True):
         '''
         This is the accelerated model for pytorch and ipex/jit.
         All the external API is based on InferenceOptimizer, so what we have here is
@@ -52,6 +52,9 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                to avoid oneDNN weights reorder. The default value is None. Explicitly setting
                this knob overwrites the configuration set by level knob. Only valid when
                ``use_ipex=True``, otherwise will be ignored.
+        :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph
+               API, which provides a flexible API for aggressive fusion. Default to
+               ``True``, only valid when use_jit is ``True``, otherwise will be ignored.
         '''
         if use_ipex:
             invalidInputError(
@@ -69,7 +72,8 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         _accelerator = "jit" if use_jit is True else None
         self._nano_context_manager = generate_context_manager(accelerator=_accelerator,
                                                               precision="bf16",
-                                                              thread_num=thread_num)
+                                                              thread_num=thread_num,
+                                                              enable_onednn=enable_onednn)
 
     @property
     def _check_cpu_isa(self):
@@ -114,4 +118,5 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                                        inplace=inplace,
                                        jit_strict=status.get('jit_strict', True),
                                        jit_method=status.get('jit_method', None),
-                                       weights_prepack=status.get('weights_prepack', None))
+                                       weights_prepack=status.get('weights_prepack', None),
+                                       enable_onednn=status.get('enable_onednn', True))

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -66,7 +66,8 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                                      channels_last_available=channels_last_available,
                                      from_load=from_load, inplace=inplace, jit_strict=jit_strict,
                                      jit_method=jit_method, weights_prepack=weights_prepack)
-        self._nano_context_manager = generate_context_manager(accelerator=None,
+        _accelerator = "jit" if use_jit is True else None
+        self._nano_context_manager = generate_context_manager(accelerator=_accelerator,
                                                               precision="bf16",
                                                               thread_num=thread_num)
 

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -24,8 +24,8 @@ import torch
 class PytorchIPEXJITModel(AcceleratedLightningModule):
     def __init__(self, model: torch.nn.Module, input_sample=None, use_ipex=False, dtype=None,
                  use_jit=False, channels_last=None, channels_last_available=[],
-                 thread_num=None, from_load=False,
-                 inplace=False, jit_strict=True, jit_method=None, weights_prepack=None):
+                 thread_num=None, from_load=False, inplace=False, jit_strict=True, 
+                 jit_method=None, weights_prepack=None, enable_onednn=True):
         """
         This is the accelerated model for pytorch and ipex/jit.
         All the external API is based on InferenceOptimizer, so what we have here is
@@ -56,6 +56,9 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                to avoid oneDNN weights reorder. The default value is None. Explicitly setting
                this knob overwrites the configuration set by level knob. Only valid when
                ``use_ipex=True``, otherwise will be ignored.
+        :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph
+               API, which provides a flexible API for aggressive fusion. Default to
+               ``True``, only valid when use_jit is ``True``, otherwise will be ignored.
         """
         super().__init__(model)
         if from_load:
@@ -68,10 +71,12 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             if self.channels_last:
                 self.model = self.model.to(memory_format=torch.channels_last)
                 self.channels_last_available = channels_last_available
+            self.enable_onednn = enable_onednn
             _accelerator = "jit" if use_jit is True else None
             self._nano_context_manager = generate_context_manager(accelerator=_accelerator,
                                                                   precision="fp32",
-                                                                  thread_num=thread_num)
+                                                                  thread_num=thread_num,
+                                                                  enable_onednn=enable_onednn)
             return
         self.channels_last = channels_last
         self.original_state_dict = model.state_dict()
@@ -131,8 +136,10 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         _accelerator = "jit" if use_jit is True else None
         self._nano_context_manager = generate_context_manager(accelerator=_accelerator,
                                                               precision="fp32",
-                                                              thread_num=thread_num)
+                                                              thread_num=thread_num,
+                                                              enable_onednn=enable_onednn)
         self.thread_num = thread_num
+        self.enable_onednn = enable_onednn
 
     @property
     def forward_args(self):
@@ -180,8 +187,9 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                        "checkpoint": "ckpt.pth",
                        "thread_num": self.thread_num,
                        "jit_strict": self.jit_strict,
-                       'jit_method': self.jit_method,
-                       'weights_prepack': self.weights_prepack})
+                       "jit_method": self.jit_method,
+                       "weights_prepack": self.weights_prepack,
+                       "enable_onednn": self.enable_onednn})
         return status
 
     @staticmethod
@@ -214,7 +222,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                                    inplace=inplace,
                                    jit_strict=status.get('jit_strict', True),
                                    jit_method=status.get('jit_method', None),
-                                   weights_prepack=status.get('weights_prepack', None))
+                                   weights_prepack=status.get('weights_prepack', None),
+                                   enable_onednn=statue.get('enable_onednn', True))
 
     def _save_model(self, path):
         if self.use_jit:

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -24,7 +24,7 @@ import torch
 class PytorchIPEXJITModel(AcceleratedLightningModule):
     def __init__(self, model: torch.nn.Module, input_sample=None, use_ipex=False, dtype=None,
                  use_jit=False, channels_last=None, channels_last_available=[],
-                 thread_num=None, from_load=False, inplace=False, jit_strict=True, 
+                 thread_num=None, from_load=False, inplace=False, jit_strict=True,
                  jit_method=None, weights_prepack=None, enable_onednn=True):
         """
         This is the accelerated model for pytorch and ipex/jit.

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -68,7 +68,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             if self.channels_last:
                 self.model = self.model.to(memory_format=torch.channels_last)
                 self.channels_last_available = channels_last_available
-            self._nano_context_manager = generate_context_manager(accelerator=None,
+            _accelerator = "jit" if use_jit is True else None
+            self._nano_context_manager = generate_context_manager(accelerator=_accelerator,
                                                                   precision="fp32",
                                                                   thread_num=thread_num)
             return
@@ -127,7 +128,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                         except Exception:
                             self.model = torch.jit.script(self.model)
                     self.model = torch.jit.freeze(self.model)
-        self._nano_context_manager = generate_context_manager(accelerator=None,
+        _accelerator = "jit" if use_jit is True else None
+        self._nano_context_manager = generate_context_manager(accelerator=_accelerator,
                                                               precision="fp32",
                                                               thread_num=thread_num)
         self.thread_num = thread_num

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -223,7 +223,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                                    jit_strict=status.get('jit_strict', True),
                                    jit_method=status.get('jit_method', None),
                                    weights_prepack=status.get('weights_prepack', None),
-                                   enable_onednn=statue.get('enable_onednn', True))
+                                   enable_onednn=status.get('enable_onednn', True))
 
     def _save_model(self, path):
         if self.use_jit:

--- a/python/nano/src/bigdl/nano/pytorch/context_manager.py
+++ b/python/nano/src/bigdl/nano/pytorch/context_manager.py
@@ -25,10 +25,10 @@ class BaseContextManager(object):
 
     This context manager is used for providing no_grad context only.
     """
-
-    def __init__(self, thread_num=None):
+    def __init__(self, thread_num=None, accelerator=None):
         self.infer_mode = torch.inference_mode(mode=True)
         self.thread_num = thread_num
+        self.accelerator = accelerator
         self.original_thread_num = torch.get_num_threads()
 
     def __enter__(self):
@@ -38,6 +38,8 @@ class BaseContextManager(object):
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         self.infer_mode.__exit__(exc_type, exc_value, exc_tb)
+        if self.accelerator == "jit":
+            torch.jit.enable_onednn_fusion(False)
         torch.set_num_threads(self.original_thread_num)
 
 
@@ -48,8 +50,8 @@ class AutocastContextManager(BaseContextManager):
     This context manager is used for providing no grad and autocast context,
     which is used for bf16 model.
     """
-    def __init__(self, thread_num=None):
-        super().__init__(thread_num=thread_num)
+    def __init__(self, thread_num=None, accelerator=None):
+        super().__init__(thread_num=thread_num, accelerator=accelerator)
         if compare_version("torch", operator.lt, "1.13.0"):
             # In torch1.12, torch.inference_mode(mode=True) will cause bug for jit+bf16
             self.infer_mode = torch.no_grad()
@@ -57,6 +59,12 @@ class AutocastContextManager(BaseContextManager):
 
     def __enter__(self):
         super().__enter__()
+        if self.accelerator == "jit":
+            if compare_version("torch", operator.le, "1.13.1"):
+                # onednn fusion for bf16 only work for torch version > 1.13
+                torch.jit.enable_onednn_fusion(False)
+            # Disable AMP for JIT
+            torch._C._jit_set_autocast_mode(False)
         self.autocast.__enter__()
 
     def __exit__(self, exc_type, exc_value, exc_tb):
@@ -67,12 +75,12 @@ class AutocastContextManager(BaseContextManager):
 def generate_context_manager(accelerator=None, precision="fp32", thread_num=None):
     '''
     generate correct context manager according to different situation
-    :param acclerator: str, the accelerator to use, we support "onnxruntime", "openvino"
-           and None for pytorch framework.
+    :param acclerator: str, the accelerator to use, we support "onnxruntime", "openvino",
+           "jit", and None for pytorch framework.
     :param precision: str, the precision to use, we support "fp32", "bf16" and "int8".
     :param thread_num: int, the thread number to allocate, None for no limit.
     '''
     if precision != "bf16":
-        return BaseContextManager(thread_num=thread_num)
+        return BaseContextManager(thread_num=thread_num, accelerator=accelerator)
     else:
-        return AutocastContextManager(thread_num=thread_num)
+        return AutocastContextManager(thread_num=thread_num, accelerator=accelerator)

--- a/python/nano/src/bigdl/nano/pytorch/context_manager.py
+++ b/python/nano/src/bigdl/nano/pytorch/context_manager.py
@@ -62,7 +62,6 @@ class AutocastContextManager(BaseContextManager):
     def __init__(self, thread_num=None, accelerator=None, enable_onednn=True):
         super().__init__(thread_num=thread_num, accelerator=accelerator,
                          enable_onednn=enable_onednn)
-        super().__init__(thread_num=thread_num, accelerator=accelerator)
         if compare_version("torch", operator.lt, "1.13.0"):
             # In torch1.12, torch.inference_mode(mode=True) will cause bug for jit+bf16
             self.infer_mode = torch.no_grad()

--- a/python/nano/src/bigdl/nano/pytorch/context_manager.py
+++ b/python/nano/src/bigdl/nano/pytorch/context_manager.py
@@ -25,17 +25,18 @@ class BaseContextManager(object):
 
     This context manager is used for providing no_grad context only.
     """
-    def __init__(self, thread_num=None, accelerator=None):
+    def __init__(self, thread_num=None, accelerator=None, enable_onednn=True):
         self.infer_mode = torch.inference_mode(mode=True)
         self.thread_num = thread_num
         self.accelerator = accelerator
+        self.enable_onednn = enable_onednn
         self.original_thread_num = torch.get_num_threads()
 
     def __enter__(self):
         if self.thread_num is not None:
             torch.set_num_threads(self.thread_num)
         self.infer_mode.__enter__()
-        if self.accelerator == "jit":
+        if self.accelerator == "jit" and self.enable_onednn is True:
             if compare_version("torch", operator.ge, "1.12.0"):
                 # onednn fusion be added to torch from version 1.12
                 if not torch.jit.onednn_fusion_enabled():
@@ -43,7 +44,7 @@ class BaseContextManager(object):
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         self.infer_mode.__exit__(exc_type, exc_value, exc_tb)
-        if self.accelerator == "jit":
+        if self.accelerator == "jit" and self.enable_onednn is True:
             if compare_version("torch", operator.ge, "1.12.0"):
                 # onednn fusion be added to torch from version 1.12
                 torch.jit.enable_onednn_fusion(False)
@@ -58,7 +59,9 @@ class AutocastContextManager(BaseContextManager):
     This context manager is used for providing no grad and autocast context,
     which is used for bf16 model.
     """
-    def __init__(self, thread_num=None, accelerator=None):
+    def __init__(self, thread_num=None, accelerator=None, enable_onednn=True):
+        super().__init__(thread_num=thread_num, accelerator=accelerator,
+                         enable_onednn=enable_onednn)
         super().__init__(thread_num=thread_num, accelerator=accelerator)
         if compare_version("torch", operator.lt, "1.13.0"):
             # In torch1.12, torch.inference_mode(mode=True) will cause bug for jit+bf16
@@ -67,7 +70,7 @@ class AutocastContextManager(BaseContextManager):
 
     def __enter__(self):
         super().__enter__()
-        if self.accelerator == "jit":
+        if self.accelerator == "jit" and self.enable_onednn is True:
             if compare_version("torch", operator.le, "1.13.1"):
                 # onednn fusion for bf16 only work for torch version > 1.13
                 if compare_version("torch", operator.ge, "1.12.0"):
@@ -82,15 +85,21 @@ class AutocastContextManager(BaseContextManager):
         super().__exit__(exc_type, exc_value, exc_tb)
 
 
-def generate_context_manager(accelerator=None, precision="fp32", thread_num=None):
+def generate_context_manager(accelerator=None, precision="fp32", thread_num=None,
+                             enable_onednn=True):
     '''
     generate correct context manager according to different situation
     :param acclerator: str, the accelerator to use, we support "onnxruntime", "openvino",
            "jit", and None for pytorch framework.
     :param precision: str, the precision to use, we support "fp32", "bf16" and "int8".
     :param thread_num: int, the thread number to allocate, None for no limit.
+    :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph
+           API, which provides a flexible API for aggressive fusion. Default to
+           ``True``, only valid when accelerator="jit", otherwise will be ignored.
     '''
     if precision != "bf16":
-        return BaseContextManager(thread_num=thread_num, accelerator=accelerator)
+        return BaseContextManager(thread_num=thread_num, accelerator=accelerator,
+                                  enable_onednn=enable_onednn)
     else:
-        return AutocastContextManager(thread_num=thread_num, accelerator=accelerator)
+        return AutocastContextManager(thread_num=thread_num, accelerator=accelerator,
+                                      enable_onednn=enable_onednn)

--- a/python/nano/src/bigdl/nano/pytorch/context_manager.py
+++ b/python/nano/src/bigdl/nano/pytorch/context_manager.py
@@ -48,7 +48,6 @@ class BaseContextManager(object):
             if compare_version("torch", operator.ge, "1.12.0"):
                 # onednn fusion be added to torch from version 1.12
                 torch.jit.enable_onednn_fusion(False)
-        self.infer_mode.__exit__(exc_type, exc_value, exc_tb)
         torch.set_num_threads(self.original_thread_num)
 
 

--- a/python/nano/src/bigdl/nano/pytorch/context_manager.py
+++ b/python/nano/src/bigdl/nano/pytorch/context_manager.py
@@ -74,6 +74,7 @@ class AutocastContextManager(BaseContextManager):
                 if compare_version("torch", operator.ge, "1.12.0"):
                     # onednn fusion be added to torch from version 1.12
                     torch.jit.enable_onednn_fusion(False)
+        if self.accelerator == "jit":
             # Disable AMP for JIT
             torch._C._jit_set_autocast_mode(False)
         self.autocast.__enter__()

--- a/python/nano/src/bigdl/nano/pytorch/context_manager.py
+++ b/python/nano/src/bigdl/nano/pytorch/context_manager.py
@@ -35,6 +35,11 @@ class BaseContextManager(object):
         if self.thread_num is not None:
             torch.set_num_threads(self.thread_num)
         self.infer_mode.__enter__()
+        if self.accelerator == "jit":
+            if compare_version("torch", operator.ge, "1.12.0"):
+                #  onednn fusion be added from torch version 1.12
+                if not torch.jit.onednn_fusion_enabled():
+                    torch.jit.enable_onednn_fusion(True)
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         self.infer_mode.__exit__(exc_type, exc_value, exc_tb)

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -516,6 +516,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                  logging: bool = True,
                  inplace: bool = False,
                  weights_prepack: Optional[bool] = None,
+                 enable_onednn: bool = True,
                  q_config=None,
                  **kwargs):
         """
@@ -631,6 +632,12 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                 Only valid when ``use_ipex=True``, otherwise will be ignored.
                                 You can try to reduce the occupied memory size by setting this
                                 parameter to ``False``.
+        :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph API,
+                              which provides a flexible API for aggressive fusion. Default to
+                              ``True``, only valid when accelerator='jit', otherwise will
+                              be ignored. For more details, please refer https://github.com/
+                              pytorch/pytorch/tree/master/torch/csrc/jit/codegen/
+                              onednn#pytorch---onednn-graph-api-bridge.
         :param q_config: describes how to quantize a layer or a part of the network
                          by providing settings (observer classes) for activations and weights
                          respectively. Note that QConfig needs to contain observer classes
@@ -688,7 +695,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                                    thread_num=thread_num, inplace=inplace,
                                                    jit_strict=jit_strict,
                                                    jit_method=jit_method,
-                                                   weights_prepack=weights_prepack)
+                                                   weights_prepack=weights_prepack,
+                                                   enable_onednn=enable_onednn)
                 else:
                     bf16_model = BF16Model(model, channels_last=channels_last,
                                            input_sample=input_sample,
@@ -892,6 +900,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
               logging: bool = True,
               inplace: bool = False,
               weights_prepack: Optional[bool] = None,
+              enable_onednn: bool = True,
               **kwargs):
         """
         Trace a torch.nn.Module and convert it into an accelerated module for inference.
@@ -954,6 +963,12 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                 Only valid when ``use_ipex=True``, otherwise will be ignored.
                                 You can try to reduce the occupied memory size by setting this
                                 parameter to ``False``.
+        :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph API,
+                              which provides a flexible API for aggressive fusion. Default to 
+                              ``True``, only valid when accelerator='jit', otherwise will be
+                              ignored. For more details, please refer https://github.com/pytorch/
+                              pytorch/tree/master/torch/csrc/jit/codegen/
+                              onednn#pytorch---onednn-graph-api-bridge.
         :param **kwargs: Other extra advanced settings include:
                          1. those be passed to torch.onnx.export function,
                          only valid when accelerator='onnxruntime'/'openvino',
@@ -1015,7 +1030,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                        use_jit=use_jit, channels_last=channels_last,
                                        thread_num=thread_num, inplace=inplace,
                                        jit_strict=jit_strict, jit_method=jit_method,
-                                       weights_prepack=weights_prepack)
+                                       weights_prepack=weights_prepack,
+                                       enable_onednn=enable_onednn)
         invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
 
     @staticmethod

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -964,7 +964,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                 You can try to reduce the occupied memory size by setting this
                                 parameter to ``False``.
         :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph API,
-                              which provides a flexible API for aggressive fusion. Default to 
+                              which provides a flexible API for aggressive fusion. Default to
                               ``True``, only valid when accelerator='jit', otherwise will be
                               ignored. For more details, please refer https://github.com/pytorch/
                               pytorch/tree/master/torch/csrc/jit/codegen/

--- a/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
@@ -223,11 +223,11 @@ class Pytorch1_11:
         model = resnet18(num_classes=10)
         x = torch.rand((10, 3, 256, 256))
         # test jit + ipex
-        model = InferenceOptimizer.trace(model, precision='bf16',
-                                         accelerator="jit",
-                                         use_ipex=True,
-                                         input_sample=x,
-                                         weights_prepack=False)
+        model = InferenceOptimizer.quantize(model, precision='bf16',
+                                            accelerator="jit",
+                                            use_ipex=True,
+                                            input_sample=x,
+                                            weights_prepack=False)
         with InferenceOptimizer.get_context(model):
             model(x)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
@@ -284,11 +284,11 @@ class Pytorch1_11:
         model = resnet18(num_classes=10)
         x = torch.rand((10, 3, 256, 256))
         # test jit + ipex
-        model = InferenceOptimizer.trace(model, precision='bf16',
-                                         accelerator="jit",
-                                         use_ipex=True,
-                                         input_sample=x,
-                                         enable_onednn=True)
+        model = InferenceOptimizer.quantize(model, precision='bf16',
+                                            accelerator="jit",
+                                            use_ipex=True,
+                                            input_sample=x,
+                                            enable_onednn=True)
         with InferenceOptimizer.get_context(model):
             model(x)
         with tempfile.TemporaryDirectory() as tmp_dir_name:

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -17,7 +17,7 @@
 
 import os
 from unittest import TestCase
-
+import operator
 import pytest
 import torch
 from torch.utils.data import TensorDataset, DataLoader

--- a/python/nano/test/run-nano-type-test.sh
+++ b/python/nano/test/run-nano-type-test.sh
@@ -4,4 +4,6 @@ export ANALYTICS_ZOO_ROOT=${ANALYTICS_ZOO_ROOT}
 export NANO_HOME=${ANALYTICS_ZOO_ROOT}/python/nano/
 export NANO_TEST_DIR=${ANALYTICS_ZOO_ROOT}/python/nano/test
 # "mypy --install-types --non-interactive" is to automatically install missing types 
+mkdir .mypy_cache  # fix error: --install-types failed (no mypy cache directory)
 mypy --install-types --non-interactive --config-file ${NANO_TEST_DIR}/mypy.ini $NANO_HOME/src $NANO_HOME/example
+rm -r .mypy_cache


### PR DESCRIPTION
## Description

I have tried ONEDNN Graph API based on [this link](https://github.com/pytorch/pytorch/tree/master/torch/csrc/jit/codegen/onednn#pytorch---onednn-graph-api-bridge), and I found ONEDNN fusion can bring obvious acceleration to jit (speedup >= 2x) !

  | Torch Version | FP32 | BF16
-- | -- | -- | --
Original | nightly | 4.15s | 3.3s
ONEDNN | nightly | 0.86s | 0.78s
Original | 1.13.1 | 4.7s | 2.18s
ONEDNN | 1.13.1 | 1.0s | Not supported now
Original | 1.12 | 1.65s | 1.39s
ONEDNN | 1.12 | 0.76s | Not supported now

So here try to support ONEDNN fusion for jit automatically inside context manager.

notes:
1. ONEDNN fusion for fp32 is only supported for versions above torch1.12
2. ONEDNN fusion for bf16 is only supported for versions above torch1.14 [or torch 2.0]
3. speedup is achieved only for static shapes, for dynamic shapes, there is little difference between using ONEDNN fusion or not.

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/247

### 2. User API changes

new parameter `enable_onednn` for PyTorch InferenceOptimizer's `trace`/`quantize` for user to decide whether use ONEDNN fusion or not.
```python
model = InferenceOptimizer.trace(self.model, accelerator="jit",
                                 use_ipex=True, input_sample=self.data_sample,
                                 enable_onednn=True)
model = InferenceOptimizer.quantize(model, precision='bf16',
                                    accelerator="jit",
                                    use_ipex=True,
                                    input_sample=x,
                                    enable_onednn=True)
```

### 3. Summary of the change 

- support ONEDNN fusion for jit inside context manager
- new parameter `enable_onednn` for PyTorch InferenceOptimizer's trace/quantize
- related uts
- fix mypy error: --install-types failed (no mypy cache directory)

### 4. How to test?
- [x] Unit test
