### PR TITLE
Orca: Refactor use_tqdm with TqdmCallback

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tensorboard.py
@@ -77,7 +77,7 @@ class TensorBoardCallback(Callback):
         """
         if self.freq == "epoch" and self._is_rank_zero(runner):
             writer = SummaryWriter(log_dir=self.tmp_dir, **self.kwargs)
-            for name, value in runner.epochs_stats.items():
+            for name, value in runner.epoch_stats.items():
                 if name not in self.unlog_items:
                     writer.add_scalar(name, value, runner.epochs)
             writer.close()

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tqdm.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tqdm.py
@@ -1,0 +1,59 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+import shutil
+import tempfile
+
+from bigdl.orca.learn.pytorch.callbacks import Callback
+from bigdl.dllib.utils.log4Error import invalidInputError
+
+tqdm = None
+try:
+    from tqdm import tqdm
+except ImportError:
+    pass
+
+
+class TqdmCallback(Callback):
+
+    def __init__(self):
+        self._progress_bar = None
+        super().__init__()
+
+    def after_train_iter(self, runner):
+        if self._is_rank_zero(runner):
+            runner._progress_bar.n = runner.batch_idx
+            postfix = {}
+            if "train_loss" in runner.metrics_stats:
+                postfix.update(loss=runner.metrics_stats["train_loss"])
+            runner._progress_bar.set_postfix(postfix)
+
+    def before_train_epoch(self, runner):
+        if self._is_rank_zero(runner):
+            desc = "{}/{}e".format(runner.epochs + 1,
+                                   runner.num_epochs)
+
+            invalidInputError(tqdm is not None,
+                              "tqdm is not installed, please install with 'pip install tqdm'")
+            runner._progress_bar = tqdm(total=len(runner.train_loader),
+                                        desc=desc,
+                                        unit="batch",
+                                        leave=False)
+
+    def _is_rank_zero(self, runner):
+        invalidInputError(runner, "Sanity check failed. Runner must not be None!")
+        rank = runner.rank
+        return rank == 0

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/wandb.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/wandb.py
@@ -71,7 +71,7 @@ class WandbLoggerCallback(Callback):
             epoch, the values of the Model's metrics are returned.
             Example : {'loss': 0.2, 'accuracy': 0.7}
         """
