### PR TITLE
Nano: Fix issue for bigdl-nano-init --perf

### DIFF
--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -153,7 +153,7 @@ if [ -f "${LIB_DIR}/libiomp5.so" ]; then
 
         if [[ "${PERF_VAR}" == "1" ]]; then
             # experiment variable to speed up performance.
-            export OPENMP=0
+            export OPENMP=1
             export KMP_AFFINITY=granularity=fine,compact,1,0
         fi
 


### PR DESCRIPTION
## Description

### 1. Why the change?
Currently, there are 2 issues for `source bigdl-nano-init --perf`.
issue 1. if it is called in a clean environment (i.e., no `source bigdl-nano-init` called before), then `LD_PRELOAD` won't have intel-openmp's .so file
issue 2. if it is called in a normal environment (i.e., `source bigdl-nano-init` was called before), then there will be an extra `tcmalloc.so` added to `LD_PRELOAD` (but won't affect the performance)

This fix won't be migrated to branch-2.2 since
issue 1 is not a normal usage to `source bigdl-nano-init --perf`, issue 2 is normal usage while it does not affect the performance.

### 2. User API changes
nothing

### 3. Summary of the change 
Change an internal variable setting.

### 4. How to test?
- [ ] Unit test

