### PR TITLE
[Doc] Change version badge in doc home page for release 2.2.0

### DIFF
--- a/docs/readthedocs/source/conf.py
+++ b/docs/readthedocs/source/conf.py
@@ -62,7 +62,7 @@ html_context = {
 html_logo = "../image/bigdl_logo.png"
 
 # hard code it for now, may change it to read from installed bigdl
-release = "latest"
+release = "v2.2.0"
 
 # The suffix of source filenames.
 from recommonmark.parser import CommonMarkParser


### PR DESCRIPTION
Change version badge in doc home page for release 2.2.0
![image](https://user-images.githubusercontent.com/54161268/213348391-24389ab4-d947-41e6-b70b-d9339284f45a.png)


Document test: https://yuwentestdocs.readthedocs.io/en/change-doc-2-2-version-badge/