### PR TITLE
Chronos: support new context manager without overhead

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -90,8 +90,8 @@ class BasePytorchForecaster(Forecaster):
 
             self.accelerated_model = None  # accelerated model obtained from various accelerators
             self.accelerate_method = None  # str indicates current accelerate method
-            self.cxt_manager = DummyForecasterContextManager()
-            self.context_enabled = False
+        self.cxt_manager = DummyForecasterContextManager()
+        self.context_enabled = False
 
     def _build_automodel(self, data, validation_data=None, batch_size=32, epochs=1):
         """Build a Generic Model using config parameters."""
@@ -966,7 +966,7 @@ class BasePytorchForecaster(Forecaster):
 
         self.thread_num = set_pytorch_thread(self.optimized_model_thread_num, self.thread_num)
         if not self.context_enabled:
-            self.cxt_manager = ForecasterContextManager(self, self.thread_num, acceleration)
+            self.cxt_manager = ForecasterContextManager(self, self.thread_num)
 
         if isinstance(data, TSDataset):
             _rolled = data.numpy_x is None

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -90,8 +90,8 @@ class BasePytorchForecaster(Forecaster):
 
             self.accelerated_model = None  # accelerated model obtained from various accelerators
             self.accelerate_method = None  # str indicates current accelerate method
-        self.cxt_manager = DummyForecasterContextManager()
-        self.context_enabled = False
+            self.cxt_manager = DummyForecasterContextManager()
+            self.context_enabled = False
 
     def _build_automodel(self, data, validation_data=None, batch_size=32, epochs=1):
         """Build a Generic Model using config parameters."""
@@ -705,9 +705,6 @@ class BasePytorchForecaster(Forecaster):
         if quantize or acceleration:
             self.thread_num = set_pytorch_thread(self.optimized_model_thread_num, self.thread_num)
 
-        if not self.context_enabled:
-            self.cxt_manager = ForecasterContextManager(self, self.thread_num, acceleration)
-
         if isinstance(data, TSDataset):
             _rolled = data.numpy_x is None
             data = data.to_torch_data_loader(batch_size=batch_size,
@@ -743,6 +740,8 @@ class BasePytorchForecaster(Forecaster):
             if not self.fitted:
                 invalidInputError(False,
                                   "You must call fit or restore first before calling predict!")
+            if not self.context_enabled:
+                self.cxt_manager = ForecasterContextManager(self, self.thread_num, acceleration)
             with self.cxt_manager:
                 if quantize:
                     if self.accelerate_method != "pytorch_int8":
@@ -966,7 +965,7 @@ class BasePytorchForecaster(Forecaster):
 
         self.thread_num = set_pytorch_thread(self.optimized_model_thread_num, self.thread_num)
         if not self.context_enabled:
-            self.cxt_manager = ForecasterContextManager(self, self.thread_num)
+            self.cxt_manager = ForecasterContextManager(self, self.thread_num, True)
 
         if isinstance(data, TSDataset):
             _rolled = data.numpy_x is None

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -32,8 +32,8 @@ from torch.utils.data import TensorDataset, DataLoader
 from .utils_hpo import GenericLightningModule, _format_metric_str, _config_has_search_space
 from bigdl.nano.utils.log4Error import invalidOperationError, invalidInputError
 from bigdl.chronos.data.tsdataset import TSDataset
-from bigdl.chronos.pytorch.context_manager import DummyForecasterContextManager, \
-                                                  ForecasterContextManager
+from bigdl.chronos.pytorch.context_manager import DummyForecasterContextManager,\
+    ForecasterContextManager
 
 
 class BasePytorchForecaster(Forecaster):
@@ -746,22 +746,22 @@ class BasePytorchForecaster(Forecaster):
                 if quantize:
                     if self.accelerate_method != "pytorch_int8":
                         invalidInputError(False,
-                                        "Can't find the quantized model, "
-                                        "please call .quantize() method first")
+                                          "Can't find the quantized model, "
+                                          "please call .quantize() method first")
                     yhat = _pytorch_fashion_inference(model=self.accelerated_model,
-                                                    input_data=data,
-                                                    batch_size=batch_size)
+                                                      input_data=data,
+                                                      batch_size=batch_size)
                 else:
                     if acceleration is False or self.accelerated_model is None:
                         self.internal.eval()
                         yhat = _pytorch_fashion_inference(model=self.internal,
-                                                        input_data=data,
-                                                        batch_size=batch_size)
+                                                          input_data=data,
+                                                          batch_size=batch_size)
                     else:
                         self.accelerated_model.eval()
                         yhat = _pytorch_fashion_inference(model=self.accelerated_model,
-                                                        input_data=data,
-                                                        batch_size=batch_size)
+                                                          input_data=data,
+                                                          batch_size=batch_size)
             if not is_local_data:
                 yhat = np_to_xshard(yhat, self.workers_per_node, prefix="prediction")
             return yhat
