### PR TITLE
[Nano] Fix the long warm-up time of jit model

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -17,6 +17,7 @@
 from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
 from bigdl.nano.pytorch.context_manager import generate_context_manager
 from bigdl.nano.deps.ipex.ipex_api import ipex_optimize
+from bigdl.nano.utils.log4warning import register_suggestion
 import torch
 
 
@@ -54,6 +55,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         """
         super().__init__(model)
         if from_load:
+            register_suggestion(" The first two inference times will be longer than the subsequent \
+                                inference times for the reason that model loaded lack of warm up.")
             self.use_ipex = use_ipex
             self.use_jit = use_jit
             self.channels_last = channels_last

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -679,16 +679,19 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                         invalidInputError(not TORCH_VERSION_LESS_1_10,
                                           "torch version should >=1.10 to use ipex")
                     use_jit = (accelerator == "jit")
-                    if use_jit:
-                        invalidInputError(jit_method in [None, 'trace', 'script'],
-                                          "jit_method {} is invalid.".format(jit_method))
-                    return PytorchIPEXJITBF16Model(model, input_sample=input_sample,
+                    ipex_jit_bf16_model =  PytorchIPEXJITBF16Model(model, input_sample=input_sample,
                                                    use_ipex=use_ipex, use_jit=use_jit,
                                                    channels_last=channels_last,
                                                    thread_num=thread_num, inplace=inplace,
                                                    jit_strict=jit_strict,
                                                    jit_method=jit_method,
                                                    weights_prepack=weights_prepack)
+                    if use_jit:
+                        invalidInputError(jit_method in [None, 'trace', 'script'],
+                                          "jit_method {} is invalid.".format(jit_method))
+                        for _ in range(2):
+                            ipex_jit_bf16_model(input_sample)
+                    return ipex_jit_bf16_model
                 else:
                     bf16_model = BF16Model(model, channels_last=channels_last,
                                            thread_num=thread_num)
@@ -1007,14 +1010,21 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 invalidInputError(not TORCH_VERSION_LESS_1_10,
                                   "torch version should >=1.10 to use ipex")
             use_jit = (accelerator == "jit")
+            ipex_jit_fp32_model = PytorchIPEXJITModel(model, input_sample=input_sample, 
+                                                    use_ipex=use_ipex, use_jit=use_jit, 
+                                                    channels_last=channels_last,
+                                                    thread_num=thread_num, inplace=inplace,
+                                                    jit_strict=jit_strict, jit_method=jit_method,
+                                                    weights_prepack=weights_prepack)
             if use_jit:
                 invalidInputError(jit_method in [None, 'trace', 'script'],
                                   "jit_method {} is invalid.".format(jit_method))
-            return PytorchIPEXJITModel(model, input_sample=input_sample, use_ipex=use_ipex,
-                                       use_jit=use_jit, channels_last=channels_last,
-                                       thread_num=thread_num, inplace=inplace,
-                                       jit_strict=jit_strict, jit_method=jit_method,
-                                       weights_prepack=weights_prepack)
+                print('======================DEBUG START: warm up successfully======================')
+                for _ in range(2):
+                    ipex_jit_fp32_model(input_sample)
+                print('======================DEBUG  END : warm up successfully======================')
+            return ipex_jit_fp32_model
+
         invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
 
     @staticmethod

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -1019,10 +1019,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             if use_jit:
                 invalidInputError(jit_method in [None, 'trace', 'script'],
                                   "jit_method {} is invalid.".format(jit_method))
-                print('======================DEBUG START: warm up successfully======================')
                 for _ in range(2):
                     ipex_jit_fp32_model(input_sample)
-                print('======================DEBUG  END : warm up successfully======================')
             return ipex_jit_fp32_model
 
         invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))


### PR DESCRIPTION
## Description

* Add warm up action when optimize jit model by `trace` or `quantize` function 

### 1. Why the change?

* To solve the problem #7062 

### 2. User API changes

None

### 3. Summary of the change 

* Add warm up action before return jit model optimized by `trace` or `quantize`
* Add warning when load jit model

### 4. How to test?
* test code: change the `PRECISION` to test `bf16_jit` or `fp32_jit`
```python
#%%
import torch
from torchvision.models import resnet18
from bigdl.nano.pytorch import InferenceOptimizer

#%%
USE_JIT = True
# USE_JIT = False
# PRECISION = "fp32"
PRECISION = "bf16"

model_ft = resnet18(pretrained=True)

if PRECISION == "fp32":
    jit_model = InferenceOptimizer.trace(
        model_ft,
        accelerator="jit",
        use_ipex=True,
        input_sample=torch.rand(1, 3, 224, 224),
        thread_num=1,
    )
elif PRECISION == "bf16":
    jit_model = InferenceOptimizer.quantize(
        model_ft,
        precision="bf16",
        accelerator="jit",
        use_ipex=True,
        input_sample=torch.rand(1, 3, 224, 224),
        thread_num=1,
    )
else:
    print("Error: The PRECISION must be 'fp32' or 'bf16'")

x = torch.rand(3, 3, 224, 224)
#%%
with torch.no_grad():
    with torch.jit.optimized_execution(USE_JIT):
        %time y_hat = jit_model(x)

#%%
with torch.no_grad():
    with torch.jit.optimized_execution(USE_JIT):
        %time y_hat = jit_model(x)
#%%
with torch.no_grad():
    with torch.jit.optimized_execution(USE_JIT):
        %time y_hat = jit_model(x)
#%%
with torch.no_grad():
    with torch.jit.optimized_execution(USE_JIT):
        %time y_hat = jit_model(x)
#%%
with torch.no_grad():
    with torch.jit.optimized_execution(USE_JIT):
        %time y_hat = jit_model(x)
#%%
with torch.no_grad():
    with torch.jit.optimized_execution(USE_JIT):
        %time y_hat = jit_model(x)
#%%
```

### 5. Result of test
* Result without warmup before(bf16)
![MicrosoftTeams-image](https://user-images.githubusercontent.com/58850527/212010835-a96f1942-bfeb-4eef-83fc-b3c07d5ba273.png)
* Result after warmup 
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/58850527/212010990-52af65b0-0b95-4642-8b9b-fffed618a7a3.png)
