### PR TITLE
hotfix bigdlcompressor: bad arguments error

### DIFF
--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/BigDLEncryptCompressor.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/BigDLEncryptCompressor.scala
@@ -84,8 +84,12 @@ class BigDLEncryptCompressor(cryptoMode: CryptoMode, dataKeyPlaintext: String) e
       val o = if (hasHeader) {
         val o = bigdlEncrypt.update(this.lv2Buffer, this.lv2Off, this.lv2Len)
         bytesRead += this.lv2Len
-        // create a buffer to cache undecrypted data.
-        this.b.copyToArray(this.lv2Buffer)
+        // create a buffer to cache undecrypted data, size of this.b is changing.
+        if (lv2Buffer.size >= this.b.size) {
+          this.b.copyToArray(this.lv2Buffer)
+        } else {
+          lv2Buffer = this.b.clone()
+        }
         lv2Off = this.off
         lv2Len = this.len
         this.len = 0


### PR DESCRIPTION
## Description

hotfix bigdlcompressor: bad arguments error， when enable codec on hive.

### 1. Why the change?


The size of b maybe change, this may lead to a bad arguments error.
We need to ensure the size of lv2buffer is bigger than b.

### 2. User API changes

none

### 3. Summary of the change 

Ensure the size of lv2buffer is bigger than b.

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
