### PR TITLE
Orca: remove batch_info in torch estimator and runner

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -202,7 +202,6 @@ class PyTorchPySparkEstimator(BaseEstimator):
             batch_size: int=32,
             profile: bool=False,
             reduce_results: bool=True,
-            info: Optional[Dict]=None,
             feature_cols: Optional[List[str]]=None,
             label_cols: Optional[List[str]]=None,
             validation_data: Union['SparkXShards',
@@ -229,8 +228,6 @@ class PyTorchPySparkEstimator(BaseEstimator):
                one dict. If a metric is a non-numerical value, the one value will be randomly
                selected among the workers. If False, returns a list of dicts for
                all workers. Default is True.
-        :param info: An optional dictionary that can be passed to the TorchRunner for
-               train_epoch and train_batch.
         :param feature_cols: feature column names if data is Spark DataFrame.
         :param label_cols: label column names if data is Spark DataFrame.
         :param validation_data: validation data. Validation data type should be the same
@@ -299,7 +296,6 @@ class PyTorchPySparkEstimator(BaseEstimator):
             epochs=epochs,
             batch_size=batch_size,
             profile=profile,
-            info=info,
             callbacks=callbacks
         )
 
@@ -488,7 +484,6 @@ class PyTorchPySparkEstimator(BaseEstimator):
                  num_steps: Optional[int]=None,
                  profile: bool=False,
                  reduce_results: bool=True,
-                 info: Optional[Dict]=None,
                  feature_cols: Optional[List[str]]=None,
                  label_cols: Optional[List[str]]=None,
                  callbacks: Optional[List['Callback']]=None) -> Union[List[Dict], Dict]:
@@ -514,8 +509,6 @@ class PyTorchPySparkEstimator(BaseEstimator):
                one dict. If a metric is a non-numerical value, the one value will be randomly
                selected among the workers. If False, returns a list of dicts for
                all workers. Default is True.
-        :param info: An optional dictionary that can be passed to the TorchRunner
-               for validate.
         :param feature_cols: feature column names if train data is Spark DataFrame.
         :param label_cols: label column names if train data is Spark DataFrame.
         :param callbacks: A list for all callbacks. Note that only one MainCallback
@@ -555,7 +548,6 @@ class PyTorchPySparkEstimator(BaseEstimator):
             batch_size=batch_size,
             num_steps=num_steps,
             profile=profile,
-            info=info,
             callbacks=callbacks
         )
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -128,14 +128,13 @@ class PytorchPysparkWorker(TorchRunner):
                 self.setup_operator(self.models)
 
     def train_epochs(self, data_creator, epochs=1, batch_size=32, profile=False,
-                     info=None, wrap_dataloader=None, callbacks=None,
+                     wrap_dataloader=None, callbacks=None,
                      validation_data_creator=None):
         self.load_state_dict(self.state_dict.value)
         stats_list = super().train_epochs(data_creator=data_creator,
                                           epochs=epochs,
                                           batch_size=batch_size,
                                           profile=profile,
-                                          info=info,
                                           wrap_dataloader=wrap_dataloader,
                                           callbacks=callbacks,
                                           validation_data_creator=validation_data_creator)
@@ -154,10 +153,10 @@ class PytorchPysparkWorker(TorchRunner):
             return [state_dict, stats_list]
 
     def validate(self, data_creator, batch_size=32, num_steps=None, profile=False,
-                 info=None, wrap_dataloader=None, callbacks=None):
+                 wrap_dataloader=None, callbacks=None):
         """Evaluates the model on the validation data set."""
         self.load_state_dict(self.state_dict.value)
-        validation_stats = super().validate(data_creator, batch_size, num_steps, profile, info,
+        validation_stats = super().validate(data_creator, batch_size, num_steps, profile,
                                             wrap_dataloader, callbacks)
         if self.log_to_driver:
             LogMonitor.stop_log_monitor(self.log_path, self.logger_thread, self.thread_stop)

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -145,7 +145,6 @@ class PyTorchRayEstimator(BaseRayEstimator):
             batch_size: int=32,
             profile: bool=False,
             reduce_results: bool=True,
-            info: Optional[Dict]=None,
             feature_cols: Optional[List[str]]=None,
             label_cols: Optional[List[str]]=None,
             validation_data: Union['SparkXShards',
@@ -172,8 +171,6 @@ class PyTorchRayEstimator(BaseRayEstimator):
                one dict. If a metric is a non-numerical value, the one value will be randomly
                selected among the workers. If False, returns a list of dicts for
                all workers. Default is True.
-        :param info: An optional dictionary that can be passed to the TorchRunner for
-               train_epoch and train_batch.
         :param feature_cols: feature column names if data is Spark DataFrame or Ray Dataset.
         :param label_cols: label column names if data is Spark DataFrame or Ray Dataset.
         :param validation_data: validation data. Validation data type should be the same
@@ -203,7 +200,6 @@ class PyTorchRayEstimator(BaseRayEstimator):
             epochs=epochs,
             batch_size=batch_size,
             profile=profile,
-            info=info,
             callbacks=callbacks,
         )
 
@@ -393,7 +389,6 @@ class PyTorchRayEstimator(BaseRayEstimator):
                  num_steps: int=None,
                  profile: bool=False,
                  reduce_results: bool=True,
-                 info: Dict=None,
                  feature_cols: Optional[List[str]]=None,
                  label_cols:  Optional[List[str]]=None,
                  callbacks: Optional[List['Callback']]=None) -> Union[List[Dict], Dict]:
@@ -419,8 +414,6 @@ class PyTorchRayEstimator(BaseRayEstimator):
                one dict. If a metric is a non-numerical value, the one value will be randomly
                selected among the workers. If False, returns a list of dicts for
                all workers. Default is True.
-        :param info: An optional dictionary that can be passed to the TorchRunner
-               for validate.
         :param feature_cols: feature column names if train data is Spark DataFrame or Ray Dataset.
         :param label_cols: label column names if train data is Spark DataFrame or Ray Dataset.
         :param callbacks: A list for all callbacks. Note that only one MainCallback
@@ -453,7 +446,6 @@ class PyTorchRayEstimator(BaseRayEstimator):
         params = dict(batch_size=batch_size,
                       num_steps=num_steps,
                       profile=profile,
-                      info=info,
                       wrap_dataloader=False,
                       callbacks=callbacks)
 


### PR DESCRIPTION
## Description

It seems that batch_info will not be used anymore after tqdmcallback.