### PR TITLE
Nano: support evaluation related features for INC

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1921,7 +1921,7 @@ class BasePytorchForecaster(Forecaster):
                                               precision='int8',
                                               accelerator=accelerator,
                                               method=method,
-                                              calib_dataloader=calib_data,
+                                              calib_data=calib_data,
                                               metric=metric,
                                               conf=conf,
                                               approach=approach,

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -132,16 +132,18 @@ class TestChronosNBeatsForecaster(TestCase):
         forecaster.fit(train_loader, epochs=2)
 
         forecaster.quantize(calib_data=train_loader,
-                    val_data=val_loader,
-                    metric="mae",
-                    framework='pytorch_fx')
+                            val_data=val_loader,
+                            metric="mae",
+                            framework='pytorch_fx',
+                            relative_drop=0.2)
         q_yhat = forecaster.predict(data=test_loader, quantize=True, acceleration=False)
         yhat = forecaster.predict(data=test_loader, acceleration=False)
         forecaster.evaluate(test_loader, batch_size=32, acceleration=False)
         forecaster.quantize(calib_data=train_loader,
-                    val_data=val_loader,
-                    metric="mae",
-                    framework='onnxrt_qlinearops')
+                            val_data=val_loader,
+                            metric="mae",
+                            framework='onnxrt_qlinearops',
+                            relative_drop=0.2)
         q_onnx_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
         forecaster.evaluate_with_onnx(test_loader, batch_size=32, quantize=True)
         forecaster.evaluate_with_onnx(test_loader)
@@ -238,7 +240,7 @@ class TestChronosNBeatsForecaster(TestCase):
                                       lr=0.01)
         forecaster.fit(train_data, epochs=2)
         # quantization with tunning
-        forecaster.quantize(train_data)
+        forecaster.quantize(train_data, relative_drop=0.2)
         pred_q = forecaster.predict(test_data[0], quantize=True, acceleration=False)
         eval_q = forecaster.evaluate(test_data, quantize=True, acceleration=False)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
@@ -262,8 +264,7 @@ class TestChronosNBeatsForecaster(TestCase):
                                       loss='mae',
                                       lr=0.01)
         forecaster.fit(train_data, epochs=2)
-        # no tunning quantization
-        forecaster.quantize(train_data, framework='onnxrt_qlinearops')
+        forecaster.quantize(train_data, framework='onnxrt_qlinearops', relative_drop=0.2)
         pred_q = forecaster.predict_with_onnx(test_data[0], quantize=True)
         eval_q = forecaster.evaluate_with_onnx(test_data, quantize=True)
 
@@ -278,7 +279,7 @@ class TestChronosNBeatsForecaster(TestCase):
         forecaster.fit(train_data, epochs=2)
         # quantization with tunning
         forecaster.quantize(train_data, val_data=val_data,
-                            metric="mse", relative_drop=0.1, max_trials=3,
+                            metric="mse", relative_drop=0.2, max_trials=3,
                             framework='onnxrt_qlinearops')
         pred_q = forecaster.predict_with_onnx(test_data[0], quantize=True)
         eval_q = forecaster.evaluate_with_onnx(test_data, quantize=True)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -279,7 +279,7 @@ class TestChronosNBeatsForecaster(TestCase):
         forecaster.fit(train_data, epochs=2)
         # quantization with tunning
         forecaster.quantize(train_data, val_data=val_data,
-                            metric="mse", relative_drop=0.2, max_trials=3,
+                            metric="mse", relative_drop=0.5, max_trials=3,
                             framework='onnxrt_qlinearops')
         pred_q = forecaster.predict_with_onnx(test_data[0], quantize=True)
         eval_q = forecaster.evaluate_with_onnx(test_data, quantize=True)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -684,7 +684,7 @@ class TestChronosModelTCNForecaster(TestCase):
         forecaster.internal.eval()
         # quantization with tunning
         forecaster.quantize(train_data, val_data=val_data,
-                            metric="rmse", relative_drop=0.1, max_trials=3)
+                            metric="rmse", relative_drop=0.2, max_trials=3)
         pred_q = forecaster.predict(test_data[0], quantize=True, acceleration=False)
         eval_q = forecaster.evaluate(test_data, quantize=True, acceleration=False)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
