### PR TITLE
Nano: Use subprocess to calculate throughput for original model to achieve thread control

### DIFF
--- a/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     thread_num = sys.argv[2]
     if thread_num != 'None':
         thread_num = int(thread_num)  # type: ignore
-        tf.config.threading.set_inter_op_parallelism_threads(1)
+        tf.config.threading.set_inter_op_parallelism_threads(0)
         tf.config.threading.set_intra_op_parallelism_threads(thread_num)
     params = pickle.load(open(param_file, "rb"))
     latency = throughput_calculate_helper(**params)

--- a/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
@@ -40,7 +40,12 @@ def throughput_calculate_helper(iterrun, func, model, input_sample):
 
 
 if __name__ == "__main__":
-    my_input = sys.argv[1:]
-    params = pickle.load(open(my_input[0], "rb"))
+    param_file = sys.argv[1]
+    thread_num = sys.argv[2]
+    if thread_num != 'None':
+        thread_num = int(thread_num)
+        tf.config.threading.set_inter_op_parallelism_threads(1)
+        tf.config.threading.set_intra_op_parallelism_threads(thread_num)
+    params = pickle.load(open(param_file, "rb"))
     latency = throughput_calculate_helper(**params)
     print(latency)

--- a/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
@@ -1,0 +1,29 @@
+import time
+import sys
+import numpy as np
+import pickle
+import tensorflow as tf
+tf.config.threading.set_inter_op_parallelism_threads(1)
+tf.config.threading.set_intra_op_parallelism_threads(1)
+
+def throughput_calculate_helper(iterrun, func, model, input_sample):
+    '''
+    A simple helper to calculate average latency
+    '''
+    time_list = []
+    for i in range(iterrun):
+        st = time.perf_counter()
+        func(model, input_sample)
+        end = time.perf_counter()
+        time_list.append(end - st)
+    time_list.sort()
+    # remove top and least 10% data
+    time_list = time_list[int(0.1 * iterrun): int(0.9 * iterrun)]
+    return np.mean(time_list) * 1000
+
+
+if __name__ == "__main__":
+    my_input = sys.argv[1:]
+    params = pickle.load(open(my_input[0], "rb"))
+    latency = throughput_calculate_helper(**params)
+    print(latency)

--- a/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
@@ -19,8 +19,6 @@ import sys
 import numpy as np
 import pickle
 import tensorflow as tf
-tf.config.threading.set_inter_op_parallelism_threads(1)
-tf.config.threading.set_intra_op_parallelism_threads(1)
 
 
 def throughput_calculate_helper(iterrun, func, model, input_sample):

--- a/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
@@ -1,3 +1,19 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import time
 import sys
 import numpy as np

--- a/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
@@ -43,7 +43,7 @@ if __name__ == "__main__":
     param_file = sys.argv[1]
     thread_num = sys.argv[2]
     if thread_num != 'None':
-        thread_num = int(thread_num)
+        thread_num = int(thread_num)  # type: ignore
         tf.config.threading.set_inter_op_parallelism_threads(1)
         tf.config.threading.set_intra_op_parallelism_threads(thread_num)
     params = pickle.load(open(param_file, "rb"))

--- a/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
@@ -22,6 +22,7 @@ import tensorflow as tf
 tf.config.threading.set_inter_op_parallelism_threads(1)
 tf.config.threading.set_intra_op_parallelism_threads(1)
 
+
 def throughput_calculate_helper(iterrun, func, model, input_sample):
     '''
     A simple helper to calculate average latency

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -259,7 +259,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                 my_env = None
                             worker_file = os.path.join(os.path.split(os.path.realpath(__file__))[0],
                                                        "_worker.py")
-                            result = subprocess.run(["python", worker_file, _filename, str(thread_num)],
+                            result = subprocess.run(["python", worker_file,
+                                                     _filename, str(thread_num)],  # two params
                                                     capture_output=True,
                                                     universal_newlines=True,
                                                     env=my_env)

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -259,7 +259,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                 my_env = None
                             worker_file = os.path.join(os.path.split(os.path.realpath(__file__))[0],
                                                        "_worker.py")
-                            result = subprocess.run(["python", worker_file, _filename],
+                            result = subprocess.run(["python", worker_file, _filename, str(thread_num)],
                                                     capture_output=True,
                                                     universal_newlines=True,
                                                     env=my_env)

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -181,7 +181,6 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         if os.getenv('OMP_NUM_THREADS') is not None:
             default_threads: int = int(os.getenv('OMP_NUM_THREADS'))  # type: ignore
         else:
-            # TODO: how to get and control thread num in tf?
             default_threads = None  # type: ignore
         thread_num = default_threads if thread_num is None else int(thread_num)  # type: ignore
 

--- a/python/nano/test/tf/inference/test_inf_optimizer.py
+++ b/python/nano/test/tf/inference/test_inf_optimizer.py
@@ -36,6 +36,7 @@ class TestInferencePipeline(TestCase):
                      latency_sample_num=10,
                      thread_num=8)
         model = opt.get_best_model()
+        assert isinstance(opt.optimized_model_dict["original"]["latency"], float)
 
     def test_optimize_model_without_accuracy(self):
         model = MobileNetV2(weights=None, input_shape=[40, 40, 3], classes=10)


### PR DESCRIPTION
## Description

Keras use `tf.config.threading.set_inter_op_parallelism_threads()` and `tf.config.threading.set_intra_op_parallelism_threads()` to achieve thread control, however, these two functions can only be called at the beginning of program running. so now in keras `InferenceOptimizer`'s `optimize`, we can't dynamically change the thread number of inference for model without accelerator.
To solve this problem, this PR uses subprocess to start a new subprocess for throughput calculation of original model. In this way, we can spawn a new subprocess which has specified `OMP_NUM_THREADS=thread_num` and setting `inter_op_parallelism_threads=1` and `intra_op_parallelism_threads=thread_num`.

For example, if we set `thread_num=4` when `optimize`, the CPU usage for original model when calculating throughput looks like:
![image](https://user-images.githubusercontent.com/105281011/212583372-0b414a08-9b84-4143-8a83-7248cbb51e90.png)
which is inaccurate and obviously occupy more threads.
After this PR, the CPU usage looks like:
![image](https://user-images.githubusercontent.com/105281011/212583530-fbf76b30-93e2-45b6-8ef4-f137c2c4e994.png)

### 1. Why the change?

Use subprocess to calculate throughput for original model to achieve thread control.

### 2. User API changes

No change, just internal update for `InferenceOptimizer`'s `optimize`.

### 3. Summary of the change

- Use subprocess to calculate throughput for original model to achieve thread control
- update related ut for this case

### 4. How to test?
- [x] Unit test
