### PR TITLE
Update k8s tutorial and script

### DIFF
--- a/docs/readthedocs/source/doc/Orca/Tutorial/k8s.md
+++ b/docs/readthedocs/source/doc/Orca/Tutorial/k8s.md
@@ -218,7 +218,7 @@ cp /path/to/fashion-mnist/data/fashion/* /bigdl/nfsdata/dataset/FashionMNIST/raw
 gzip -d /bigdl/nfsdata/dataset/FashionMNIST/raw/*
 ```
 
-In the given example, you can specify the argument `--remote_dir` to be the directory on NFS for the Fashion-MNIST dataset. The directory should contain `FashionMNIST/raw/train-images-idx3-ubyte` and `FashionMNIST/raw/t10k-images-idx3`.
+In the given example, you can specify the argument `--data_dir` to be the directory on NFS for the Fashion-MNIST dataset. The directory should contain `FashionMNIST/raw/train-images-idx3-ubyte` and `FashionMNIST/raw/t10k-images-idx3`.
 
 
 ---
@@ -288,7 +288,7 @@ See [here](#init-orca-context) for the runtime configurations.
 #### 6.1.1 K8s-Client
 Run the example with the following command by setting the cluster_mode to "k8s-client":
 ```bash
-python train.py --cluster_mode k8s-client --remote_dir file:///bigdl/nfsdata/dataset
+python train.py --cluster_mode k8s-client --data_dir /bigdl/nfsdata/dataset
 ```
 
 
@@ -317,7 +317,7 @@ cp /path/to/model.py /bigdl/nfsdata
 
 Run the example with the following command by setting the cluster_mode to “k8s-cluster”:
 ```bash
-python /bigdl/nfsdata/train.py --cluster_mode k8s-cluster --remote_dir /bigdl/nfsdata/dataset
+python /bigdl/nfsdata/train.py --cluster_mode k8s-cluster --data_dir /bigdl/nfsdata/dataset
 ```
 
 
@@ -379,7 +379,7 @@ ${SPARK_HOME}/bin/spark-submit \
     --conf spark.executor.extraClassPath=${BIGDL_HOME}/jars/* \
     --conf spark.kubernetes.executor.volumes.persistentVolumeClaim.${RUNTIME_PERSISTENT_VOLUME_CLAIM}.options.claimName=${RUNTIME_PERSISTENT_VOLUME_CLAIM} \
     --conf spark.kubernetes.executor.volumes.persistentVolumeClaim.${RUNTIME_PERSISTENT_VOLUME_CLAIM}.mount.path=/bigdl/nfsdata \
-    train.py --cluster_mode spark-submit --remote_dir /bigdl/nfsdata/dataset
+    train.py --cluster_mode spark-submit --data_dir /bigdl/nfsdata/dataset
 ```
 
 In the `spark-submit` script:
@@ -431,7 +431,7 @@ ${SPARK_HOME}/bin/spark-submit \
     --conf spark.kubernetes.driver.volumes.persistentVolumeClaim.${RUNTIME_PERSISTENT_VOLUME_CLAIM}.mount.path=/bigdl/nfsdata \
     --conf spark.kubernetes.executor.volumes.persistentVolumeClaim.${RUNTIME_PERSISTENT_VOLUME_CLAIM}.options.claimName=${RUNTIME_PERSISTENT_VOLUME_CLAIM} \
     --conf spark.kubernetes.executor.volumes.persistentVolumeClaim.${RUNTIME_PERSISTENT_VOLUME_CLAIM}.mount.path=/bigdl/nfsdata \
-    file:///bigdl/nfsdata/train.py --cluster_mode spark-submit --remote_dir /bigdl/nfsdata/dataset
+    file:///bigdl/nfsdata/train.py --cluster_mode spark-submit --data_dir /bigdl/nfsdata/dataset
 ```
 
 In the `spark-submit` script:
@@ -528,7 +528,7 @@ spec:
                 --conf spark.executor.extraClassPath=local://${BIGDL_HOME}/jars/* \
                 local:///bigdl/nfsdata/train.py
                 --cluster_mode spark-submit
-                --remote_dir file:///bigdl/nfsdata/dataset
+                --data_dir file:///bigdl/nfsdata/dataset
                 "]
         securityContext:
           privileged: true
@@ -672,7 +672,7 @@ spec:
                 --conf spark.executor.extraClassPath=local://${BIGDL_HOME}/jars/* \
                 local:///bigdl/nfsdata/train.py
                 --cluster_mode spark-submit
-                --remote_dir file:///bigdl/nfsdata/dataset
+                --data_dir file:///bigdl/nfsdata/dataset
                 "]
         securityContext:
           privileged: true
@@ -845,7 +845,7 @@ spec:
                 --conf spark.executor.extraClassPath=local://${BIGDL_HOME}/jars/* \
                 local:///bigdl/nfsdata/train.py
                 --cluster_mode spark-submit
-                --remote_dir file:///bigdl/nfsdata/dataset
+                --data_dir file:///bigdl/nfsdata/dataset
                 "]
         securityContext:
           privileged: true
@@ -983,7 +983,7 @@ spec:
                 --conf spark.executor.extraClassPath=local://${BIGDL_HOME}/jars/* \
                 local:///bigdl/nfsdata/train.py
                 --cluster_mode spark-submit
-                --remote_dir file:///bigdl/nfsdata/dataset
+                --data_dir file:///bigdl/nfsdata/dataset
                 "]
         securityContext:
           privileged: true

--- a/docs/readthedocs/source/doc/Orca/Tutorial/yarn.md
+++ b/docs/readthedocs/source/doc/Orca/Tutorial/yarn.md
@@ -127,7 +127,7 @@ Then upload it to a distributed storage. Sample command to upload data to HDFS i
 ```bash
 hdfs dfs -put /path/to/local/data/FashionMNIST hdfs://path/to/remote/data
 ```
-In the given example, you can specify the argument `--remote_dir` to be the directory on a distributed storage for the Fashion-MNIST dataset. The directory should contain `FashionMNIST/raw/train-images-idx3-ubyte` and `FashionMNIST/raw/t10k-images-idx3`.
+In the given example, you can specify the argument `--data_dir` to be the directory on a distributed storage for the Fashion-MNIST dataset. The directory should contain `FashionMNIST/raw/train-images-idx3-ubyte` and `FashionMNIST/raw/t10k-images-idx3`.
 
 ---
 ## 4. Prepare Custom Modules
@@ -192,14 +192,14 @@ See [here](#init-orca-context) for the runtime configurations.
 #### 5.1.1 Yarn Client
 Run the example with the following command by setting the cluster_mode to "yarn-client":
 ```bash
-python train.py --cluster_mode yarn-client --remote_dir hdfs://path/to/remote/data
+python train.py --cluster_mode yarn-client --data_dir hdfs://path/to/remote/data
 ```
 
 
 #### 5.1.2 Yarn Cluster
 Run the example with the following command by setting the cluster_mode to "yarn-cluster":
 ```bash
-python train.py --cluster_mode yarn-cluster --remote_dir hdfs://path/to/remote/data
+python train.py --cluster_mode yarn-cluster --data_dir hdfs://path/to/remote/data
 ```
 
 
@@ -254,7 +254,7 @@ bigdl-submit \
     --archives /path/to/environment.tar.gz#environment \
     --conf spark.pyspark.driver.python=/path/to/python \
     --conf spark.pyspark.python=environment/bin/python \
-    train.py --cluster_mode bigdl-submit --remote_dir hdfs://path/to/remote/data
+    train.py --cluster_mode bigdl-submit --data_dir hdfs://path/to/remote/data
 ```
 In the `bigdl-submit` script:
 * `--master`: the spark master, set it to "yarn".
@@ -277,7 +277,7 @@ bigdl-submit \
     --archives /path/to/environment.tar.gz#environment \
     --conf spark.yarn.appMasterEnv.PYSPARK_PYTHON=environment/bin/python \
     --conf spark.executorEnv.PYSPARK_PYTHON=environment/bin/python \
-    train.py --cluster_mode bigdl-submit --remote_dir hdfs://path/to/remote/data
+    train.py --cluster_mode bigdl-submit --data_dir hdfs://path/to/remote/data
 ```
 In the `bigdl-submit` script:
 * `--master`: the spark master, set it to "yarn".
@@ -344,7 +344,7 @@ ${SPARK_HOME}/bin/spark-submit \
     --conf spark.pyspark.python=environment/bin/python \
     --py-files ${BIGDL_HOME}/python/bigdl-spark_${SPARK_VERSION}-${BIGDL_VERSION}-python-api.zip,model.py \
     --jars ${BIGDL_HOME}/jars/bigdl-assembly-spark_${SPARK_VERSION}-${BIGDL_VERSION}-jar-with-dependencies.jar \
-    train.py --cluster_mode spark-submit --remote_dir hdfs://path/to/remote/data
+    train.py --cluster_mode spark-submit --data_dir hdfs://path/to/remote/data
 ```
 In the `spark-submit` script:
 * `--master`: the spark master, set it to "yarn".
@@ -368,7 +368,7 @@ ${SPARK_HOME}/bin/spark-submit \
     --conf spark.executorEnv.PYSPARK_PYTHON=environment/bin/python \
     --py-files ${BIGDL_HOME}/python/bigdl-spark_${SPARK_VERSION}-${BIGDL_VERSION}-python-api.zip,model.py \
     --jars ${BIGDL_HOME}/jars/bigdl-assembly-spark_${SPARK_VERSION}-${BIGDL_VERSION}-jar-with-dependencies.jar \
-    train.py --cluster_mode spark-submit --remote_dir hdfs://path/to/remote/data
+    train.py --cluster_mode spark-submit --data_dir hdfs://path/to/remote/data
 ```
 In the `spark-submit` script:
 * `--master`: the spark master, set it to "yarn".

--- a/python/orca/tutorial/pytorch/FashionMNIST/model.py
+++ b/python/orca/tutorial/pytorch/FashionMNIST/model.py
@@ -19,8 +19,8 @@
 #
 
 import torch.nn as nn
-import torch.optim as optim
 import torch.nn.functional as F
+import torch.optim as optim
 
 
 class Net(nn.Module):
@@ -49,5 +49,5 @@ def model_creator(config):
 
 
 def optimizer_creator(model, config):
-    optimizer = optim.SGD(model.parameters(), lr=0.001, momentum=0.9)
+    optimizer = optim.SGD(model.parameters(), lr=config.get("lr", 0.001), momentum=0.9)
     return optimizer

--- a/python/orca/tutorial/pytorch/FashionMNIST/train.py
+++ b/python/orca/tutorial/pytorch/FashionMNIST/train.py
@@ -35,23 +35,22 @@ from bigdl.orca.learn.metrics import Accuracy
 from model import model_creator, optimizer_creator
 
 
-parser = argparse.ArgumentParser(description='PyTorch FashionMNIST Train Tutorial')
-parser.add_argument('--cluster_mode', type=str, default="spark-submit",
-                    help='The cluster mode, such as local, yarn-client, yarn-cluster, '
-                         'k8s-client, k8s-cluster, spark-submit or bigdl-submit.')
-parser.add_argument('--data_dir', type=str, required=True,
-                    help='The path to load data from local or remote resources')
+parser = argparse.ArgumentParser(description="PyTorch FashionMNIST Train Tutorial")
+parser.add_argument("--cluster_mode", type=str, default="spark-submit",
+                    help="The cluster mode, such as local, yarn-client, yarn-cluster, "
+                         "k8s-client, k8s-cluster, spark-submit or bigdl-submit.")
+parser.add_argument("--data_dir", type=str, required=True,
+                    help="The path to load data from local or remote resources.")
 args = parser.parse_args()
 
 
 def train_data_creator(config, batch_size):
     transform = transforms.Compose([transforms.ToTensor(),
                                     transforms.Normalize((0.5,), (0.5,))])
-    if is_local_path(args.data_dir):
-        data_dir = args.data_dir
-    else:
+    data_dir = config["data_dir"]
+    if not is_local_path(data_dir):
         data_dir = "/tmp/dataset"
-        get_remote_dir_to_local(remote_dir=args.data_dir, local_dir=data_dir)
+        get_remote_dir_to_local(remote_dir=config["data_dir"], local_dir=data_dir)
     trainset = torchvision.datasets.FashionMNIST(root=data_dir, train=True,
                                                  download=False, transform=transform)
     trainloader = torch.utils.data.DataLoader(trainset, batch_size=batch_size,
@@ -117,7 +116,8 @@ def main():
                                           loss=nn.CrossEntropyLoss(),
                                           metrics=[Accuracy()],
                                           use_tqdm=True,
-                                          backend="spark")
+                                          backend="spark",
+                                          config={"data_dir": args.data_dir, "lr": 0.001})
 
     train_stats = orca_estimator.fit(train_data_creator, epochs=1, batch_size=32)
     print("Train results:")
@@ -128,5 +128,6 @@ def main():
 
     stop_orca_context()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     main()

--- a/python/orca/tutorial/pytorch/FashionMNIST/train.py
+++ b/python/orca/tutorial/pytorch/FashionMNIST/train.py
@@ -30,6 +30,7 @@ from bigdl.orca import init_orca_context, stop_orca_context
 from bigdl.orca.data.file import get_remote_dir_to_local
 from bigdl.orca.learn.pytorch import Estimator
 from bigdl.orca.learn.metrics import Accuracy
+from bigdl.dllib.utils.file_utils import is_local_path
 
 from model import model_creator, optimizer_creator
 
@@ -46,8 +47,11 @@ def train_data_creator(config, batch_size):
     transform = transforms.Compose([transforms.ToTensor(),
                                     transforms.Normalize((0.5,), (0.5,))])
     if args.remote_dir is not None:
-        data_dir = "/tmp/dataset"
-        get_remote_dir_to_local(remote_dir=args.remote_dir, local_dir=data_dir)
+        data_dir = args.remote_dir
+        print(is_local_path(data_dir))
+        print(os.listdir(data_dir))
+        # data_dir = "/tmp/dataset"
+        # get_remote_dir_to_local(remote_dir=args.remote_dir, local_dir=data_dir)
         trainset = torchvision.datasets.FashionMNIST(root=data_dir, train=True,
                                                      download=False, transform=transform)
         trainloader = torch.utils.data.DataLoader(trainset, batch_size=batch_size,
@@ -112,6 +116,7 @@ def main():
                                           optimizer=optimizer_creator,
                                           loss=nn.CrossEntropyLoss(),
                                           metrics=[Accuracy()],
+                                          use_tqdm=True,
                                           backend="spark")
 
     train_stats = orca_estimator.fit(train_data_creator, epochs=1, batch_size=32)

--- a/python/orca/tutorial/pytorch/FashionMNIST/train.py
+++ b/python/orca/tutorial/pytorch/FashionMNIST/train.py
@@ -52,7 +52,6 @@ def train_data_creator(config, batch_size):
         else:
             data_dir = "/tmp/dataset"
             get_remote_dir_to_local(remote_dir=args.data_dir, local_dir=data_dir)
-        print(os.listdir(data_dir))
         trainset = torchvision.datasets.FashionMNIST(root=data_dir, train=True,
                                                      download=False, transform=transform)
         trainloader = torch.utils.data.DataLoader(trainset, batch_size=batch_size,


### PR DESCRIPTION
- Change remote_dir to data_dir, since we can run in local as well, data_dir is a better name. Add cluster_mode for local.
- For K8s, since NFS is local storage, we don't need to get the entire folder to /tmp, add a condition if the path is local, then we don't fetch remote to local. Since we fetch the parent folder of the dataset, which may contain other unnecessary files as well, fetch remote to local should be avoided in k8s.
- When treating nfs as local path, we should use `/bigdl/nfsdata` instead of `file:///bigdl/nfsdata` (which will cause file not found)
- Add tqdm for progress bar (installation already added in the tutorial environment section)
- Some other updates: including make data_dir required; add something to config for better demonstration purpose.