### PR TITLE
Chronos: fix error during nightly-build tests

### DIFF
--- a/python/chronos/src/setup.py
+++ b/python/chronos/src/setup.py
@@ -31,8 +31,8 @@ See [here](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.h
 bigdl_home = os.path.abspath(__file__ + "/../../../..")
 exclude_patterns = ["*__pycache__*", "*ipynb_checkpoints*"]
 
-VERSION = open(os.path.join(bigdl_home, 'python/version.txt'), 'r').read().strip()
-
+# VERSION = open(os.path.join(bigdl_home, 'python/version.txt'), 'r').read().strip()
+VERSION = '2.2.0b20230115'
 
 def get_bigdl_packages():
     bigdl_python_home = os.path.abspath(__file__ + "/..")
@@ -66,7 +66,8 @@ def setup_package():
         extras_require={'pytorch': ['bigdl-nano[pytorch]==' + VERSION],
                         'tensorflow': ['bigdl-nano[tensorflow_27]=='+VERSION],
                         'automl': ['optuna<=2.10.1', 'configspace<=0.5.0', 'SQLAlchemy<=1.4.27'],
-                        'distributed:platform_system!="Windows"': ['bigdl-orca[automl]=='+VERSION],
+                        'distributed:platform_system!="Windows"': ['bigdl-orca[automl]=='+VERSION,
+                                                                   'pyarrow==6.0.1'],
                         'inference': ['bigdl-nano[inference]==' + VERSION],
                         'all': ['bigdl-nano[pytorch]==' + VERSION,
                                 'bigdl-nano[tensorflow_27]=='+VERSION,

--- a/python/chronos/src/setup.py
+++ b/python/chronos/src/setup.py
@@ -33,6 +33,7 @@ exclude_patterns = ["*__pycache__*", "*ipynb_checkpoints*"]
 
 VERSION = open(os.path.join(bigdl_home, 'python/version.txt'), 'r').read().strip()
 
+
 def get_bigdl_packages():
     bigdl_python_home = os.path.abspath(__file__ + "/..")
     bigdl_packages = []

--- a/python/chronos/src/setup.py
+++ b/python/chronos/src/setup.py
@@ -31,8 +31,7 @@ See [here](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.h
 bigdl_home = os.path.abspath(__file__ + "/../../../..")
 exclude_patterns = ["*__pycache__*", "*ipynb_checkpoints*"]
 
-# VERSION = open(os.path.join(bigdl_home, 'python/version.txt'), 'r').read().strip()
-VERSION = '2.2.0b20230115'
+VERSION = open(os.path.join(bigdl_home, 'python/version.txt'), 'r').read().strip()
 
 def get_bigdl_packages():
     bigdl_python_home = os.path.abspath(__file__ + "/..")


### PR DESCRIPTION
## Description

During chronos-2.2.0b20230113 nightly-build tests, ModuleNotFoundError appears, https://github.com/intel-analytics/BigDL/actions/runs/3912669222/jobs/6687604266#step:6:164.
In this PR, fix this error.

### 4. How to test?
- [x] Unit test
- [x] Local test
(build wheel packages, run `pip install ./bigdl_chronos-2.2.0b20230115-py3-none-any.whl[automl,distributed,inference,pytorch]` and failed uts pass)
