### PR TITLE
Nano: fix keras traced/quantized model evaluate

### DIFF
--- a/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/tensorflow_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/tensorflow_onnxruntime_model.py
@@ -61,6 +61,8 @@ class KerasONNXRuntimeModel(ONNXRuntimeModel, AcceleratedKerasModel):
                     self._output_shape = model.compute_output_shape((i.shape for i in input_spec))
                 else:
                     self._output_shape = model.compute_output_shape(input_spec.shape)
+                while isinstance(self._output_shape, list) and len(self._output_shape) == 1:
+                    self._output_shape = self._output_shape[0]
                 if not isinstance(input_spec, (tuple, list)):
                     input_spec = (input_spec, )
                 tf2onnx.convert.from_keras(model, input_signature=input_spec,

--- a/python/nano/src/bigdl/nano/utils/inference/tf/model.py
+++ b/python/nano/src/bigdl/nano/utils/inference/tf/model.py
@@ -42,7 +42,10 @@ class AcceleratedKerasModel(AcceleratedModel, tf.keras.Model):
         return super().__call__(*args, **kwds)
 
     def call(self, *inputs):
-        return tf.py_function(self.forward, inputs, Tout=self.precision)
+        output = tf.py_function(self.forward, inputs, Tout=self.precision)
+        if hasattr(self, "_output_shape") and self._output_shape is not None:
+            output.set_shape(self._output_shape)
+        return output
 
     def forward(self, *inputs):
         inputs = self.on_forward_start(inputs)


### PR DESCRIPTION
## Description

Nano: fix keras traced/quantized model's `evaluate` method

### 1. Why the change?

When using `CategoricalAccuracy` as metric, calling `evaluate` will raise error.

### 2. User API changes

N/A

### 3. Summary of the change 

- `tf.py_function` will loss the shape info of the returned Tensor. We first save the shape of output, and using `set_shape` method to recover the shape info of the Tensor returned by `tf.py_function`.
- Add more test about `evaluate` method.

### 4. How to test?
- [x] Unit test
