### PR TITLE
[WIP] [PPML] Enroll and policy in BigDL Remote Attestation Service

### DIFF
--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/attestation/BigDLRemoteAttestationService.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/attestation/BigDLRemoteAttestationService.scala
@@ -16,8 +16,12 @@
 package com.intel.analytics.bigdl.ppml.attestation
 
 import java.util.concurrent.{LinkedBlockingQueue, TimeUnit}
-import java.io.{File, InputStream}
+import java.io.{File, InputStream, PrintWriter}
+import java.io.{FileInputStream, FileOutputStream, ObjectInputStream, ObjectOutputStream}
+import java.io.{BufferedOutputStream, BufferedInputStream};
 import java.security.{KeyStore, SecureRandom}
+import javax.crypto.{Cipher, SecretKey, SecretKeyFactory}
+import javax.crypto.spec.{PBEKeySpec, SecretKeySpec}
 import javax.net.ssl.{KeyManagerFactory, SSLContext, TrustManagerFactory}
 import java.util.Base64
 
@@ -33,9 +37,13 @@ import akka.util.Timeout
 import akka.http.scaladsl.marshallers.sprayjson.SprayJsonSupport._
 import spray.json.DefaultJsonProtocol._
 
-import scala.io.StdIn
+import scala.io.{Source, StdIn}
+import scala.util.Random
+import scala.util.parsing.json._
 
-import scala.concurrent.Future
+import scala.concurrent.{Await, Future}
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
 
 import org.apache.logging.log4j.LogManager
 import scopt.OptionParser
@@ -57,6 +65,87 @@ object BigDLRemoteAttestationService {
 
   val quoteVerifier = new SGXDCAPQuoteVerifierImpl()
 
+  private val salt = Array[Byte](0,1,2,3,4,5,6,7)
+  private val iterations = 65536
+  private val keySize = 256
+  private val secretKey = "password"
+  private val algorithm = "PBKDF2WithHmacSHA256"
+
+  def encrypt(data: Array[Byte]): Array[Byte] = {
+    val factory = SecretKeyFactory.getInstance(algorithm)
+    val spec = new PBEKeySpec(secretKey.toCharArray, salt, iterations, keySize)
+    val key = factory.generateSecret(spec).getEncoded()
+    val keySpec = new SecretKeySpec(key, "AES")
+
+    val cipher = Cipher.getInstance("AES/ECB/PKCS5Padding")
+    cipher.init(Cipher.ENCRYPT_MODE, keySpec)
+    cipher.doFinal(data)
+  }
+
+  def decrypt(encryptedData: Array[Byte]): Array[Byte] = {
+    val factory = SecretKeyFactory.getInstance(algorithm)
+    val spec = new PBEKeySpec(secretKey.toCharArray, salt, iterations, keySize)
+    val key = factory.generateSecret(spec).getEncoded()
+    val keySpec = new SecretKeySpec(key, "AES")
+
+    val cipher = Cipher.getInstance("AES/ECB/PKCS5Padding")
+    cipher.init(Cipher.DECRYPT_MODE, keySpec)
+    cipher.doFinal(encryptedData)
+  }
+
+  def saveFile(filename: String, content: String): Future[Unit] = Future {
+    val file = new File(filename)
+    if (!file.exists()){
+      file.createNewFile()
+    }
+    val encryptedContent = encrypt(content.getBytes("UTF-8"))
+    val out = new BufferedOutputStream(new FileOutputStream(file))
+    out.write(encryptedContent)
+    out.close()
+      
+    // val outputStream = new FileOutputStream(file)
+    // val objectOutputStream = new ObjectOutputStream(outputStream)
+    // val encryptedContent = encrypt(content.getBytes("UTF-8"))
+    // // objectOutputStream.writeObject(encryptedContent)
+    // objectOutputStream.writeObject(content.getBytes("UTF-8"))
+    // objectOutputStream.close()
+    // outputStream.close()
+  }
+
+  def loadFile(filename: String): Future[String] = Future {
+    val file = new File(filename)
+    if (!file.exists()){
+      ""
+    } else {
+      // val inputStream = new FileInputStream(file)
+      // val objectInputStream = new ObjectInputStream(inputStream)
+      // val encryptedContent = objectInputStream.readObject().asInstanceOf[Array[Byte]]
+      // val decryptedContent = new String(decrypt(encryptedContent), "UTF-8")
+      // objectInputStream.close()
+      // inputStream.close()
+      // decryptedContent
+
+      val in = new FileInputStream(file)
+      val bufIn = new BufferedInputStream(in)
+      val encryptedContent = Iterator.continually(bufIn.read()).takeWhile(_ != -1).map(_.toByte).toArray
+      bufIn.close()
+      in.close()
+      val decryptedContent = new String(decrypt(encryptedContent), "UTF-8")
+      decryptedContent
+    }
+  }
+
+  def mapToString(map: Map[String, Any]): String = {
+    JSONObject(map).toString()
+  }
+
+  def stringToMap(str: String): Map[String, Any] = {
+    JSON.parseFull(str) match {
+      case Some(map: Map[String, Any]) => map
+      case None => Map.empty
+    }
+  }
+
   def main(args: Array[String]): Unit = {
 
     val logger = LogManager.getLogger(getClass)
@@ -64,7 +153,8 @@ object BigDLRemoteAttestationService {
                           servicePort: String = "9875",
                           httpsKeyStoreToken: String = "token",
                           httpsKeyStorePath: String = "./key",
-                          httpsEnabled: Boolean = false
+                          httpsEnabled: Boolean = false,
+                          filepath: String = "./BigDLRemoteAttestationService.dat"
                           )
 
     val cmdParser : OptionParser[CmdParams] =
@@ -93,6 +183,21 @@ object BigDLRemoteAttestationService {
             val res = s"Welcome to BigDL Remote Attestation Service \n \n" +
             "verify your quote like: " +
             "POST <bigdl_remote_attestation_address>/verifyQuote \n"
+            complete(res)
+          } ~
+          path("enroll") {
+            var app_id = Random.alphanumeric.take(12).mkString
+            var api_key = Random.alphanumeric.take(16).mkString
+            val filepath = params.filepath
+            val content = Await.result(loadFile(filepath), 5.seconds)
+            var map = stringToMap(content)
+            while (map.contains(app_id)) {
+              app_id = Random.alphanumeric.take(12).mkString
+              api_key = Random.alphanumeric.take(20).mkString
+            }
+            map += (app_id -> api_key)
+            saveFile(filepath, mapToString(map))
+            val res = "{\"app_id\":\"" + app_id + ",\"api_key\":\"" + api_key + "\"}"
             complete(res)
           }
         } ~

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/attestation/BigDLRemoteAttestationService.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/attestation/BigDLRemoteAttestationService.scala
@@ -182,8 +182,8 @@ object BigDLRemoteAttestationService {
             complete(res)
           } ~
           path("enroll") {
-            var app_id = Random.alphanumeric.take(12).mkString
-            var api_key = Random.alphanumeric.take(16).mkString
+            var app_id = Random.alphanumeric.take(32).mkString
+            var api_key = Random.alphanumeric.take(32).mkString
             val basePath = params.basePath
             val userContent = Await.result(loadFile(basePath), 5.seconds)
             var userMap = stringToMap(userContent)


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

Add `enroll` and `registePolicy` methods, and check policy when `policy_id` is not empty for `verifyQuote`.
Save account information in `basePath` and policy information in `policyPath`, encrypted with `secretKey`.

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