@@ -981,19 +981,19 @@ class BasePytorchForecaster(Forecaster):
             if quantize and False:
                 if self.accelerate_method != "jit_int8":
                     invalidInputError(False,
-                                    "Can't find the quantized model, "
-                                    "please call .quantize() method first")
+                                      "Can't find the quantized model, "
+                                      "please call .quantize() method first")
                 return _pytorch_fashion_inference(model=self.accelerated_model,
-                                                input_data=data,
-                                                batch_size=batch_size)
+                                                  input_data=data,
+                                                  batch_size=batch_size)
             else:
                 if self.accelerate_method != "jit_fp32":
                     self.build_jit()
                     self.thread_num = set_pytorch_thread(self.optimized_model_thread_num,
-                                                        self.thread_num)
+                                                         self.thread_num)
                 return _pytorch_fashion_inference(model=self.accelerated_model,
-                                                input_data=data,
-                                                batch_size=batch_size)
+                                                  input_data=data,
+                                                  batch_size=batch_size)
 
     def evaluate(self, data, batch_size=32, multioutput="raw_values", quantize=False,
                  acceleration: bool = True):

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -833,8 +833,8 @@ class BasePytorchForecaster(Forecaster):
             if quantize:
                 if self.accelerate_method != "onnxruntime_int8":
                     invalidInputError(False,
-                                     "Can't find the quantized model, "
-                                     "please call .quantize() method first")
+                                      "Can't find the quantized model, "
+                                      "please call .quantize() method first")
                 return _pytorch_fashion_inference(model=self.accelerated_model,
                                                   input_data=data,
                                                   batch_size=batch_size)

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -826,7 +826,7 @@ class BasePytorchForecaster(Forecaster):
                                              target_col=data.roll_target,
                                              shuffle=False)
         if not self.context_enabled:
-            self.cxt_manager = ForecasterContextManager(self, self.thread_num, acceleration)
+            self.cxt_manager = ForecasterContextManager(self, self.thread_num, True)
         else:
             self.cxt_manager = DummyForecasterContextManager()
         with self.cxt_manager:
@@ -907,7 +907,7 @@ class BasePytorchForecaster(Forecaster):
                                              shuffle=False)
 
         if not self.context_enabled:
-            self.cxt_manager = ForecasterContextManager(self, self.thread_num, acceleration)
+            self.cxt_manager = ForecasterContextManager(self, self.thread_num, True)
         else:
             self.cxt_manager = DummyForecasterContextManager()
         with self.cxt_manager:
@@ -988,7 +988,7 @@ class BasePytorchForecaster(Forecaster):
                                              shuffle=False)
 
         if not self.context_enabled:
-            self.cxt_manager = ForecasterContextManager(self, self.thread_num, acceleration)
+            self.cxt_manager = ForecasterContextManager(self, self.thread_num, True)
         else:
             self.cxt_manager = DummyForecasterContextManager()
         with self.cxt_manager:

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1472,6 +1472,8 @@ class BasePytorchForecaster(Forecaster):
         self.accelerated_model = None
         # str indicates current accelerate method
         self.accelerate_method = None
+        self.cxt_manager = DummyForecasterContextManager()
+        self.context_enabled = False
         return self
 
     def get_model(self):

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -91,6 +91,7 @@ class BasePytorchForecaster(Forecaster):
             self.accelerated_model = None  # accelerated model obtained from various accelerators
             self.accelerate_method = None  # str indicates current accelerate method
             self.cxt_manager = DummyForecasterContextManager()