@@ -1062,12 +1062,16 @@ class TestChronosModelTCNForecaster(TestCase):
         res = tcn.evaluate(test_loader, acceleration=False)
         tcn.quantize(calib_data=loader,
                      metric='mse',
-                     framework='pytorch_fx')
+                     framework='pytorch_fx',
+                     relative_drop=0.2,
+                     max_trials=3)
         q_yhat = tcn.predict(test, quantize=True, acceleration=False)
         q_res = tcn.evaluate(test_loader, quantize=True, acceleration=False)
         tcn.quantize(calib_data=loader,
                      metric='mse',
-                     framework='onnxrt_qlinearops')
+                     framework='onnxrt_qlinearops',
+                     relative_drop=0.2,
+                     max_trials=3)
         q_onnx_yhat = tcn.predict_with_onnx(test, quantize=True)
         q_onnx_res = tcn.evaluate_with_onnx(test_loader, quantize=True)
         onnx_yhat = tcn.predict_with_onnx(test)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -151,14 +151,18 @@ class TestChronosModelTCNForecaster(TestCase):
         forecaster.quantize(calib_data=train_loader,
                             val_data=val_loader,
                             metric="mae",
-                            framework='pytorch_fx')
+                            framework='pytorch_fx',
+                            relative_drop=0.1,
+                            max_trials=3)
         q_yhat = forecaster.predict(data=test_loader, quantize=True, acceleration=False)
         yhat = forecaster.predict(data=test_loader, acceleration=False)
         forecaster.evaluate(test_loader, batch_size=32, acceleration=False)
         forecaster.quantize(calib_data=train_loader,
                             val_data=val_loader,
                             metric="mae",
-                            framework='onnxrt_qlinearops')
+                            framework='onnxrt_qlinearops',
+                            relative_drop=0.1,
+                            max_trials=3)
         q_onnx_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
         forecaster.evaluate_with_onnx(test_loader, batch_size=32, quantize=True)
         forecaster.evaluate_with_onnx(test_loader)
@@ -182,14 +186,18 @@ class TestChronosModelTCNForecaster(TestCase):
         forecaster.quantize(calib_data=train_loader,
                             val_data=val_loader,
                             metric="mae",
-                            framework='pytorch_fx')
+                            framework='pytorch_fx',
+                            relative_drop=0.1,
+                            max_trials=3)
         q_yhat = forecaster.predict(data=test_loader, quantize=True, acceleration=False)
         yhat = forecaster.predict(data=test_loader, acceleration=False)
         forecaster.evaluate(test_loader, batch_size=32, acceleration=False)
         forecaster.quantize(calib_data=train_loader,
                             val_data=val_loader,
                             metric="mae",
-                            framework='onnxrt_qlinearops')
+                            framework='onnxrt_qlinearops',
+                            relative_drop=0.1,
+                            max_trials=3)
         q_onnx_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
         forecaster.evaluate_with_onnx(test_loader, batch_size=32, quantize=True)
         forecaster.evaluate_with_onnx(test_loader)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/core/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/core/quantization.py
@@ -25,6 +25,7 @@ class BaseQuantization(Quantization):
                  approach='post_training_static_quant',
                  tuning_strategy='bayesian',
                  accuracy_criterion: dict = {'relative': 0.99, 'higher_is_better': True},
+                 eval_func=None,
                  timeout=0,
                  max_trials=1,
                  inputs=None,
@@ -49,6 +50,11 @@ class BaseQuantization(Quantization):
                                      allows relative accuracy loss: 1%. accuracy_criterion = {
                                      'absolute': 0.99, 'higher_is_better':False} means accuracy
                                      < 0.99 must be satisfied.