-        self.run.log(runner.epochs_stats)
+        self.run.log(runner.epoch_stats)
 
     def before_run(self, runner):
         """

--- a/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
@@ -109,7 +109,6 @@ class Estimator(object):
                                          loss=loss,
                                          optimizer=optimizer,
                                          config=config,
-                                         use_tqdm=use_tqdm,
                                          metrics=metrics,
                                          model_dir=model_dir,
                                          bigdl_type="float")

--- a/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
@@ -109,6 +109,7 @@ class Estimator(object):
                                          loss=loss,
                                          optimizer=optimizer,
                                          config=config,
+                                         use_tqdm=use_tqdm,
                                          metrics=metrics,
                                          model_dir=model_dir,
                                          bigdl_type="float")

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -164,7 +164,6 @@ class PyTorchPySparkEstimator(BaseEstimator):
             optimizer_creator=optimizer_creator,
             loss_creator=loss_creator,
             scheduler_creator=scheduler_creator,
-            use_tqdm=use_tqdm,
             config=copy.copy(self.config),
             metrics=metrics,
             size=self.num_workers,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -37,6 +37,7 @@ from bigdl.orca.data.file import get_remote_file_to_local, put_local_file_to_rem
 from bigdl.dllib.utils.common import get_node_and_core_number
 from bigdl.orca.learn.log_monitor import start_log_server, stop_log_server
 from bigdl.orca.learn.pytorch.callbacks.maincallback import make_only_mainCallback
+from bigdl.orca.learn.pytorch.callbacks.tqdm import TqdmCallback
 from bigdl.orca.learn.utils import find_free_port, find_ip_and_free_port
 from bigdl.dllib.utils.utils import get_node_ip
 from bigdl.dllib.utils.log4Error import invalidInputError
@@ -136,6 +137,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
                               "Must provide a function for model_creator")
 
         self.model_dir = parse_model_dir(model_dir)
+        self.use_tqdm = use_tqdm
 
         self.model_creator = model_creator
         self.optimizer_creator = optimizer_creator
@@ -289,9 +291,10 @@ class PyTorchPySparkEstimator(BaseEstimator):
         init_params.update(self.worker_init_params)
 
         # Check uniqueness of the MainCallback
-        if not callbacks:
-            callbacks = []
+        callbacks = callbacks or []
         make_only_mainCallback(callbacks)
+        if self.use_tqdm:
+            callbacks.append(TqdmCallback())
 
         params = dict(
             epochs=epochs,
@@ -544,9 +547,10 @@ class PyTorchPySparkEstimator(BaseEstimator):
         init_params.update(self.worker_init_params)
 
         # Check uniqueness of the MainCallback
-        if not callbacks:
-            callbacks = []
+        callbacks = callbacks or []
         make_only_mainCallback(callbacks)
+        if self.use_tqdm:
+            callbacks.append(TqdmCallback())
 
         params = dict(
             batch_size=batch_size,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -61,7 +61,6 @@ class PytorchPysparkWorker(TorchRunner):
                  metrics=None,
                  scheduler_creator=None,
                  config=None,
-                 use_tqdm=False,
                  state_dict=None,
                  backend="torch-distributed",
                  mode="fit",
@@ -79,7 +78,6 @@ class PytorchPysparkWorker(TorchRunner):
                          metrics=metrics,
                          scheduler_creator=scheduler_creator,
                          config=config,
-                         use_tqdm=use_tqdm,
                          sync_stats=sync_stats,
                          log_level=log_level)
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -126,7 +126,6 @@ class PyTorchRayEstimator(BaseRayEstimator):
             optimizer_creator=self.optimizer_creator,
             loss_creator=self.loss_creator,
             scheduler_creator=self.scheduler_creator,
-            use_tqdm=self.use_tqdm,
             config=worker_config,
             metrics=metrics,
             sync_stats=sync_stats,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -28,6 +28,7 @@ from bigdl.orca.ray import OrcaRayContext
 from bigdl.orca.learn.pytorch.core.base_ray_estimator import BaseRayEstimator
 from bigdl.orca.learn.pytorch.utils import process_stats, check_for_failure
 from bigdl.orca.learn.pytorch.callbacks.maincallback import make_only_mainCallback
+from bigdl.orca.learn.pytorch.callbacks.tqdm import TqdmCallback
 
 import ray
 from bigdl.dllib.utils.log4Error import invalidInputError
@@ -113,8 +114,8 @@ class PyTorchRayEstimator(BaseRayEstimator):
         self.optimizer_creator = optimizer_creator
         self.loss_creator = loss_creator
         self.scheduler_creator = scheduler_creator
-        self.use_tqdm = use_tqdm
         self.sync_stats = sync_stats
+        self.use_tqdm = use_tqdm
         self.backend = backend
         self.workers_per_node = workers_per_node
 
@@ -194,9 +195,10 @@ class PyTorchRayEstimator(BaseRayEstimator):
             batch_size = 1
 
         # Check uniqueness of the MainCallback
-        if not callbacks:
-            callbacks = []
+        callbacks = callbacks or []
         make_only_mainCallback(callbacks)
+        if self.use_tqdm:
+            callbacks.append(TqdmCallback())
 
         params = dict(
             epochs=epochs,
@@ -444,9 +446,10 @@ class PyTorchRayEstimator(BaseRayEstimator):
                                              shard_size=batch_size)
 
         # Check uniqueness of the MainCallback
-        if not callbacks:
-            callbacks = []
+        callbacks = callbacks or []
         make_only_mainCallback(callbacks)
+        if self.use_tqdm:
+            callbacks.append(TqdmCallback())
 
         params = dict(batch_size=batch_size,
                       num_steps=num_steps,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
@@ -55,7 +55,6 @@ class PytorchRayWorker(TorchRunner):
                  metrics=None,
                  scheduler_creator=None,
                  config=None,
-                 use_tqdm=False,
                  sync_stats=True,
                  log_level=logging.INFO):
         super().__init__(model_creator=model_creator,
@@ -64,7 +63,6 @@ class PytorchRayWorker(TorchRunner):
                          metrics=metrics,
                          scheduler_creator=scheduler_creator,
                          config=config,
-                         use_tqdm=use_tqdm,
                          sync_stats=sync_stats,
                          log_level=log_level)
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
@@ -55,6 +55,7 @@ class PytorchRayWorker(TorchRunner):
                  metrics=None,
                  scheduler_creator=None,
                  config=None,
+                 use_tqdm=False,
                  sync_stats=True,
                  log_level=logging.INFO):
         super().__init__(model_creator=model_creator,
@@ -63,6 +64,7 @@ class PytorchRayWorker(TorchRunner):
                          metrics=metrics,
                          scheduler_creator=scheduler_creator,
                          config=config,
+                         use_tqdm=use_tqdm,
                          sync_stats=sync_stats,
                          log_level=log_level)
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -56,12 +56,6 @@ try:
 except ImportError:
     from collections import Iterable
 
-tqdm = None
-try:
-    from tqdm import tqdm
-except ImportError:
-    pass
-
 
 class DistBackend:
 
@@ -115,7 +109,6 @@ class TorchRunner(BaseRunner):
                  metrics=None,
                  scheduler_creator=None,
                  config=None,
-                 use_tqdm=False,
                  sync_stats=True,
                  log_level=logging.INFO):
         logging.basicConfig(level=log_level,
@@ -139,9 +132,8 @@ class TorchRunner(BaseRunner):
         self.schedulers = None
         self.train_loader = None
         self.validation_loader = None
-        self.use_tqdm = use_tqdm
         self.sync_stats = sync_stats
-        self.epochs_stats = None  # The state saved in every epoch
+        self.epoch_stats = None  # The state saved in every epoch
         self._mode = 'val'  # By default we don't use ddp model
 
     def _create_loss(self):
@@ -207,18 +199,19 @@ class TorchRunner(BaseRunner):
                      info=None, wrap_dataloader=None, callbacks=None,
                      validation_data_creator=None):
         config = copy.copy(self.config)
+        self.num_epochs = epochs
         if OrcaContext.serialize_data_creator:
             with FileLock(
                     os.path.join(tempfile.gettempdir(), ".orcadata.lock")):
-                loader = data_creator(config, batch_size)
+                self.train_loader = data_creator(config, batch_size)
         else:
-            loader = data_creator(config, batch_size)
+            self.train_loader = data_creator(config, batch_size)
 
         if wrap_dataloader is None:
-            if TorchRunner.should_wrap_dataloader(loader):
-                loader = self.with_sampler(loader)
+            if TorchRunner.should_wrap_dataloader(self.train_loader):
+                self.train_loader = self.with_sampler(self.train_loader)
         elif wrap_dataloader is True:
-            loader = self.with_sampler(loader)
+            self.train_loader = self.with_sampler(self.train_loader)
 
         if validation_data_creator:
             if OrcaContext.serialize_data_creator:
@@ -255,11 +248,14 @@ class TorchRunner(BaseRunner):
 
         stats_list = list()
         for i in range(epochs):
+            del self.epoch_stats
             self.call_hook(callbacks=callbacks, fn_name="before_train_epoch")
-            stats = self.train_epoch(loader, profile=profile, info=info, callbacks=callbacks,
-                                     val_loader=val_loader, val_steps=val_steps)
-            self.epochs_stats = stats
+            stats = self.train_epoch(self.train_loader, profile=profile, info=info,
+                                     callbacks=callbacks, val_loader=val_loader,
+                                     val_steps=val_steps)
+            self.epoch_stats = stats
             self.call_hook(callbacks=callbacks, fn_name="after_train_epoch")
+
             if self.rank == 0:
                 if self.sync_stats:
                     self.logger.info(f"Finished training epoch {i + 1}, " +
@@ -281,9 +277,9 @@ class TorchRunner(BaseRunner):
                     val_loader=None,
                     val_steps=None):
         """Runs a training epoch and updates the model parameters."""
-        if hasattr(self.train_loader, "sampler") and hasattr(
-                self.train_loader.sampler, "set_epoch"):
-            self.train_loader.sampler.set_epoch(self.epochs)
+        if hasattr(data_loader, "sampler") and hasattr(
+                data_loader.sampler, "set_epoch"):
+            data_loader.sampler.set_epoch(self.epochs)
         self.logger.debug("Begin Training Step {}".format(self.epochs + 1))
 
         if not self.criterion:
@@ -299,7 +295,6 @@ class TorchRunner(BaseRunner):
 
         if val_loader:
             with self.timers.record("validation"):
-                info = info or {}
                 validation_results = self._validate(val_loader,
                                                     metrics=self.metrics,
                                                     num_steps=val_steps,
@@ -362,23 +357,6 @@ class TorchRunner(BaseRunner):
             A dict of metrics from training.
         """
         self._mode = 'train'
