### PR TITLE
Nano: fix save & load for inc ipex quantization

### DIFF
--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
@@ -20,10 +20,10 @@ from bigdl.nano.utils.log4Error import invalidInputError
 from bigdl.nano.utils.util import compare_version
 
 
-def load_inc_model(path, model, framework):
+def load_inc_model(path, model, framework, input_sample=None):
     if framework == 'pytorch':
         from .pytorch.quantized_model import PytorchQuantizedModel
-        return PytorchQuantizedModel._load(path, model)
+        return PytorchQuantizedModel._load(path, model, example_inputs=input_sample)
     elif framework == 'tensorflow':
         from .tensorflow.model import KerasQuantizedModel
         return KerasQuantizedModel._load(path, model)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
@@ -23,6 +23,7 @@ from bigdl.nano.utils.util import compare_version
 def load_inc_model(path, model, framework, input_sample=None):
     if framework == 'pytorch':
         from .pytorch.quantized_model import PytorchQuantizedModel
+        # only ipex quantization needs example_inputs
         return PytorchQuantizedModel._load(path, model, example_inputs=input_sample)
     elif framework == 'tensorflow':
         from .tensorflow.model import KerasQuantizedModel

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
@@ -153,15 +153,16 @@ def _quantize(
         timeout=timeout,
         max_trials=max_trials,
     )
+    # For ipex quantization, we should set backend = "ipex"
+    backend = "default" if framework != "pytorch_ipex" else "ipex"
     config = PostTrainingQuantConfig(
         accuracy_criterion=accuracy_criterion,
         tuning_criterion=tuning_criterion,
         approach=approach,
         inputs=inputs,
         outputs=outputs,
+        backend=backend
     )