+        :param eval_func:       A evaluation function which only accepts model as input and return
+                                evaluation value. This parameter provides a higher degree of
+                                freedom than using eval_loader and metric. Default to None meaning
+                                no performance tuning, but it would be better give an evaluation
+                                function to get better quantization performance.
         :param timeout:     Tuning timeout (seconds). Default: 0,  which means early stop.
                             combine with max_trials field to decide when to exit.
         :param max_trials:  Max tune times. Default: 1.
@@ -73,6 +79,9 @@ class BaseQuantization(Quantization):
         cfg.model.inputs = inputs
         cfg.model.outputs = outputs
         super().__init__(qconf)
+        if eval_func is not None:
+            self._eval_func = eval_func
+            self._eval_func.builtin = True
 
     def post_training_quantize(self, model, calib_dataloader=None, metric=None):
         self.sanity_check_before_execution(model, calib_dataloader, metric)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/core/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/core/quantization.py
@@ -46,10 +46,12 @@ class BaseQuantization(Quantization):
                             Default: 'post_training_static_quant'.
         :param tuning_strategy:    'bayesian', 'basic', 'mse', 'sigopt'. Default: 'bayesian'.
         :param accuracy_criterion:  Tolerable accuracy drop.
-                                    accuracy_criterion = {'relative': 0.1, 'higher_is_better':True}
-                                     allows relative accuracy loss: 1%. accuracy_criterion = {
-                                     'absolute': 0.99, 'higher_is_better':False} means accuracy
-                                     < 0.99 must be satisfied.
+                                    accuracy_criterion = {'absolute':0.99, 'higher_is_better':False}
+                                    means accuracy loss must be smaller than 0.99. For example, if
+                                    higher_is_better is True, then this requires original metric
+                                    value subtract current metric value be smaller than 0.99.
+                                    accuracy_criterion = {'relative':0.1, 'higher_is_better':True}
+                                    allows relative accuracy loss: 10%.
         :param eval_func:       A evaluation function which only accepts model as input and return
                                 evaluation value. This parameter provides a higher degree of
                                 freedom than using eval_loader and metric. Default to None meaning

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
@@ -34,10 +34,11 @@ def load_inc_model(path, model, framework, input_sample=None):
                           " Please choose from 'pytorch'/'tensorflow'.")
 
 
-def quantize(model, dataloader=None, metric=None, thread_num=None, **kwargs):
+def quantize(model, dataloader=None, eval_func=None, metric=None,
+             thread_num=None, **kwargs):
     if compare_version("neural_compressor", operator.ge, "2.0"):
         from .inc_api_2 import quantize
