### PR TITLE
Orca: rm unnecessary for loop in examples

### DIFF
--- a/python/orca/example/learn/tf2/resnet/resnet-50-imagenet.py
+++ b/python/orca/example/learn/tf2/resnet/resnet-50-imagenet.py
@@ -434,6 +434,6 @@ if __name__ == "__main__":
             callbacks=callbacks,
             validation_steps=args.num_images_validation // global_batch_size,
         )
-            
+
         trainer.save(os.path.join(args.log_dir, f"model-{args.epochs}.pkl"))
     stop_orca_context()

--- a/python/orca/example/learn/tf2/resnet/resnet-50-imagenet.py
+++ b/python/orca/example/learn/tf2/resnet/resnet-50-imagenet.py
@@ -423,19 +423,17 @@ if __name__ == "__main__":
             callbacks=callbacks,
         )
     else:
-        epoch = 0
-        for i in range(5):
-            dummy = args.use_dummy_data
+        dummy = args.use_dummy_data
 
-            results = trainer.fit(
-                data=train_data_creator if not dummy else dummy_data_creator,
-                epochs=args.epochs,
-                batch_size=global_batch_size,
-                validation_data=val_data_creator if not dummy else dummy_data_creator,
-                steps_per_epoch=args.num_images_train // global_batch_size,
-                callbacks=callbacks,
-                validation_steps=args.num_images_validation // global_batch_size,
-            )
-            epoch += args.epochs
-        trainer.save(os.path.join(args.log_dir, f"model-{epoch}.pkl"))
+        results = trainer.fit(
+            data=train_data_creator if not dummy else dummy_data_creator,
+            epochs=args.epochs,
+            batch_size=global_batch_size,
+            validation_data=val_data_creator if not dummy else dummy_data_creator,
+            steps_per_epoch=args.num_images_train // global_batch_size,
+            callbacks=callbacks,
+            validation_steps=args.num_images_validation // global_batch_size,
+        )
+            
+        trainer.save(os.path.join(args.log_dir, f"model-{args.epochs}.pkl"))
     stop_orca_context()


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

remove unnecessary for loops in examples, users should use more epochs instead.

https://github.com/analytics-zoo/Telecom-CTC-E2E/issues/27

