### PR TITLE
Nano: Add some user guide and warning messages according to feedback

### DIFF
--- a/docs/readthedocs/source/doc/Nano/Overview/install.md
+++ b/docs/readthedocs/source/doc/Nano/Overview/install.md
@@ -48,7 +48,7 @@ You can select bigdl-nano along with some dependencies specific to PyTorch or Te
 .. note::
     Since bigdl-nano is still in the process of rapid iteration, we highly recommend that you install nightly build version through the above command to facilitate your use of the latest features.
 
-    For stable version, please refer to the document and installation guide `here <https://bigdl.readthedocs.io/en/v2.1.0/doc/Nano/Overview/nano.html>`_ .
+    For stable version, please refer to the document and installation guide `here <https://bigdl.readthedocs.io/en/v2.2.0/doc/Nano/Overview/install.html>`_ .
 ```
 
 ## Environment Management
@@ -73,6 +73,9 @@ In a conda environment, when you run `source bigdl-nano-init` manually, this com
 ### Install in pure pip environment
 
 In a pure pip environment, you need to run `source bigdl-nano-init` every time you open a new shell to get optimal performance and run `source bigdl-nano-unset-env` if you want to unset these environment variables.
+
+## Other PyTorch/Tensorflow Version Support
+We support a wide range of PyTorch and Tensorflow. We only care the MAJOR.MINOR in [Semantic Versioning](https://semver.org/). If you have a specific PyTorch/Tensorflow version want to use, e.g. PyTorch 1.11.0+cpu, you may select corresponding MAJOR.MINOR (i.e., PyTorch 1.11 in this case) and install PyTorch again after installing nano.
 
 ## Python Version
 `bigdl-nano` is validated on Python 3.7-3.9.

--- a/python/nano/src/bigdl/nano/pytorch/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/__init__.py
@@ -22,6 +22,7 @@ import os
 import torch
 import platform
 import warnings
+from bigdl.nano.utils.log4warning import register_suggestion
 
 
 if 'KMP_INIT_AT_FORK' in os.environ:
@@ -57,9 +58,10 @@ if platform.system() == "Linux":
             affinity_core_num = preset_thread_nums
 
     if preset_thread_nums > affinity_core_num:
-        # setting thread num will cause bug
-        # todo
-        pass
+        register_suggestion(f"CPU Affinity is set to this program and {affinity_core_num} "
+                            f"cores are binded. While OpenMP code block will use "
+                            f"{preset_thread_nums} cores, which may cause severe performance "
+                            f"downgrade. Please set `OMP_NUM_THREADS` to {affinity_core_num}.")
 
 from .dispatcher import patch_torch, unpatch_torch
 from bigdl.nano.pytorch.inference import InferenceOptimizer

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -227,7 +227,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                inference. This parameter only controls the usage of thread number in the process
                of latency calculation as well as later inference process of your obtained
                accelerated model. In other words, the process of model conversion and optional
-               accuracy calculation won't be restricted by this parameter.
+               accuracy calculation won't be restricted by this parameter. Defaults to None,
+               represents that all cores will be used.
         :param accelerator: (optional) A string tuple that specifys the accelerators to search.
                The optional accelerators are: None, 'openvino', 'onnxruntime', 'jit'.
                Defaults to None which represents there is no restriction on accelerators.

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -140,8 +140,12 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param direction: (optional) A string that indicates the higher/lower
                better for the metric, "min" for the lower the better and "max" for the
                higher the better. Default value is "max".
-        :param thread_num: (optional) a int represents how many threads(cores) is needed for
-               inference.
+        :param thread_num: (optional) An int represents how many threads(cores) is needed for
+               inference. This parameter only controls the usage of thread number in the process
+               of latency calculation as well as later inference process of your obtained
+               accelerated model. In other words, the process of model conversion and optional
+               accuracy calculation won't be restricted by this parameter. Defaults to None,
+               represents that all cores will be used.
         :param logging: whether to log detailed information of model conversion.
                Default: False.
         :param latency_sample_num: (optional) a int represents the number of repetitions


### PR DESCRIPTION
## Description

### 1. Why the change?
1. Add more information to `thread_num` of InferenceOptimizer (both pytorch and tensorflow)
2. Add warning message for affinity cores < openmp cores
3. Add guides for specific pytorch/tensorflow version support.

### 2. User API changes
nothing

### 3. Summary of the change 
code/document change, fairly straight forward.

### 4. How to test?
- [ ] Unit test
