### PR TITLE
Nano: replace `torch.no_grad()` with `torch.inference_mode()` in context manager 

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/context_manager.py
+++ b/python/nano/src/bigdl/nano/pytorch/context_manager.py
@@ -25,17 +25,17 @@ class BaseContextManager(object):
     """
 
     def __init__(self, thread_num=None):
-        self.no_grad = torch.no_grad()
+        self.infer_mode = torch.inference_mode(mode=True)
         self.thread_num = thread_num
         self.original_thread_num = torch.get_num_threads()
 
     def __enter__(self):
         if self.thread_num is not None:
             torch.set_num_threads(self.thread_num)
-        self.no_grad.__enter__()
+        self.infer_mode.__enter__()
 
     def __exit__(self, exc_type, exc_value, exc_tb):
-        self.no_grad.__exit__(exc_type, exc_value, exc_tb)
+        self.infer_mode.__exit__(exc_type, exc_value, exc_tb)
         torch.set_num_threads(self.original_thread_num)
 
 

--- a/python/nano/src/bigdl/nano/pytorch/context_manager.py
+++ b/python/nano/src/bigdl/nano/pytorch/context_manager.py
@@ -15,6 +15,8 @@
 #
 
 import torch
+import operator
+from bigdl.nano.utils.util import compare_version
 
 
 class BaseContextManager(object):
@@ -48,6 +50,9 @@ class AutocastContextManager(BaseContextManager):
     """
     def __init__(self, thread_num=None):
         super().__init__(thread_num=thread_num)
+        if compare_version("torch", operator.lt, "1.13.0"):
+            # In torch1.12, torch.inference_mode(mode=True) will cause bug for jit+bf16
+            self.infer_mode = torch.no_grad()
         self.autocast = torch.cpu.amp.autocast(enabled=True, dtype=torch.bfloat16)
 
     def __enter__(self):


### PR DESCRIPTION
## Description

I found torch.inference_mode(True) is more recommended than torch.no_grad() now.
https://pytorch.org/docs/stable/generated/torch.inference_mode.html
_InferenceMode is a new context manager analogous to no_grad to be used when you are certain your operations will have no interactions with autograd (e.g., model training). Code run under this mode gets better performance by disabling view tracking and version counter bumps.Note that unlike some other mechanisms that locally enable or disable grad, entering inference_mode also disables to [forward-mode AD](https://pytorch.org/docs/stable/autograd.html#forward-mode-ad)_
As it disables more things than no_grad, I think it would provide slight better performance.
After my simple test, `torch.inference_mode(True)` has 5% acceleration compared with `torch.no_grad`.

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/256

### 2. User API changes

No change

### 3. Summary of the change 

replace `torch.no_grad()` with `torhch.inference_mode()` in context manager 

### 4. How to test?
- [x] Unit test
