### PR TITLE
Orca: Remove the loop of fit in our example Super Resolution

### DIFF
--- a/python/orca/example/learn/pytorch/super_resolution/super_resolution.py
+++ b/python/orca/example/learn/pytorch/super_resolution/super_resolution.py
@@ -304,7 +304,7 @@ elif opt.backend in ["ray", "spark"]:
     if exists(model_dir):
         shutil.rmtree(model_dir)
 
-    f_model_out_path = model_dir + "/" + "model_epoch_{epoch:02d}.pth"
+    f_model_out_path = join(model_dir, "model_epoch_{epoch:02d}.pth")
 
     stats = estimator.fit(data=train_data_creator,
                           epochs=opt.epochs,

--- a/python/orca/example/learn/pytorch/super_resolution/super_resolution.py
+++ b/python/orca/example/learn/pytorch/super_resolution/super_resolution.py
@@ -313,13 +313,13 @@ elif opt.backend in ["ray", "spark"]:
                                                      save_weights_only=True)])
     for epochinfo in stats:
         print("===> Epoch {} Complete: Avg. Loss: {:.4f}"
-                .format(epochinfo["epoch"], epochinfo["train_loss"]))
+              .format(epochinfo["epoch"], epochinfo["train_loss"]))
 
     val_stats = estimator.evaluate(data=validation_data_creator,
-                                    batch_size=opt.test_batch_size)
+                                   batch_size=opt.test_batch_size)
     print("===> Validation Complete: Avg. PSNR: {:.4f} dB, Avg. Loss: {:.4f}"
-            .format(10 * log10(1. / val_stats["val_loss"]), val_stats["val_loss"]))
-    
+          .format(10 * log10(1. / val_stats["val_loss"]), val_stats["val_loss"]))
+
     model = estimator.get_model()
     last_model_path = f_model_out_path.format(epoch=opt.epochs)
     estimator.save(last_model_path)

--- a/python/orca/example/learn/pytorch/super_resolution/super_resolution.py
+++ b/python/orca/example/learn/pytorch/super_resolution/super_resolution.py
@@ -43,6 +43,7 @@ from bigdl.orca import init_orca_context, stop_orca_context
 from bigdl.orca.learn.pytorch import Estimator
 from bigdl.orca.learn.metrics import MSE
 from bigdl.orca.learn.trigger import EveryEpoch
+from bigdl.orca.learn.pytorch.callbacks.model_checkpoint import ModelCheckpoint
 
 parser = argparse.ArgumentParser(description='PyTorch Super Res Example')
 parser.add_argument('--upscale_factor', type=int,
@@ -302,21 +303,27 @@ elif opt.backend in ["ray", "spark"]:
     if not exists(model_dir):
         makedirs(model_dir)
 
-    for epoch in range(1, opt.epochs + 1):
-        stats = estimator.fit(data=train_data_creator, epochs=1, batch_size=opt.batch_size)
-        for epochinfo in stats:
-            print("===> Epoch {} Complete: Avg. Loss: {:.4f}"
-                  .format(epoch, epochinfo["train_loss"]))
+    f_model_out_path = model_dir + "/" + "model_epoch_{epoch:02d}.pth"
 
-        val_stats = estimator.evaluate(data=validation_data_creator,
-                                       batch_size=opt.test_batch_size)
-        print("===> Validation Complete: Avg. PSNR: {:.4f} dB, Avg. Loss: {:.4f}"
-              .format(10 * log10(1. / val_stats["val_loss"]), val_stats["val_loss"]))
+    stats = estimator.fit(data=train_data_creator,
+                          epochs=opt.epochs,
+                          batch_size=opt.batch_size,
+                          callbacks=[ModelCheckpoint(filepath=f_model_out_path,
+                                                     save_weights_only=True)])
+    for epochinfo in stats:
+        print("===> Epoch {} Complete: Avg. Loss: {:.4f}"
+                .format(epochinfo["epoch"], epochinfo["train_loss"]))
 
-        model_out_path = model_dir + "/" + "model_epoch_{}.pth".format(epoch)
-        model = estimator.get_model()
-        torch.save(model, model_out_path)
-        print("Checkpoint saved to {}".format(model_out_path))
+    val_stats = estimator.evaluate(data=validation_data_creator,
+                                    batch_size=opt.test_batch_size)
+    print("===> Validation Complete: Avg. PSNR: {:.4f} dB, Avg. Loss: {:.4f}"
+            .format(10 * log10(1. / val_stats["val_loss"]), val_stats["val_loss"]))
+
+    
+    model = estimator.get_model()
+    last_model_path = f_model_out_path.format(epoch=opt.epoch)
+    torch.save(model, last_model_path)
+    print("Checkpoint saved to {}".format(last_model_path))
 else:
     invalidInputError(False, "Only bigdl, ray, and spark are supported as the backend, "
                       "but got {}".format(opt.backend))

--- a/python/orca/example/learn/pytorch/super_resolution/super_resolution.py
+++ b/python/orca/example/learn/pytorch/super_resolution/super_resolution.py
@@ -26,6 +26,7 @@ from math import log10
 from PIL import Image
 import urllib
 import tarfile
+import shutil
 import os
 from os import makedirs, remove, listdir
 from os.path import exists, join, basename
@@ -300,8 +301,8 @@ elif opt.backend in ["ray", "spark"]:
         }
     )
 
-    if not exists(model_dir):
-        makedirs(model_dir)
+    if exists(model_dir):
+        shutil.rmtree(model_dir)
 
     f_model_out_path = model_dir + "/" + "model_epoch_{epoch:02d}.pth"
 
@@ -318,11 +319,10 @@ elif opt.backend in ["ray", "spark"]:
                                     batch_size=opt.test_batch_size)
     print("===> Validation Complete: Avg. PSNR: {:.4f} dB, Avg. Loss: {:.4f}"
             .format(10 * log10(1. / val_stats["val_loss"]), val_stats["val_loss"]))
-
     
     model = estimator.get_model()
-    last_model_path = f_model_out_path.format(epoch=opt.epoch)
-    torch.save(model, last_model_path)
+    last_model_path = f_model_out_path.format(epoch=opt.epochs)
+    estimator.save(last_model_path)
     print("Checkpoint saved to {}".format(last_model_path))
 else:
     invalidInputError(False, "Only bigdl, ray, and spark are supported as the backend, "


### PR DESCRIPTION
## Description

Call estimator.fit in a loop may raise a big overhead when there is a short period of time for real training, and it seems that our examples are misleading our user to do that.
https://github.com/analytics-zoo/Telecom-CTC-E2E/issues/27#issue-1527156829

So we just apply another way to achieve this.