### PR TITLE
Orca: fix tf2 api issue

### DIFF
--- a/python/orca/src/bigdl/orca/data/image/imagenet_dataset.py
+++ b/python/orca/src/bigdl/orca/data/image/imagenet_dataset.py
@@ -41,12 +41,6 @@ import threading
 import numpy as np
 from bigdl.dllib.utils.log4Error import invalidInputError
 
-try:
-    from tensorflow.gfile import Glob, Exists, MakeDirs, FastGFile as GFile
-except:
-    # tensorflow 2.0 changes the api
-    from tensorflow.io.gfile import glob as Glob, exists as Exists, makedirs as MakeDirs, GFile
-
 if TYPE_CHECKING:
     from numpy import ndarray
     import tensorflow as tf
@@ -66,6 +60,7 @@ def convert_imagenet_to_tf_records(
         raw_data_dir: str,
         output_dir: str) -> None:
     """Converts the Imagenet dataset into TF-Record dumps."""
+    import tensorflow as tf
     # Shuffle training records to ensure we are distributing classes
     # across the batches.
     random.seed(0)
@@ -76,7 +71,7 @@ def convert_imagenet_to_tf_records(
         return order
 
     # Glob all the training files
-    training_files = Glob(
+    training_files = tf.io.gfile.glob(
         os.path.join(raw_data_dir, TRAINING_DIRECTORY, '*', '*.JPEG'))
 
     # Get training file synset labels from the directory name
@@ -89,11 +84,11 @@ def convert_imagenet_to_tf_records(
     training_synsets = [training_synsets[i] for i in training_shuffle_idx]
 
     # Glob all the validation files
-    validation_files = sorted(Glob(
+    validation_files = sorted(tf.io.gfile.glob(
         os.path.join(raw_data_dir, VALIDATION_DIRECTORY, '*.JPEG')))
 
     # Get validation file synset labels from labels.txt
-    validation_synsets = GFile(
+    validation_synsets = tf.io.gfile.GFile(
         os.path.join(raw_data_dir, VALIDATION_LABELS), 'rb').read().splitlines()
 
     # Create unique ids for all synsets
@@ -209,8 +204,9 @@ def _process_image(
     width: integer, image width in pixels.
 
     """
+    import tensorflow as tf
     # Read the image file.
-    with GFile(filename, 'rb') as f:
+    with tf.io.gfile.GFile(filename, 'rb') as f:
         image_data = f.read()
 
     # Clean the dirty data.
@@ -267,8 +263,9 @@ def _process_image_files_batch(
 
 def _check_or_create_dir(directory: str) -> None:
     """Checks if directory exists otherwise creates it."""
-    if not Exists(directory):
-        MakeDirs(directory)
+    import tensorflow as tf
+    if not tf.io.gfile.exists(directory):
+        tf.io.gfile.makedirs(directory)
 
 
 def _int64_feature(value: Union[int, Iterable[int]]) -> "Feature":

--- a/python/orca/src/bigdl/orca/data/image/imagenet_dataset.py
+++ b/python/orca/src/bigdl/orca/data/image/imagenet_dataset.py
@@ -41,6 +41,12 @@ import threading
 import numpy as np
 from bigdl.dllib.utils.log4Error import invalidInputError
 
+try:
+    from tensorflow.gfile import Glob, Exists, MakeDirs, FastGFile as GFile
+except:
+    # tensorflow 2.0 changes the api
+    from tensorflow.io.gfile import glob as Glob, exists as Exists, makedirs as MakeDirs, GFile
+
 if TYPE_CHECKING:
     from numpy import ndarray
     import tensorflow as tf
@@ -60,7 +66,6 @@ def convert_imagenet_to_tf_records(
         raw_data_dir: str,
         output_dir: str) -> None:
     """Converts the Imagenet dataset into TF-Record dumps."""
-    import tensorflow as tf
     # Shuffle training records to ensure we are distributing classes
     # across the batches.
     random.seed(0)
@@ -71,7 +76,7 @@ def convert_imagenet_to_tf_records(
         return order
 
     # Glob all the training files
-    training_files = tf.gfile.Glob(
+    training_files = Glob(
         os.path.join(raw_data_dir, TRAINING_DIRECTORY, '*', '*.JPEG'))
 
     # Get training file synset labels from the directory name
@@ -84,11 +89,11 @@ def convert_imagenet_to_tf_records(
     training_synsets = [training_synsets[i] for i in training_shuffle_idx]
 
     # Glob all the validation files
-    validation_files = sorted(tf.gfile.Glob(
+    validation_files = sorted(Glob(
         os.path.join(raw_data_dir, VALIDATION_DIRECTORY, '*.JPEG')))
 
     # Get validation file synset labels from labels.txt
-    validation_synsets = tf.gfile.FastGFile(
+    validation_synsets = GFile(
         os.path.join(raw_data_dir, VALIDATION_LABELS), 'rb').read().splitlines()
 
     # Create unique ids for all synsets
@@ -204,9 +209,8 @@ def _process_image(
     width: integer, image width in pixels.
 
     """
-    import tensorflow as tf
     # Read the image file.
-    with tf.gfile.FastGFile(filename, 'rb') as f:
+    with GFile(filename, 'rb') as f:
         image_data = f.read()
 
     # Clean the dirty data.
@@ -262,10 +266,9 @@ def _process_image_files_batch(
 
 
 def _check_or_create_dir(directory: str) -> None:
-    import tensorflow as tf
     """Checks if directory exists otherwise creates it."""
-    if not tf.gfile.Exists(directory):
-        tf.gfile.MakeDirs(directory)
+    if not Exists(directory):
+        MakeDirs(directory)
 
 
 def _int64_feature(value: Union[int, Iterable[int]]) -> "Feature":

--- a/python/orca/src/bigdl/orca/data/image/imagenet_dataset.py
+++ b/python/orca/src/bigdl/orca/data/image/imagenet_dataset.py
@@ -262,8 +262,8 @@ def _process_image_files_batch(
 
 
 def _check_or_create_dir(directory: str) -> None:
-    """Checks if directory exists otherwise creates it."""
     import tensorflow as tf
+    """Checks if directory exists otherwise creates it."""
     if not tf.io.gfile.exists(directory):
         tf.io.gfile.makedirs(directory)
 


### PR DESCRIPTION
## Description


### 1. Why the change?

TensorFlow 2.0 + removes the api `gfile` and thus this python sciprt cannot run under `tf 2.9.0`. This PR makes the python script compatible to both tf1 and tf2.

API changes include:
+ `tf.gfile.FastGFile` -> `tf.io.gfile.GFile` [what-is-difference-between-tf-gfile-gfile-and-tf-gfile-fastgfile](https://stackoverflow.com/questions/45904463/what-is-difference-between-tf-gfile-gfile-and-tf-gfile-fastgfile)
+ `tf.gfile.Glob` -> `tf.io.gfile.glob`
+ `tf.gfile.Exists` -> `tf.io.gfile.exists`
+ `tf.gfile.MakeDirs` -> `tf.io.gfile.makedirs`

**More APIs need be changed**:

+ `tf.placeholder`(tf1 only) -> `tf.compat.v1.placeholder`(tf2 only) https://github.com/intel-analytics/BigDL/actions/runs/4062624774/jobs/6993962769
+ `tf.Session()`(tf1 only) -> `tf.compat.v1.Session()` (tf2 only)
+ `tf.python_io`(tf1 only) -> `tf.compat.v1.python_io` (compatible to both tf1 and tf2)

reference:
+ [tf 2.11.0 io.gfile document](https://www.tensorflow.org/api_docs/python/tf/io/gfile)
+ [tf 1.15.0 io.gfile document](https://www.tensorflow.org/versions/r1.15/api_docs/python/tf/io/gfile)
+ [tf 1.15.0 gfile document](https://www.tensorflow.org/versions/r1.15/api_docs/python/tf/gfile)
<!-- Provide the related github issue link if available -->


### 2. How to test?
- [x] tf 1.15.0 test https://github.com/intel-analytics/BigDL/actions/runs/4061377661/jobs/6992639522
- [ ] tf 2.9.0 test https://github.com/intel-analytics/BigDL/actions/runs/4062624774/jobs/6993962769 ❎ 