+            self.context_enabled = False
 
     def _build_automodel(self, data, validation_data=None, batch_size=32, epochs=1):
         """Build a Generic Model using config parameters."""

--- a/python/chronos/src/bigdl/chronos/pytorch/context_manager.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/context_manager.py
@@ -1,0 +1,65 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+from bigdl.chronos.forecaster.utils import set_pytorch_thread
+
+
+class DummyForecasterContextManager(object):
+    """
+    This context manager is used when users have enbaled `ForecasterContextManager`
+    during inference
+    """
+    def __init__(self):
+        pass
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        pass
+
+
+class ForecasterContextManager(object):
+    """
+    This context manager is used for Pytorch Model Inference.
+
+    Provide thread control and autocast context which is for bf16 model.
+    """
+    def __init__(self, forecaster, thread_num, optimize):
+        self.forecaster = forecaster
+        if thread_num:
+            self.thread_num = thread_num
+        elif optimize and self.forecaster.optimized_model_thread_num:
+            self.thread_num = self.forecaster.optimized_model_thread_num
+        else:
+            self.thread_num = None
+        self.bf16_enable = 'bf16' in self.forecaster.accelerate_method
+        if optimize and self.bf16_enable:
+            self.autocast = torch.cpu.amp.autocast(enabled=True, dtype=torch.bfloat16)
+
+    def __enter__(self):
+        # call `torch.set_num_threads` at most once
+        self.forecaster.thread_num = set_pytorch_thread(self.thread_num,
+                                                        self.forecaster.thread_num)
+        self.forecaster.context_enabled = True
+        if self.bf16_enable:
+            self.autocast.__enter__()
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        self.forecaster.context_enabled = False
+        if self.bf16_enable:
+            self.autocast.__exit__(exc_type, exc_value, exc_tb)

--- a/python/chronos/src/bigdl/chronos/pytorch/context_manager.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/context_manager.py
@@ -48,7 +48,7 @@ class ForecasterContextManager(object):
         else:
             self.thread_num = None
         self.bf16_enable = self.forecaster.accelerate_method is not None and \
-                           'bf16' in self.forecaster.accelerate_method
+            'bf16' in self.forecaster.accelerate_method
         if optimize and self.bf16_enable:
             self.autocast = torch.cpu.amp.autocast(enabled=True, dtype=torch.bfloat16)
 

--- a/python/chronos/src/bigdl/chronos/pytorch/context_manager.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/context_manager.py
@@ -47,7 +47,8 @@ class ForecasterContextManager(object):
             self.thread_num = self.forecaster.optimized_model_thread_num
         else:
             self.thread_num = None
-        self.bf16_enable = 'bf16' in self.forecaster.accelerate_method
+        self.bf16_enable = self.forecaster.accelerate_method is not None and \
+                           'bf16' in self.forecaster.accelerate_method
         if optimize and self.bf16_enable:
             self.autocast = torch.cpu.amp.autocast(enabled=True, dtype=torch.bfloat16)
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -842,3 +842,22 @@ class TestChronosModelLSTMForecaster(TestCase):
         assert new_current_thread == current_thread
         assert forecaster.thread_num == current_thread
         assert forecaster.optimized_model_thread_num == num
