### PR TITLE
[Nano] Fix `bigdl.nano.tf.keras.Model` api doc issue after V1Model and V2Model is added

### DIFF
--- a/python/nano/src/bigdl/nano/tf/keras/__init__.py
+++ b/python/nano/src/bigdl/nano/tf/keras/__init__.py
@@ -17,6 +17,6 @@ import tensorflow as tf
 
 
 from .Sequential import Sequential
-from .Model import Model
+from .Model import V2Model as Model
 from .inference.optimizer import InferenceOptimizer
 from .customized_training_utils import nano_bf16


### PR DESCRIPTION
## Description

Fix the problematic API doc of `bigdl.nano.tf.keras.Model` after merging #7211:
<img src=https://user-images.githubusercontent.com/54161268/211771673-2ad37fca-b731-4378-bb4a-a4ccce9b7684.png width=500>
that is, the api doc is currently showing the api for `tf.keras.Model`. This is because we are not injecting functions for class `Model` itself. It seems that `tf.keras.Model` will decide whether to use `V1Model` or `V2Model` during code execution, while autodoc "import the corresponding module and extract the docstring of the given objects" with no execution.

https://github.com/analytics-zoo/nano/issues/239#issuecomment-1378517493

### How to test?
- [x] Unit test
- [x] Document test: https://yuwentestdocs.readthedocs.io/en/nano-tf-model-api-fix/doc/PythonAPI/Nano/tensorflow.html#bigdl-nano-tf-keras