-    if framework == 'pytorch_ipex':
-        config['backend'] = 'ipex'
     # if metric is None and eval_dataloader is None:
     if metric is None:
         config.performance_only = True

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
@@ -172,7 +172,7 @@ def _quantize(
 
     q_model = quantization.fit(
         model=model,
-        conf=config,
+        conf=q_conf,
         calib_dataloader=dataloader,
         # todo: add eval
     )

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
@@ -161,16 +161,16 @@ def _quantize(
         outputs=outputs,
     )
     config.performance_only = True
-    config = Config(quantization=config, benchmark=None, pruning=None,
-                    distillation=None, nas=None)
-
-    q_conf = QuantConf()
-    q_conf.map_pyconfig_to_cfg(config)
-    q_conf.usr_cfg.model.framework = framework
+    if framework == "pytorch_ipex":
+        backend = "ipex"
+    else:
+        backend = "default"
+    # for onnxruntime, what is the backend?
+    config.backend = backend
 
     q_model = quantization.fit(
         model=model,
-        conf=q_conf,
+        conf=config,
         calib_dataloader=dataloader,
         # todo: add eval
     )

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
@@ -160,13 +160,15 @@ def _quantize(
         inputs=inputs,
         outputs=outputs,
     )
-    config.performance_only = True
-    if framework == "pytorch_ipex":
-        backend = "ipex"
-    else:
-        backend = "default"
-    # for onnxruntime, what is the backend?
-    config.backend = backend
+    # if metric is None and eval_dataloader is None:
+    if metric is None:
+        config.performance_only = True
+    config = Config(quantization=config, benchmark=None, pruning=None,
+                    distillation=None, nas=None)
+
+    q_conf = QuantConf()
+    q_conf.map_pyconfig_to_cfg(config)
+    q_conf.usr_cfg.model.framework = framework
 
     q_model = quantization.fit(
         model=model,

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
@@ -160,6 +160,8 @@ def _quantize(
         inputs=inputs,
         outputs=outputs,
     )
+    if framework == 'pytorch_ipex':
+        config['backend'] = 'ipex'
     # if metric is None and eval_dataloader is None:
     if metric is None:
         config.performance_only = True

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
@@ -16,7 +16,6 @@
 from pathlib import Path
 import yaml
 import operator
-import torch
 from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
 from ..core import version as inc_version
 from neural_compressor.utils.pytorch import load
@@ -29,6 +28,7 @@ from bigdl.nano.utils.util import compare_version
 
 class PytorchQuantizedModel(AcceleratedLightningModule):
     def __init__(self, model, thread_num=None):
+        super().__init__(model.model)
         self.quantized = model
         self.thread_num = thread_num
         self._nano_context_manager = generate_context_manager(accelerator=None,

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
@@ -31,7 +31,7 @@ class PytorchQuantizedModel(AcceleratedLightningModule):
     def __init__(self, model, thread_num=None):
         if isinstance(model, torch.jit._script.RecursiveScriptModule):
             # ipex quantization's save will check whether model is instance
-            # torch.jit._script.RecursiveScriptModule
+            # of torch.jit._script.RecursiveScriptModule
             super().__init__(model)
         else:
             super().__init__(model.model)

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -1089,7 +1089,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         save_model(model, path)
 
     @staticmethod
-    def load(path, model: Optional[nn.Module] = None, inplace=False, device=None):
+    def load(path, model: Optional[nn.Module] = None, input_sample=None,
+             inplace=False, device=None):
         """
         Load a model from local.
 
@@ -1098,13 +1099,16 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                the model with accelerator=None by InferenceOptimizer.trace/
                InferenceOptimizer.quantize. model should be set to None if you choose
                accelerator="onnxruntime"/"openvino"/"jit".
+        :param input_sample: Input sample for your model, could be a Tensor or a tuple.
+               Only valid for inc ipex quantization model, otherwise will be ignored.
         :param inplace: whether to perform inplace optimization. Default: ``False``.
         :param device: A string represents the device of the inference. Default to None.
                Only valid for openvino model, otherwise will be ignored.
         :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                  precision(FP32/FP16/BF16/INT8).
         """
-        return load_model(path, model, inplace=inplace, device=device)
+        return load_model(path, model, input_sample=input_sample,
+                          inplace=inplace, device=device)
 
     @staticmethod
     def to_multi_instance(model: nn.Module, num_processes: int = 4,

--- a/python/nano/src/bigdl/nano/pytorch/utils.py
+++ b/python/nano/src/bigdl/nano/pytorch/utils.py
@@ -118,7 +118,8 @@ def save_model(model: pl.LightningModule, path):
         torch.save(model.state_dict(), checkpoint_path)
 
 
-def load_model(path, model: pl.LightningModule = None, inplace=False, device=None):
+def load_model(path, model: pl.LightningModule = None, input_sample=None,
+               inplace=False, device=None):
     """
     Load a model from local.
 
@@ -126,6 +127,8 @@ def load_model(path, model: pl.LightningModule = None, inplace=False, device=Non
     :param model: Required FP32 model to load pytorch model, it is needed if you accelerated
             the model with accelerator=None by Trainer.trace/Trainer.quantize. model
             should be set to None if you choose accelerator="onnxruntime"/"openvino"/"jit".
+    :param input_sample: Input sample for your model, could be a Tensor or a tuple.
+            Only valid for inc ipex quantization model, otherwise will be ignored.
     :param inplace: whether to perform inplace optimization. Default: ``False``.
     :param device: A string represents the device of the inference. Default to None.
                    Only valid for openvino model, otherwise will be ignored.
@@ -150,7 +153,7 @@ def load_model(path, model: pl.LightningModule = None, inplace=False, device=Non
                           "Argument 'model' must be None for ONNX Runtime loading.")
         return load_onnxruntime_model(path)
     if model_type == 'PytorchQuantizedModel':
-        return load_inc_model(path, model, 'pytorch')
+        return load_inc_model(path, model, 'pytorch', input_sample=input_sample)
     if model_type == 'PytorchIPEXJITModel':
         return load_ipexjit_model(path, model, inplace=inplace)
     if model_type == 'PytorchIPEXJITBF16Model':

--- a/python/nano/test/inc/pytorch/test_quantize.py
+++ b/python/nano/test/inc/pytorch/test_quantize.py
@@ -233,6 +233,7 @@ class TestTrainer(TestCase):
         InferenceOptimizer.quantize(model,
                                     calib_data=self.train_loader,
                                     method="ipex",
+                                    # inplace=False is setting to disable back up ipex quantization
                                     inplace=False)
 
     # INC 1.14 and 2.0 doesn't supprot quantizing pytorch-lightning module,

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -205,7 +205,7 @@ class IPEXJITInference_gt_1_10:
                                                 method='ipex',
                                                 calib_data=data_loader)
         # test context manager
-        with InferenceOptimizer.get_context(model):
+        with InferenceOptimizer.get_context(inc_model):
             inc_model(self.data_sample)
 
         # test save & load

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -208,12 +208,10 @@ class IPEXJITInference_gt_1_10:
         with InferenceOptimizer.get_context(model):
             inc_model(self.data_sample)
 
-        # The save/load of ipex_int8 quanzation has konwn bug,
-        # will fix it in the future
         # test save & load
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(inc_model, tmp_dir_name)
-            new_model = InferenceOptimizer.load(tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name, model)
         with InferenceOptimizer.get_context(new_model):
             new_model(self.data_sample)
 

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -23,10 +23,11 @@ import torch
 from torch.utils.data import TensorDataset, DataLoader
 from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
 from torch import nn
-
+import operator
 from bigdl.nano.pytorch import InferenceOptimizer
 from bigdl.nano.pytorch.vision.models import vision
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
+from bigdl.nano.utils.util import compare_version
 import tempfile
 
 batch_size = 256
@@ -198,23 +199,23 @@ class IPEXJITInference_gt_1_10:
         model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
         # test dataloader contains x+y
         data_loader = create_data_loader(data_dir, batch_size, num_workers, data_transform)
-        model = InferenceOptimizer.quantize(model,
-                                            precision='int8',
-                                            accelerator=None,
-                                            method='ipex',
-                                            calib_data=data_loader)
+        inc_model = InferenceOptimizer.quantize(model,
+                                                precision='int8',
+                                                accelerator=None,
+                                                method='ipex',
+                                                calib_data=data_loader)
         # test context manager
         with InferenceOptimizer.get_context(model):
-            model(self.data_sample)
+            inc_model(self.data_sample)
 
         # The save/load of ipex_int8 quanzation has konwn bug,
         # will fix it in the future
         # test save & load
-        # with tempfile.TemporaryDirectory() as tmp_dir_name:
-        #     InferenceOptimizer.save(model, tmp_dir_name)
-        #     new_model = InferenceOptimizer.load(tmp_dir_name)
-        # with InferenceOptimizer.get_context(new_model):
-        #     new_model(self.data_sample)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(inc_model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
+        with InferenceOptimizer.get_context(new_model):
+            new_model(self.data_sample)
 
         # test dataloader only contains x
         from torchvision.models import resnet18

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -209,11 +209,14 @@ class IPEXJITInference_gt_1_10:
             inc_model(self.data_sample)
 
         # test save & load
-        with tempfile.TemporaryDirectory() as tmp_dir_name:
-            InferenceOptimizer.save(inc_model, tmp_dir_name)
-            new_model = InferenceOptimizer.load(tmp_dir_name, model)
-        with InferenceOptimizer.get_context(new_model):
-            new_model(self.data_sample)
+        import operator
+        if compare_version("neural_compressor", operator.ge, "2.0"):
+            with tempfile.TemporaryDirectory() as tmp_dir_name:
+                InferenceOptimizer.save(inc_model, tmp_dir_name)
+                new_model = InferenceOptimizer.load(tmp_dir_name, model,
+                                                    input_sample=next(iter(data_loader))[0])
+            with InferenceOptimizer.get_context(new_model):
+                new_model(self.data_sample)
 
         # test dataloader only contains x
         from torchvision.models import resnet18


### PR DESCRIPTION
## Description

INC ipex quantization has a known bug for save & load, that is it don't save related .pt model file.
In INC2.0, this problem has beed fixed, so in Nano, we should also update code to support save & load for INC ipex quantization (version >= 2.0).

### 1. Why the change?

support save & load for INC ipex quantization(version >= 2.0).

### 2. User API changes

New paramter `input_sample` in InferenceOpitmizer.load, which only works for INC ipex quantization.
```python
inc_model = InferenceOptimizer.quantize(model,
                                        precision='int8',
                                        accelerator=None,
                                        method='ipex',
                                        calib_data=data_loader)
with InferenceOptimizer.get_context(inc_model):
    inc_model(self.data_sample)

InferenceOptimizer.save(inc_model,dir_name)
new_model = InferenceOptimizer.load(tmp_dir_name, model,
                                    input_sample=next(iter(data_loader))[0])
with InferenceOptimizer.get_context(new_model):
    new_model(data_sample)
```

### 3. Summary of the change 

- support save & load for INC ipex quantization(version >= 2.0)
- related ut

### 4. How to test?
- [x] Unit test