-        return quantize(model, dataloader, metric, thread_num, **kwargs)
+        return quantize(model, dataloader, eval_func, metric, thread_num, **kwargs)
 
     if kwargs['approach'] not in ['static', 'dynamic']:
         invalidInputError(False,

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
@@ -76,6 +76,7 @@ def _quantize(
     model,
     metric,
     dataloader,
+    eval_func,
     framework,
     conf=None,
     approach='static',
@@ -144,8 +145,7 @@ def _quantize(
         accuracy_criterion = AccuracyCriterion(
             higher_is_better=accuracy_criterion.get('higher_is_better', True),
             criterion=criterion,
-            # we calculate `tolerable_loss` by `1 - target_accuracy`
-            tolerable_loss=1.0 - accuracy_criterion[criterion]
+            tolerable_loss=float(accuracy_criterion[criterion])
         )
 
     tuning_criterion = TuningCriterion(
@@ -163,8 +163,7 @@ def _quantize(
         outputs=outputs,
         backend=backend
     )
-    # if metric is None and eval_dataloader is None:
-    if metric is None:
+    if metric is None and eval_func is None:
         config.performance_only = True
     config = Config(quantization=config, benchmark=None, pruning=None,
                     distillation=None, nas=None)
@@ -177,6 +176,8 @@ def _quantize(
         model=model,
         conf=q_conf,
         calib_dataloader=dataloader,
-        # todo: add eval
+        eval_func=eval_func,
+        eval_metric=metric,
+        eval_dataloader=dataloader  # use same dataloader as 1.0 API
     )
     return q_model

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
@@ -84,7 +84,7 @@ def _quantize(
     conf=None,
     approach='static',
     tuning_strategy='bayesian',
-    accuracy_criterion={'relative': 0.99, 'higher_is_better': True},
+    accuracy_criterion={'relative': 0.01, 'higher_is_better': True},
     timeout=0,
     max_trials=1,
     inputs=[],

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
@@ -18,7 +18,8 @@
 from bigdl.nano.utils.log4Error import invalidInputError
 
 
-def quantize(model, dataloader=None, metric=None, thread_num=None, **kwargs):
+def quantize(model, dataloader=None, eval_func=None, metric=None,
+             thread_num=None, **kwargs):
     if kwargs['approach'] not in ['static', 'dynamic']:
         invalidInputError(False,
                           "Approach should be 'static' or 'dynamic', "
@@ -29,7 +30,7 @@ def quantize(model, dataloader=None, metric=None, thread_num=None, **kwargs):
         if v is not None:
             not_none_kwargs[k] = v
 
-    q_model = _quantize(model=model, dataloader=dataloader, eval_func=kwargs['eval_func'],
+    q_model = _quantize(model=model, dataloader=dataloader, eval_func=eval_func,
                         metric=metric, **not_none_kwargs)
 
     if 'pytorch' in not_none_kwargs['framework']:

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
@@ -29,7 +29,8 @@ def quantize(model, dataloader=None, metric=None, thread_num=None, **kwargs):
         if v is not None:
             not_none_kwargs[k] = v
 
-    q_model = _quantize(model=model, dataloader=dataloader, metric=metric, **not_none_kwargs)
+    q_model = _quantize(model=model, dataloader=dataloader, eval_func=kwargs['eval_func'],
+                        metric=metric, **not_none_kwargs)
 
     if 'pytorch' in not_none_kwargs['framework']:
         from .pytorch.quantized_model import PytorchQuantizedModel
@@ -81,9 +82,9 @@ def _quantize(
     conf=None,
     approach='static',
     tuning_strategy='bayesian',
-    accuracy_criterion={'relative': 0.99, 'higher_is_better': True},
+    accuracy_criterion={'relative': 0.01, 'higher_is_better': True},
     timeout=0,
-    max_trials=1,
+    max_trials=5,
     inputs=[],
     outputs=[],
     **kwargs

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/metric.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/metric.py
@@ -19,8 +19,6 @@ import tensorflow as tf
 
 class TensorflowINCMetric(BaseINCMetric):
     def stack(self, preds, labels):
-
-        # calculate accuracy
         preds = tf.stack(preds)
         labels = tf.stack(labels)
         return preds, labels

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -529,6 +529,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                 supported type: 'int8', 'bf16', 'fp16', defaults to 'int8'.
         :param accelerator:     Use accelerator 'None', 'onnxruntime', 'openvino', defaults to None.
                                 None means staying in pytorch.
+        :param use_ipex:        Whether we use ipex as accelerator for inferencing.
+                                If precision != bf16, it will be ignored. Default: ``False``.
         :param calib_data:      Calibration data is required for static quantization.
                                 It's also used as validation dataloader.
                                 calib_data support following formats:
@@ -556,10 +558,14 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param metric:              A torchmetrics.metric.Metric object for evaluation.
         :param accuracy_criterion:  Tolerable accuracy drop, defaults to None meaning no
                                     accuracy control.
-                                    accuracy_criterion = {'relative': 0.1, 'higher_is_better': True}
-                                    allows relative accuracy loss: 1%. accuracy_criterion =
-                                    {'absolute': 0.99, 'higher_is_better':False} means accuracy
-                                    must be smaller than 0.99.
+                                    accuracy_criterion = {'absolute':0.99, 'higher_is_better':False}
+                                    means accuracy loss must be smaller than 0.99. For example, if
+                                    higher_is_better is True, then this requires original metric
+                                    value subtract current metric value be smaller than 0.99.
+                                    For inc 1.x, this value must be set to [0, 1), for inc 2.x,
+                                    there is no limit.
+                                    accuracy_criterion = {'relative':0.1, 'higher_is_better':True}
+                                    allows relative accuracy loss: 10%.
         :param approach:    'static' or 'dynamic'.
                             'static': post_training_static_quant,
                             'dynamic': post_training_dynamic_quant.
@@ -919,7 +925,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                              model is a LightningModule with any dataloader attached.
         :param accelerator: The accelerator to use, defaults to None meaning staying in Pytorch
                             backend. 'openvino', 'onnxruntime' and 'jit' are supported for now.
-        :param use_ipex: Whether we use ipex as accelerator for inferencing. Default: False.
+        :param use_ipex: Whether we use ipex as accelerator for inferencing. Only valid when
+                         accelerator='jit'/None, otherwise will be ignored. Default: ``False``.
         :param channels_last: Whether use channels last memory format, i.e. NHWC (batch size,
                               height, width, channels), as an alternative way to store tensors in
                               classic/contiguous NCHW order. This setting only works for 4-dim

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -494,6 +494,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                  use_ipex: bool = False,
                  calib_data: Union[DataLoader, torch.Tensor, Tuple[torch.Tensor]] = None,
                  calib_dataloader: Union[DataLoader] = None,
+                 eval_func: Optional[Callable] = None,
                  metric: Optional[Metric] = None,
                  accuracy_criterion: Optional[dict] = None,
                  approach: str = 'static',
@@ -547,6 +548,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                   ``calib_dataloader`` will be deprecated in future release.
 
                   Please use ``calib_data`` instead.
+        :param eval_func:       A evaluation function which only accepts model as input and return
+                                evaluation value. This parameter provides a higher degree of
+                                freedom than using eval_loader and metric. Default to None meaning
+                                no performance tuning, but it would be better give an evaluation
+                                function to get better quantization performance.
         :param metric:              A torchmetrics.metric.Metric object for evaluation.
         :param accuracy_criterion:  Tolerable accuracy drop, defaults to None meaning no
                                     accuracy control.
@@ -783,6 +789,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 `quantized_model.model`.
                 """
                 inc_quantize_arguments = {"model": model, "dataloader": inc_calib_dataloader,
+                                          "eval_func": eval_func,
                                           "metric": metric, "thread_num": thread_num,
                                           "framework": framework, "conf": conf,
                                           "approach": approach,

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -430,11 +430,16 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                 no performance tuning, but it would be better give an evaluation
                                 function to get better quantization performance.
         :param metric:          A tensorflow.keras.metrics.Metric object for evaluation.
-        :param accuracy_criterion:  Tolerable accuracy drop.
-                                    accuracy_criterion = {'relative': 0.1, 'higher_is_better': True}
-                                    allows relative accuracy loss: 1%. accuracy_criterion =
-                                    {'absolute': 0.99, 'higher_is_better':False} means accuracy
-                                    must be smaller than 0.99.
+        :param accuracy_criterion:  Tolerable accuracy drop, defaults to None meaning no
+                                    accuracy control.
+                                    accuracy_criterion = {'absolute':0.99, 'higher_is_better':False}
+                                    means accuracy loss must be smaller than 0.99. For example, if
+                                    higher_is_better is True, then this requires original metric
+                                    value subtract current metric value be smaller than 0.99.
+                                    For inc 1.x, this value must be set to [0, 1), for inc 2.x,
+                                    there is no limit.
+                                    accuracy_criterion = {'relative':0.1, 'higher_is_better':True}
+                                    allows relative accuracy loss: 10%.
         :param approach:        'static' or 'dynamic'.
                                 'static': post_training_static_quant,
                                 'dynamic': post_training_dynamic_quant.

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -23,7 +23,7 @@ import numpy as np
 import traceback
 import inspect
 import tensorflow as tf
-from typing import Dict, Optional, List, Union
+from typing import Dict, Optional, List, Union, Callable
 from bigdl.nano.utils.inference.common.base_optimizer import BaseInferenceOptimizer
 from bigdl.nano.utils.inference.common.checker import available_acceleration_combination
 from bigdl.nano.utils.inference.common.utils import AccelerationOption,\
@@ -376,6 +376,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                  precision: str = 'int8',
                  accelerator: Optional[str] = None,
                  input_spec=None,
+                 eval_func: Optional[Callable] = None,
                  metric: Optional[Metric] = None,
                  accuracy_criterion: Optional[dict] = None,
                  approach: str = 'static',
@@ -423,6 +424,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                            ``input_spec`` is required. If ``accelerator='openvino'``, or
                            ``accelerator=None`` and ``precision='int8'``, ``input_spec``
                            is required when you have a custom Keras model.
+        :param eval_func:       A evaluation function which only accepts model as input and return
+                                evaluation value. This parameter provides a higher degree of
+                                freedom than using eval_loader and metric. Default to None meaning
+                                no performance tuning, but it would be better give an evaluation
+                                function to get better quantization performance.
         :param metric:          A tensorflow.keras.metrics.Metric object for evaluation.
         :param accuracy_criterion:  Tolerable accuracy drop.
                                     accuracy_criterion = {'relative': 0.1, 'higher_is_better': True}
@@ -601,6 +607,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                         outputs = "outputs"    # type: ignore
 
             result = inc_quantzie(model, dataloader=calib_dataset,
+                                  eval_func=eval_func,
                                   metric=metric,
                                   framework='tensorflow',
                                   conf=conf,
@@ -669,6 +676,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             }
             framework = method_map.get(method, None)
             result = inc_quantzie(onnx_model, dataloader=(x, y),
+                                  eval_func=eval_func,
                                   metric=metric,
                                   framework=framework,
                                   thread_num=thread_num,

--- a/python/nano/test/inc/tf/test_keras_quantize.py
+++ b/python/nano/test/inc/tf/test_keras_quantize.py
@@ -16,6 +16,7 @@
 
 
 import pytest
+import operator
 import tempfile
 from unittest import TestCase
 import tensorflow as tf
@@ -23,6 +24,7 @@ from tensorflow.keras.applications.mobilenet_v2 import MobileNetV2
 from keras.utils.np_utils import to_categorical
 import numpy as np
 from bigdl.nano.tf.keras import Model, InferenceOptimizer
+from bigdl.nano.utils.util import compare_version
 
 
 class TestModelQuantize(TestCase):
@@ -99,37 +101,46 @@ class TestModelQuantize(TestCase):
         q_model = InferenceOptimizer.quantize(model, x=train_dataset)
         assert q_model(train_examples[0:10]).shape == (10, 10)
 
-    def test_model_quantize_tunning(self):
+    def test_model_quantize_tuning(self):
         model = MobileNetV2(weights=None, input_shape=[40, 40, 3], classes=10)
         model = Model(inputs=model.inputs, outputs=model.outputs)
         model.compile(optimizer=tf.keras.optimizers.Adam(learning_rate=1e-3),
-                      loss=tf.keras.losses.BinaryCrossentropy(),
-                      metrics=[tf.keras.metrics.CategoricalAccuracy()],)
+                        loss=tf.keras.losses.BinaryCrossentropy(),
+                        metrics=[tf.keras.metrics.CategoricalAccuracy()],)
         train_examples = np.random.random((100, 40, 40, 3))
         train_labels = np.random.randint(0, 10, size=(100,))
         train_labels = to_categorical(train_labels, num_classes=10)
         train_dataset = tf.data.Dataset.from_tensor_slices((train_examples, train_labels))
-        
-        # Case 1: absoulute accuracy_criterion for metric
+
+        # Case 1: test eval function
+        if compare_version("neural_compressor", operator.ge, "1.14.1"):
+            # eval function only works for version >= 1.14.1
+            def eval_func(model):
+                # model (tf.saved_model.load): The input model will be the class of tf.saved_model.load(quantized_model_path).
+                # model is a tensorflow.python.training.tracking.autotrackable.AutoTrackable
+                infer = model.signatures["serving_default"]
+                output_dict_keys = infer.structured_outputs.keys()
+                output_name = list(output_dict_keys )[0]
+                inputs = np.array(train_examples)
+                input_tensor = tf.constant(inputs, dtype=tf.float32)
+                preds = infer(input_tensor)[output_name]
+                acc = tf.keras.metrics.CategoricalAccuracy()(preds, train_labels).numpy()
+                return acc
+
+            q_model = InferenceOptimizer.quantize(model,
+                                                  x=train_dataset,
+                                                  eval_func=eval_func,
+                                                  accuracy_criterion={'relative': 0.99,
+                                                                      'higher_is_better': True})
+            assert q_model
+            output = q_model(train_examples[0:10])
+            assert output.shape == (10, 10)
+
+        # Case 2: test eval metric
         q_model = InferenceOptimizer.quantize(model,
                                               x=train_dataset,
                                               metric=tf.keras.metrics.CategoricalAccuracy(),
                                               tuning_strategy='basic',
-                                              accuracy_criterion={'relative': 0.99,
-                                                                  'higher_is_better': True})
-        assert q_model
-        output = q_model(train_examples[0:10])
-        assert output.shape == (10, 10)
-        
-        # Case 2: absoulute accuracy_criterion for eval_func
-        def eval_func(model):
-            pred = model(train_examples)
-            acc = tf.keras.metrics.CategoricalAccuracy()(pred, train_labels)
-            return acc
-
-        q_model = InferenceOptimizer.quantize(model,
-                                              x=train_dataset,
-                                              eval_func=eval_func,
                                               accuracy_criterion={'relative': 0.99,
                                                                   'higher_is_better': True})
         assert q_model


### PR DESCRIPTION
## Description

After we have upgrade INC version to 2.0, we have not supported `eval_metric` for this version, and we never support `eval function` for quantization until now, which is an effective tool to support a more flexible evaluation form. However, `eval_metric` and `eval_function` are important for the quantization quality.

### 1. Why the change?

To support `eval_metric` and `eval_function` in `InferenceOptimizer.quantize` for both PyTorch and Tensorflow.

### 2. User API changes

new parameter `eval_function` for `InferenceOptimizer.quantize`, here take PyTorch for example:
```python
def eval_func(model):
    acc = 0
    for sample, label in self.train_loader:
        logits = model(sample)
        pred = logits.argmax(dim=1)
        acc += torch.eq(pred, label).sum().float().item()
    return acc

qmodel = InferenceOptimizer.quantize(pl_model,
                                     calib_data=self.train_loader,
                                     eval_func=eval_func,
                                     accuracy_criterion={'relative': 0.8,
                                                         'higher_is_better': True},
                                     timeout=0,
                                     max_trials=10,
                                     thread_num=8)
```
At the same time, `metric` parameter now actually works for INC 2.0 version.
### 3. Summary of the change 

-  support eval function for INC 2.0 in PyTorch InferenceOptimizer
- support eval function for INC 2.0 in keras InferenceOptimizer
- support eval function for INC 1.x in PyTorch InferenceOptimizer
- support eval function for **INC 1.14.1 or higher version** in keras InferenceOptimizer
- support eval metric for INC 2.0 in PyTorch InferenceOptimizer
- support eval metric for INC 2.0 in keras InferenceOptimizer
- related uts for PyTorch
- related uts for keras
- update comment for `use_ipex` in PyTorch InferenceOptimizer
- update comment for `accuracy_criterion` in `quantize`

### 4. How to test?
- [x] Unit test
