### PR TITLE
[Orca] Optimize Spark Dataframe Input Performance with Openvino Estimator

### DIFF
--- a/python/orca/src/bigdl/orca/learn/openvino/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/openvino/estimator.py
@@ -27,7 +27,7 @@ from bigdl.dllib.utils import nest
 from bigdl.dllib.nncontext import init_nncontext
 from bigdl.orca.data.utils import spark_df_to_pd_sparkxshards
 from bigdl.orca.learn.utils import process_xshards_of_pandas_dataframe,\
-                                   add_predict_to_pd_xshards
+    add_predict_to_pd_xshards
 
 from openvino.inference_engine import IECore
 import numpy as np

--- a/python/orca/src/bigdl/orca/learn/openvino/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/openvino/estimator.py
@@ -63,7 +63,6 @@ class OpenvinoEstimator(SparkEstimator):
     def predict(self,  # type: ignore[override]
                 data: Union["SparkXShards", "DataFrame", "np.ndarray", List["np.ndarray"]],
                 feature_cols: Optional[List[str]] = None,
-                label_cols: Optional[List[str]] = None,
                 batch_size: Optional[int] = 4,
                 input_cols: Optional[Union[str, List[str]]]=None
                 ) -> Optional[Union["SparkXShards", "DataFrame", "np.ndarray", List["np.ndarray"]]]:
@@ -239,8 +238,7 @@ class OpenvinoEstimator(SparkEstimator):
         if isinstance(data, DataFrame):
             xshards = spark_df_to_pd_sparkxshards(data)
             pd_sparkxshards = process_xshards_of_pandas_dataframe(xshards,
-                                                                  feature_cols=feature_cols,
-                                                                  label_cols=label_cols)
+                                                                  feature_cols=feature_cols)
 
             transformed_data = pd_sparkxshards.transform_shard(predict_transform, batch_size)
             result_rdd = transformed_data.rdd.mapPartitions(lambda iter: partition_inference(iter))

--- a/python/orca/src/bigdl/orca/learn/openvino/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/openvino/estimator.py
@@ -229,10 +229,7 @@ class OpenvinoEstimator(SparkEstimator):
 
         def update_result_shard(data):
             shard, y = data
-            pred_list = []
-            for i in range(len(y)):
-                pred_list.append(y[i].tolist())
-            shard["prediction"] = pred_list
+            shard["prediction"] = y
             return shard
 
         if isinstance(data, DataFrame):

--- a/python/orca/src/bigdl/orca/learn/utils.py
+++ b/python/orca/src/bigdl/orca/learn/utils.py
@@ -141,7 +141,10 @@ def add_predict_to_pd_xshards(xshards, pred_xshards):
     def add_prediction(df_preds):
         df, preds = df_preds
         preds = preds["prediction"]
-        df["prediction"] = [pred for pred in preds]
+        if isinstance(preds[0], np.ndarray):
+            df["prediction"] = [pred.tolist() for pred in preds]
+        else:
+            df["prediction"] = [pred for pred in preds]
         return df
 
     result = SparkXShards(xshards.rdd.zip(pred_xshards.rdd).map(add_prediction),


### PR DESCRIPTION
## Description
This PR applies `spark_df_to_pd_xshards`, which is optimized by arrow to decrease memory usage and improve the inference pipeline performance. 

Performance on Yarn (Spark 2.4.6 Version, without arrow, Minimum Configuration Requirements):
| Input | Executor Num | Executor Memory |
| --- | --- | ---  |
| 2000 Images DataFrame | 2 | 8g | 

Spark 3.1.3 Version still get oom error when converting xshards to spark dataframe (2000 images dataframe).

### 1. Why the change?
In the previous implementation, converting spark dataframe to xshards could cause a lot of memory and time, which may exceed the user's hardware capabilities.

### 2. User API changes
N/A

### 3. Summary of the change
Use arrow-optimized functionalities to improve pipeline performance.

### 4. How to test?
- [ ] Unit test
- [x] Application test
