### PR TITLE
Chronos: support quantization for keras forecasters

### DIFF
--- a/python/chronos/dev/test/run-installation-options.sh
+++ b/python/chronos/dev/test/run-installation-options.sh
@@ -42,6 +42,9 @@ python -m pytest -v -m "${OPTIONS}" test/bigdl/chronos/autots \
                                     test/bigdl/chronos/model \
                                     test/bigdl/chronos/pytorch \
                                     test/bigdl/chronos/simulator
+       -k "not test_tcn_keras_forecaster_quantization"
+python -m pytest -s test/bigdl/chronos/forecaster/tf/\
+test_tcn_keras_forecaster.py::TestTCNForecaster::test_tcn_keras_forecaster_quantization
 
 exit_status_0=$?
 if [ $exit_status_0 -ne 0 ];

--- a/python/chronos/dev/test/run-pytests.sh
+++ b/python/chronos/dev/test/run-pytests.sh
@@ -62,7 +62,10 @@ python -m pytest -v test/bigdl/chronos/forecaster \
            not TestChronosNBeatsForecaster and \
            not TestChronosModelSeq2SeqForecaster and \
            not TestChronosModelTCNForecaster and \
-           not test_forecast_tcmf_distributed"
+           not test_forecast_tcmf_distributed and \
+           not test_tcn_keras_forecaster_quantization"
+python -m pytest -s test/bigdl/chronos/forecaster/tf/\
+test_tcn_keras_forecaster.py::TestTCNForecaster::test_tcn_keras_forecaster_quantization
 exit_status_0=$?
 if [ $exit_status_0 -ne 0 ];
 then

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -40,10 +40,10 @@ class BaseTF2Forecaster(Forecaster):
                                                  backend=self.remote_distributed_backend)
         else:
             self.internal = self.model_creator({**self.model_config})
+            self.accelerated_model = None  # accelerated model obtained from various accelerators
+            self.accelerate_method = None  # str indicates current accelerate method
 
         self.fitted = False