+
+    def test_lstm_forecaster_ctx_manager(self):
+        train_loader, val_loader, test_loader = create_data(loader=True)
+        forecaster = LSTMForecaster(past_seq_len=24,
+                                    input_feature_num=2,
+                                    output_feature_num=2,
+                                    loss="mse",
+                                    lr=0.01)
+        forecaster.fit(train_loader, epochs=1)
+        original_thread = torch.get_num_threads()
+        assert forecaster.thread_num == original_thread
+
+        num = max(1, original_thread//2)
+        with forecaster.get_context(thread_num=num, optimize=True):
+            assert forecaster.context_enabled == True
+            current_thread = torch.get_num_threads()
+            assert current_thread == num
+            for x, y in test_loader:
+                yhat = forecaster.predict(x.numpy())

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -770,3 +770,21 @@ class TestChronosNBeatsForecaster(TestCase):
         assert new_current_thread == current_thread
         assert forecaster.thread_num == current_thread
         assert forecaster.optimized_model_thread_num == num
+
+    def test_nbeats_forecaster_ctx_manager(self):
+        train_loader, val_loader, test_loader = create_data(loader=True)
+        forecaster = NBeatsForecaster(past_seq_len=24,
+                                      future_seq_len=5,
+                                      loss='mse',
+                                      lr=0.01)
+        forecaster.fit(train_loader, epochs=1)
+        original_thread = torch.get_num_threads()
+        assert forecaster.thread_num == original_thread
+
+        num = max(1, original_thread//2)
+        with forecaster.get_context(thread_num=num, optimize=True):
+            assert forecaster.context_enabled == True
+            current_thread = torch.get_num_threads()
+            assert current_thread == num
+            for x, y in test_loader:
+                yhat = forecaster.predict(x.numpy())

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -726,3 +726,23 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         assert new_current_thread == current_thread
         assert forecaster.thread_num == current_thread
         assert forecaster.optimized_model_thread_num == num
+
+    def test_s2s_forecaster_ctx_manager(self):
+        train_loader, val_loader, test_loader = create_data(loader=True)
+        forecaster = Seq2SeqForecaster(past_seq_len=24,
+                                       future_seq_len=5,
+                                       input_feature_num=1,
+                                       output_feature_num=1,
+                                       loss="mse",
+                                       lr=0.01)
+        forecaster.fit(train_loader, epochs=1)
+        original_thread = torch.get_num_threads()
+        assert forecaster.thread_num == original_thread
+
+        num = max(1, original_thread//2)
+        with forecaster.get_context(thread_num=num, optimize=True):
+            assert forecaster.context_enabled == True
+            current_thread = torch.get_num_threads()
+            assert current_thread == num
+            for x, y in test_loader:
+                yhat = forecaster.predict(x.numpy())

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -1480,3 +1480,24 @@ class TestChronosModelTCNForecaster(TestCase):
         assert new_current_thread == current_thread
         assert forecaster.thread_num == current_thread
         assert forecaster.optimized_model_thread_num == num
+
+    def test_tcn_forecaster_ctx_manager(self):
+        train_loader, val_loader, test_loader = create_data(loader=True)
+        forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=1,
+                                   output_feature_num=1,
+                                   kernel_size=4,
+                                   num_channels=[16, 16],
+                                   lr=0.01)
+        forecaster.fit(train_loader, epochs=1)
+        original_thread = torch.get_num_threads()
+        assert forecaster.thread_num == original_thread
+
+        num = max(1, original_thread//2)
+        with forecaster.get_context(thread_num=num, optimize=True):
+            assert forecaster.context_enabled == True
+            current_thread = torch.get_num_threads()
+            assert current_thread == num
+            for x, y in test_loader:
+                yhat = forecaster.predict(x.numpy())


### PR DESCRIPTION
## Description

In https://github.com/intel-analytics/BigDL/pull/7193, we temporarily workaround by not using nano context manger to avoid overhead. However, to implement autocast of bf16, we need to support a new context manager more friendly without overhead.

**Notice: If we directly call nano context manager inside predict, this make the context manager inside the inference loop and call `torch.set_num_thread` once and once again cause some overhead.**

After some discussions, we decide to support new context manager for Chronos.

### 2. User API changes

Provide a new `get_context` method for forecasters to implement thread control and autocast
```python
with forecaster.get_context(thread_num=xxx, optimize=True):
    for _ in range(n):
        forecaster.predict(data)
```
It's recommend to use above context manager in inference loop.

But, if users don't use context manager, the following loop still works. (For bf16 and small batch-size cases, throughput is smaller; first call is much slower)
```python
for _ in range(n):
    forecaster.predict(data)
```

### 3. Summary of the change 

- Provide two context manager, `DummyForecasterContextManager` and `ForecasterContextManager`
- `get_context` method
- In `predict`  `predixt_with_onnx`  `predixt_with_openvino` `predixt_with_jit`, we will generate `ForecasterContextManager` if users don't use context manager; otherwise, just use `DummyForecasterContextManager`


### 4. How to test?
- [ ] Unit test
- [ ] Local test (whether cause overhead)