-        if self.use_tqdm and self.rank == 0:
-            desc = ""
-            if info is not None and "epoch_idx" in info:
-                if "num_epochs" in info:
-                    desc = "{}/{}e".format(info["epoch_idx"] + 1,
-                                           info["num_epochs"])
-                else:
-                    desc = "{}e".format(info["epoch_idx"] + 1)
-            invalidInputError(tqdm is not None,
-                              "tqdm is not installed, please install with 'pip install tqdm'")
-            _progress_bar = tqdm(
-                total=len(iterator),
-                desc=desc,
-                unit="batch",
-                leave=False)
-        else:
-            _progress_bar = None
 
         metric_meters = AverageMeterCollection()
 
@@ -389,27 +367,20 @@ class TorchRunner(BaseRunner):
         from torch.nn.parallel import DistributedDataParallel as DDP
         if isinstance(self.model, DDP):
             with self.model.join():
-                self._train_loop(iterator, _progress_bar, metric_meters, callbacks)
+                self._train_loop(iterator, metric_meters, callbacks)
         else:
-            self._train_loop(iterator, _progress_bar, metric_meters, callbacks)
+            self._train_loop(iterator, metric_meters, callbacks)
 
         self.call_hook(callbacks=callbacks, fn_name="on_lr_adjust")
 
         return metric_meters.summary(sync_stats=self.sync_stats,
                                      dist_backend=self.dist_backend)
 
-    def _train_loop(self, iterator, _progress_bar, metric_meters, callbacks):
+    def _train_loop(self, iterator, metric_meters, callbacks):
         for batch_idx, batch in enumerate(iterator):
             self.batch_idx = batch_idx
 
             self._train_batch(batch, callbacks=callbacks)
-
-            if self.use_tqdm and self.rank == 0:
-                _progress_bar.n = batch_idx + 1
-                postfix = {}
-                if "train_loss" in self.metrics_stats:
-                    postfix.update(loss=self.metrics_stats["train_loss"])
-                _progress_bar.set_postfix(postfix)
 
             metric_meters.update(self.metrics_stats, n=self.metrics_stats.pop(NUM_SAMPLES, 1))
             self.global_step += 1


### PR DESCRIPTION
## Description

We implement TqdmCallback so we can make our torchrunner a clean structure and simplify our estimator interface.
We may provide more features to users with more callbacks like tqdmCallback.

## API Changes
old:
```python
Estimator.from_torch(*, use_tqdm=True,* )
```
new:
```python
Estimator.fit(*, callbacks=[TqdmCallback()],* )
```
## Tasks
- [x] Append TqdmCallback
- [x] Deprecate use_tqdm in torch estimator.
- [x] Rebase Branch