-        self.accelerated_model = None  # accelerated model obtained from various accelerators
-        self.accelerate_method = None  # str indicates current accelerate method
 
     def fit(self, data, epochs=1, batch_size=32):
         """
@@ -504,6 +504,7 @@ class BaseTF2Forecaster(Forecaster):
                    input_feature_num=input_feature_num,
                    output_feature_num=output_feature_num,
                    **kwargs)
+
 
 def _str2metric(metric):
     # map metric str to function

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -215,8 +215,6 @@ class BaseTF2Forecaster(Forecaster):
             method = method[:-3]
         input_spec = tf.TensorSpec(shape=(None, self.model_config["past_seq_len"],
                                    self.model_config["input_feature_num"]))
-        input_shape = input_spec.shape
-        self.internal.compute_output_shape(input_shape)
         q_model = InferenceOptimizer.quantize(self.internal,
                                               x=input_data,
                                               y=target_data,

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -213,8 +213,10 @@ class BaseTF2Forecaster(Forecaster):
         else:
             accelerator = 'onnxruntime'
             method = method[:-3]
-        input_spec = input_spec=tf.TensorSpec(shape=(None, self.model_config["past_seq_len"],
-                                                     self.model_config["input_feature_num"]))
+        input_spec = tf.TensorSpec(shape=(None, self.model_config["past_seq_len"],
+                                   self.model_config["input_feature_num"]))
+        input_shape = input_spec.shape
+        self.internal.compute_output_shape(input_shape)
         q_model = InferenceOptimizer.quantize(self.internal,
                                               x=input_data,
                                               y=target_data,

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -113,7 +113,6 @@ class BaseTF2Forecaster(Forecaster):
 
     def quantize(self, input_data=None,
                  target_data=None,
-                 input_spec=None,
                  metric=None,
                  conf=None,
                  framework='tensorflow',
@@ -130,11 +129,13 @@ class BaseTF2Forecaster(Forecaster):
 
         :param input_data: Input data which is used for training. Support following formats:
 
-               | 1. a Numpy array (or array-like), or a list of arrays (in case the model
-               | has multiple inputs).
+               | 1. a numpy ndarray:
+               | The shape is (num_samples, lookback, feature_dim) where lookback and feature_dim
+               | should be the same as past_seq_len and input_feature_num.
                |
-               | 2. a TensorFlow tensor, or a list of tensors (in case the model has
-               | multiple inputs).
+               | 2. TensorFlow tensor:
+               | The shape is (num_samples, lookback, feature_dim) where lookback and feature_dim
+               | should be the same as past_seq_len and input_feature_num.
                |
                | 3. an unbatched tf.data.Dataset. Should return a tuple of (inputs, targets).
                |
@@ -145,8 +146,6 @@ class BaseTF2Forecaster(Forecaster):
         :param target_data: Target data. It could be either Numpy array(s) or TensorFlow tensor(s)
                while the length should be consistent with `input_data`.
                If `input_data` is dataset, `target_data` will be ignored.
-        :param input_spec: A (tuple or list of) tf.TensorSpec or numpy array defining the
-                           shape/dtype of the input.
         :param metric: A str represent the metrics for tunning the quality of
                quantization. You may choose from "mse", "mae", "rmse", "r2", "mape", "smape".
         :param conf: A path to conf yaml file for quantization. Default to None,
@@ -214,6 +213,8 @@ class BaseTF2Forecaster(Forecaster):
         else:
             accelerator = 'onnxruntime'
             method = method[:-3]
+        input_spec = input_spec=tf.TensorSpec(shape=(None, self.model_config["past_seq_len"],
+                                                     self.model_config["input_feature_num"]))
         q_model = InferenceOptimizer.quantize(self.internal,
                                               x=input_data,
                                               y=target_data,

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/tcn_forecaster.py
@@ -129,7 +129,7 @@ class TCNForecaster(BaseTF2Forecaster):
         # self.num_processes = max(1, current_num_threads//8)  # 8 is a magic num
         # self.use_ipex = False  # TCN has worse performance on ipex
         # self.onnx_available = True
-        # self.quantize_available = True
+        self.quantize_available = True
         # self.checkpoint_callback = False
 
         super().__init__()

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
@@ -252,5 +252,21 @@ class TestTCNForecaster(TestCase):
 
         stop_orca_context()
 
+    def test_tcn_forecaster_quantization(self):
+        train_data, _, test_data = create_data()
+        forecaster = TCNForecaster(past_seq_len=10,
+                                    future_seq_len=2,
+                                    input_feature_num=10,
+                                    output_feature_num=2)
+
+        forecaster.fit(train_data, epochs=1)
+        forecaster.quantize(input_data=train_data[0], target_data=train_data[1],
+                            input_spec=tf.TensorSpec(shape=(None, 10, 10), dtype=tf.float32))
+        assert forecaster.accelerated_model
+        assert forecaster.accelerate_method == "tensorflow_int8"
+        pred_q = forecaster.predict(test_data[0], quantize=True)
+        eval_q = forecaster.evaluate(test_data, quantize=True)
+        assert pred_q.shape == test_data[1].shape
+
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
@@ -262,8 +262,7 @@ class TestTCNForecaster(TestCase):
                                     output_feature_num=2)
 
         forecaster.fit(train_data, epochs=1)
-        forecaster.quantize(input_data=train_data[0], target_data=train_data[1],
-                            input_spec=tf.TensorSpec(shape=(None, 10, 10), dtype=tf.float32))
+        forecaster.quantize(input_data=train_data[0], target_data=train_data[1])
         assert forecaster.accelerated_model
         assert forecaster.accelerate_method == "tensorflow_int8"
         pred_q = forecaster.predict(test_data[0], quantize=True)

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
@@ -252,7 +252,9 @@ class TestTCNForecaster(TestCase):
 
         stop_orca_context()
 
-    def test_tcn_forecaster_quantization(self):
+    def test_tcn_keras_forecaster_quantization(self):
+        # Capturing behaviors during `pytest -v` influence generating the valid sampling log
+        # during quantization. Work around by using `pytest -s` to test this ut.
         train_data, _, test_data = create_data()
         forecaster = TCNForecaster(past_seq_len=10,
                                     future_seq_len=2,

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
@@ -257,9 +257,9 @@ class TestTCNForecaster(TestCase):
         # during quantization. Work around by using `pytest -s` to test this ut.
         train_data, _, test_data = create_data()
         forecaster = TCNForecaster(past_seq_len=10,
-                                    future_seq_len=2,
-                                    input_feature_num=10,
-                                    output_feature_num=2)
+                                   future_seq_len=2,
+                                   input_feature_num=10,
+                                   output_feature_num=2)
 
         forecaster.fit(train_data, epochs=1)
         forecaster.quantize(input_data=train_data[0], target_data=train_data[1])

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -618,7 +618,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
 
             saved_model_input_spec_set = model._saved_model_inputs_spec is not None
             if not model.built and not saved_model_input_spec_set or \
-                not hasattr(model, 'output_shape'):
+            not hasattr(model, 'output_shape'):
                 invalidInputError(input_spec is not None,
                                   "`input_spec` cannot be None when passing unbuilt model.")
                 # model cannot be saved either because the input shape is not available

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -617,7 +617,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 calib_dataset = calib_dataset.batch(batch)
 
             saved_model_input_spec_set = model._saved_model_inputs_spec is not None
-            if not model.built and not saved_model_input_spec_set:
+            if not model.built and not saved_model_input_spec_set or \
+                not hasattr(model, 'output_shape'):
                 invalidInputError(input_spec is not None,
                                   "`input_spec` cannot be None when passing unbuilt model.")
                 # model cannot be saved either because the input shape is not available

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -618,7 +618,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
 
             saved_model_input_spec_set = model._saved_model_inputs_spec is not None
             if not model.built and not saved_model_input_spec_set or \
-            not hasattr(model, 'output_shape'):
+                    not hasattr(model, 'output_shape'):
                 invalidInputError(input_spec is not None,
                                   "`input_spec` cannot be None when passing unbuilt model.")
                 # model cannot be saved either because the input shape is not available


### PR DESCRIPTION
## Description

Now, Nano upgrade INC to 2.0 and InferenceOptimizer also support custom model for keras INC.
Considering we only support quantization for pytorch forecasters, implement quantization for keras forecasters also.


### 2. User API changes

- a new API `quantization` for keras forecaster ()
```python
forecaster.quantize(input_data=train_data[0], target_data=train_data[1])
```
- a new parameter `quantize` in `predict` and `evaluate`
```python
def predict(self, data, batch_size=32, quantize=False)

def evaluate(self, data, batch_size=32, multioutput="raw_values", quantize=False)
```

### 3. Summary of the change 

- add `quantization`
- update `predict` and `evaluate` with a new parameter `quantize`
- enable TCN keras forecaster
- ut (**Note: capturing behaviors of `pytest -v` influence generating the valid sampling log during quantization. Work around by using `pytest -s` to test this ut.**)

### 4. How to test?
- [x] Unit test
