### PR TITLE
Nano: fix `bigdl-nano-init` to support MacOS

### DIFF
--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -20,9 +20,9 @@ function enable-jemalloc-var {
 }
 
 function enable-tcmalloc-var {
-	echo "Option: Enable tcmalloc and set related variables"
-	ENABLE_TCMALLOC_VAR=1
-	unset ENABLE_JEMALLOC_VAR
+    echo "Option: Enable tcmalloc and set related variables"
+    ENABLE_TCMALLOC_VAR=1
+    unset ENABLE_JEMALLOC_VAR
 }
 
 function disable-allocator {
@@ -53,7 +53,7 @@ function set-allocator {
     fi
 
     if [ $OS = "linux" ]; then
-        # if `LD_PRELOAD` or `JEMLLOC_PATH` is empty, there will be
+        # if `LD_PRELOAD` or `lib_path` is empty, there will be
         # extra space on the left or right sides, use echo to remove them
         export LD_PRELOAD=$(echo ${LD_PRELOAD} ${lib_path})
     elif [ $OS = "macos" ] && [ ! -z $lib_path ]; then

--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -10,18 +10,18 @@
 # Get options
 function disable-openmp-var {
     echo "Option: Disable opemMP and unset related variables"
-    export DISABLE_OPENMP_VAR=1
+    DISABLE_OPENMP_VAR=1
 }
 
 function enable-jemalloc-var {
     echo "Option: Enable jemalloc and set related variables"
-    export ENABLE_JEMALLOC_VAR=1
+    ENABLE_JEMALLOC_VAR=1
     unset ENABLE_TCMALLOC_VAR
 }
 
 function enable-tcmalloc-var {
 	echo "Option: Enable tcmalloc and set related variables"
-	export ENABLE_TCMALLOC_VAR=1
+	ENABLE_TCMALLOC_VAR=1
 	unset ENABLE_JEMALLOC_VAR
 }
 
@@ -34,6 +34,31 @@ function disable-allocator {
 function enable-perf-var {
     echo "Option: Enable perf mode"
     PERF_VAR=1
+}
+
+function set-allocator {
+    echo "Setting $1..."
+    if [ $OS = "linux" ]; then
+        local lib_name="lib$1.so"
+    elif [ $OS = "macos" ]; then
+        local lib_name="lib$1.dylib"
+    fi
+
+    if [ -f "${NANO_DIR}/libs/${lib_name}" ]; then
+        local lib_path="${NANO_DIR}/libs/${lib_name}"
+    elif [ -f "${LIB_DIR}/${lib_name}" ]; then
+        local lib_path="${LIB_DIR}/${lib_name}"
+    else
+        echo "Failed to find ${lib_name} in ${NANO_DIR}/libs and ${LIB_DIR}"
+    fi
+
+    if [ $OS = "linux" ]; then
+        # if `LD_PRELOAD` or `JEMLLOC_PATH` is empty, there will be
+        # extra space on the left or right sides, use echo to remove them
+        export LD_PRELOAD=$(echo ${LD_PRELOAD} ${lib_path})
+    elif [ $OS = "macos" ] && [ ! -z $lib_path ]; then
+        export DYLD_INSERT_LIBRARIES=$(echo ${DYLD_INSERT_LIBRARIES}:${lib_path})
+    fi
 }
 
 function display-error {
@@ -57,10 +82,13 @@ function display-help {
         echo "    -p, --perf                Use performance mode"
 }
 
-# Init
-export ENABLE_JEMALLOC_VAR=1
+# Init internel variables
+ENABLE_JEMALLOC_VAR=1
 unset ENABLE_TCMALLOC_VAR
-# Set TF_ENABLE_ONEDNN_OPTS
+unset DISABLE_OPENMP_VAR
+unset PERF_VAR
+
+# Init exported variables
 export TF_ENABLE_ONEDNN_OPTS=1
 
 OPTIND=1
@@ -123,110 +151,84 @@ done
 
 shift $((OPTIND -1))
 
-# Find conda dir
+# Find bigdl-nano-init dir
 if [ ! -z $BASH_SOURCE ]; then
     # using bash
-    BASE_DIR="$(dirname $BASH_SOURCE)/.."
+    BIN_DIR="$(dirname $BASH_SOURCE)"
 else
     # using zsh
-    BASE_DIR="$(dirname ${(%):-%N})/.."
+    BIN_DIR="$(dirname ${(%):-%N})"
 fi
-echo "conda dir found: $BASE_DIR"
-LIB_DIR=$BASE_DIR/lib
+echo "Sourcing bigdl-nano-init in: $BIN_DIR"
 
-PYTHON_VERSION=$(python3 -c "import platform; major, mnior, patch = platform.python_version_tuple();print(major+'.'+mnior)")
+LIB_DIR=`dirname ${BIN_DIR}`/lib
+NANO_DIR=$(dirname $(python3 -c "import bigdl; print(bigdl.__file__)"))/nano
+PYTHON_VERSION=`python3 --version | awk '{print $2}'`
 
-NANO_DIR="$(dirname "$(python3 -c "import bigdl; print(bigdl.__file__)")")/nano/"
+uName=`uname -s`
+if [ ${uName: 0: 5} = "Linux" ]; then
+    OS="linux"
+elif [ ${uName: 0: 6} = "Darwin" ]; then
+    OS="macos"
+else
+    echo "Unsupported OS: ${uName}"
+    return 1
+fi
 
+# Detect Intel openMP library and init LD_PRELOAD
 OPENMP=0
-# Detect Intel openMP library
-if [ -f "${LIB_DIR}/libiomp5.so" ]; then
-    echo "OpenMP library found..."
+export LD_PRELOAD=""
+export DYLD_INSERT_LIBRARIES=""
+if [ ! -z "${DISABLE_OPENMP_VAR:-}" ]; then
+    : # do nothing
+elif [ $OS = "linux" ] && [ -f "${LIB_DIR}/libiomp5.so" ]; then
     OPENMP=1
+    export LD_PRELOAD="${LIB_DIR}/libiomp5.so"
+elif [ $OS = "macos" ] && [ -f "${LIB_DIR}/libiomp5.dylib" ]; then
+    OPENMP=1
+    export DYLD_INSERT_LIBRARIES="${LIB_DIR}/libiomp5.dylib"
+else
+    echo "No OpenMP library found in ${LIB_DIR}."
+fi
 
-    # detect number of physical cores
-    cpu_infos=($(lscpu -p=CPU,Socket,Core | grep -P '^(\d*),(\d*),(\d*)$'))
-    max_cpu_info=($(echo ${cpu_infos[-1]} | sed 's/,/\ /g'))
-    # bash's array index starts from 0, while zsh's array index starts from 1,
-    # so we use -1, -2, -3 as index here for consistency
-    let cpu_=${max_cpu_info[-3]}+1
-    let sockets_=${max_cpu_info[-2]}+1
-    let core_=${max_cpu_info[-1]}+1
-    let threads_per_core=$cpu_/$core_
-    let cores_per_socket=$core_/$sockets_
-
-
-    # set env variables
+if [ "${OPENMP}" -eq 1 ]; then
     echo "Setting OMP_NUM_THREADS..."
-    export OMP_NUM_THREADS=$core_
+    if [ $OS = "linux" ]; then 
+        cpu_infos=($(lscpu -p=CPU,Socket,Core | grep -P '^(\d*),(\d*),(\d*)$'))
+        max_cpu_info=($(echo ${cpu_infos[-1]} | sed 's/,/\ /g'))
+        # bash's array index starts from 0, while zsh's array index starts from 1,
+        # so we use -1, -2, -3 as index here for consistency
+        let cpu_=${max_cpu_info[-3]}+1
+        let sockets_=${max_cpu_info[-2]}+1
+        let core_=${max_cpu_info[-1]}+1
+        let threads_per_core=$cpu_/$core_
+        let cores_per_socket=$core_/$sockets_
+        export OMP_NUM_THREADS=$core_
+    elif [ $OS = "macos" ]; then
+        export OMP_NUM_THREADS=$(sysctl -n hw.physicalcpu)
+    else
+        unset OMP_NUM_THREADS
+    fi
 
     echo "Setting KMP_AFFINITY..."
-    export KMP_AFFINITY=granularity=fine,none
-
-    if [[ "${PERF_VAR}" -eq "1" ]]; then
+    if [[ "${PERF_VAR}" -eq 1 ]]; then
         # experiment variable to speed up performance.
-        export OPENMP=0
         export KMP_AFFINITY=granularity=fine,compact,1,0
+    else
+        export KMP_AFFINITY=granularity=fine,none
     fi
 
     echo "Setting KMP_BLOCKTIME..."
     export KMP_BLOCKTIME=1
-
-else
-    echo "No openMP library found in ${LIB_DIR}."
 fi
 
-# set env variables
-echo "Setting MALLOC_CONF..."
-export MALLOC_CONF="oversize_threshold:1,background_thread:false,metadata_thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1"
-
-# Set LD_PRELOAD
-echo "Setting LD_PRELOAD..."
-if [[ $OPENMP -eq 1 && -z "${DISABLE_OPENMP_VAR:-}" ]]; then
-    export LD_PRELOAD="${LIB_DIR}/libiomp5.so"
-fi
-
-# Set JEMALLOC lib path
+# Set allocator
 if [[ ! -z "${ENABLE_JEMALLOC_VAR:-}" ]]; then
-    if [ -f "${NANO_DIR}/libs/libjemalloc.so" ]; then
-        JEMALLOC_PATH="${NANO_DIR}/libs/libjemalloc.so"
-    elif [ -f "${LIB_DIR}/libjemalloc.so" ]; then
-        JEMALLOC_PATH="${LIB_DIR}/libjemalloc.so"
-    fi
-    # if `LD_PRELOAD` or `JEMLLOC_PATH` is empty, there will be
-    # extra space on the left or right sides, use echo to remove them
-    export LD_PRELOAD=$(echo ${LD_PRELOAD} ${JEMALLOC_PATH})
+    set-allocator jemalloc
+    export MALLOC_CONF="oversize_threshold:1,background_thread:false,metadata_thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1"
 elif [[ ! -z "${ENABLE_TCMALLOC_VAR:-}" ]]; then
-    if [ -f "${NANO_DIR}/libs/libtcmalloc.so" ]; then
-        TCMALLOC_PATH="${NANO_DIR}/libs/libtcmalloc.so"
-    elif [ -f "${LIB_DIR}/libtcmalloc.so" ]; then
-        TCMALLOC_PATH="${LIB_DIR}/libtcmalloc.so"
-    fi
-    # the same as above
-    export LD_PRELOAD=$(echo ${LD_PRELOAD} ${TCMALLOC_PATH})
-fi
-
-# Clean up perf var
-if [[ "${PERF_VAR}" -eq "1" ]]; then
-    unset PERF_VAR
-fi
-
-# Disable openmp or jemalloc according to options
-if [ ! -z "${DISABLE_OPENMP_VAR:-}" ]; then
-    unset OMP_NUM_THREADS
-    unset KMP_AFFINITY
-    unset KMP_BLOCKTIME
-    unset DISABLE_OPENMP_VAR
-    export LD_PRELOAD=`echo $LD_PRELOAD | sed "s/\s.*libiomp5\.so//g" | sed "s/.*libiomp5\.so\s*//g"`
-fi
-
-if [ -z "${ENABLE_JEMALLOC_VAR:-}" ]; then
+    set-allocator tcmalloc
     unset MALLOC_CONF
-    export LD_PRELOAD=`echo $LD_PRELOAD | sed "s/\s.*libjemalloc\.so//g" | sed "s/.*libjemalloc\.so\s*//g"`
-fi
-
-if [ -z "${ENABLE_TCMALLOC_VAR:-}" ]; then
-    export LD_PRELOAD=`echo $LD_PRELOAD | sed "s/\s.*libtcmalloc\.so//g" | sed "s/.*libtcmalloc\.so\s*//g"`
 fi
 
 if [ -z "${CONDA_DEFAULT_ENV:-}" ]; then
@@ -265,7 +267,11 @@ else
 fi
 
 echo "+++++ Env Variables +++++"
-echo "LD_PRELOAD=${LD_PRELOAD}"
+if [ $OS = "linux" ]; then 
+    echo "LD_PRELOAD=${LD_PRELOAD}"
+elif [ $OS = "macos" ]; then
+    echo "DYLD_INSERT_LIBRARIES=${DYLD_INSERT_LIBRARIES}"
+fi
 echo "MALLOC_CONF=${MALLOC_CONF}"
 echo "OMP_NUM_THREADS=${OMP_NUM_THREADS}"
 echo "KMP_AFFINITY=${KMP_AFFINITY}"

--- a/python/nano/scripts/bigdl-nano-unset-env
+++ b/python/nano/scripts/bigdl-nano-unset-env
@@ -2,6 +2,7 @@
 
 echo "Unset Nano envs"
 unset LD_PRELOAD
+unset DYLD_INSERT_LIBRARIES
 unset MALLOC_CONF
 unset OMP_NUM_THREADS
 unset KMP_AFFINITY


### PR DESCRIPTION
## Description

Try to fix <https://github.com/analytics-zoo/nano/issues/257> and contains #7312

- Use `DYLD_INSERT_LIBRARIES` instead of `LD_PRELOAD` on MacOS
- Use `sysctl -n hw.physicalcpu` instead of `lscpu` on MacOS
- Search for `libjemlloc.dylib` and `libjemalloc.dylib` on MacOS
- Use `=` instead of `==`, because `==` only works on bash, we can also use `-eq` for integer comparison