### PR TITLE
Orca: fix the bug of unnecessary `import pyarrow` in orca/data/image

### DIFF
--- a/python/orca/src/bigdl/orca/data/image/parquet_dataset.py
+++ b/python/orca/src/bigdl/orca/data/image/parquet_dataset.py
@@ -28,7 +28,6 @@ from bigdl.dllib.utils.common import get_node_and_core_number
 import os
 import numpy as np
 import random
-import pyarrow.parquet as pq
 import io
 import math
 from bigdl.dllib.utils.log4Error import invalidInputError
@@ -173,6 +172,7 @@ class ParquetIterable:
         self.cur_tail = len(self.datapiece)
 
     def _load_data(self, schema):
+        import pyarrow.parquet as pq
         if self.num_shards is None or self.rank is None:
             filter_row_group_indexed = [
                 index for index in list(range(len(self.row_group)))]

--- a/python/orca/src/bigdl/orca/data/image/utils.py
+++ b/python/orca/src/bigdl/orca/data/image/utils.py
@@ -19,7 +19,6 @@ import os
 from collections import namedtuple
 from io import BytesIO
 import numpy as np
-import pyarrow as pa
 from itertools import chain, islice
 
 from enum import Enum
@@ -168,6 +167,7 @@ def chunks(iterable: List[Dict[str, Union[str, int, float, "ndarray"]]],
 
 
 def pa_fs(path):
+    import pyarrow as pa
     if path.startswith("hdfs"):  # hdfs://url:port/file_path
         fs = pa.hdfs.connect()
         path = path[len("hdfs://"):]


### PR DESCRIPTION
When importing orca `tensorboard callback` locally, the error shows that it needs `import pyarrow`. 
The line `import pyarrow as pa` is moved into specific functions below to avoid unnecessary importing.