### PR TITLE
Chronos: init bigdl-nano in nightly tests

### DIFF
--- a/.github/workflows/chronos-install-option-py38-test.yml
+++ b/.github/workflows/chronos-install-option-py38-test.yml
@@ -49,7 +49,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch]
-          pip install numpy==1.23.5
+          source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "torch and not inference and not automl and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-py38-env -y --all
@@ -87,6 +87,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[tensorflow]
+          source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "tf2 and not inference and not automl and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-py38-env -y --all
@@ -124,6 +125,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch,inference]
+          source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "torch and not automl and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-py38-env -y --all
@@ -161,7 +163,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch,inference,automl]
-          pip install SQLAlchemy==1.4.27
+          source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "torch and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-py38-env -y --all

--- a/.github/workflows/chronos-nb-python-2.4-py37.yml
+++ b/.github/workflows/chronos-nb-python-2.4-py37.yml
@@ -48,7 +48,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch]
-          # source bigdl-nano-init
+          source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "torch and not inference and not automl and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-nb-env-py37 -y --all
@@ -101,7 +101,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch,inference]
-          # source bigdl-nano-init
+          source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "torch and not automl and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-nb-env-py37 -y --all
@@ -153,7 +153,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch,inference,automl]
-          # source bigdl-nano-init
+          source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "torch and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-nb-env-py37 -y --all
@@ -207,7 +207,7 @@ jobs:
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch,inference,automl,distributed]
           export SPARK_LOCAL_HOSTNAME=localhost
           export KERAS_BACKEND=tensorflow
-          # source bigdl-nano-init
+          source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "torch and not automl and not diff_set_all"
           source deactivate
           conda remove -n chronos-nb-env-py37 -y --all

--- a/.github/workflows/chronos-nb-python-2.4-py37.yml
+++ b/.github/workflows/chronos-nb-python-2.4-py37.yml
@@ -48,6 +48,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch]
+          source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "torch and not inference and not automl and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-nb-env-py37 -y --all
@@ -100,6 +101,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch,inference]
+          source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "torch and not automl and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-nb-env-py37 -y --all
@@ -151,7 +153,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch,inference,automl]
-          pip install SQLAlchemy==1.4.27
+          source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "torch and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-nb-env-py37 -y --all
@@ -205,6 +207,7 @@ jobs:
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch,inference,automl,distributed]
           export SPARK_LOCAL_HOSTNAME=localhost
           export KERAS_BACKEND=tensorflow
+          source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "torch and not automl and not diff_set_all"
           source deactivate
           conda remove -n chronos-nb-env-py37 -y --all

--- a/.github/workflows/chronos-nb-python-2.4-py37.yml
+++ b/.github/workflows/chronos-nb-python-2.4-py37.yml
@@ -48,7 +48,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch]
-          source bigdl-nano-init
+          # source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "torch and not inference and not automl and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-nb-env-py37 -y --all
@@ -101,7 +101,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch,inference]
-          source bigdl-nano-init
+          # source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "torch and not automl and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-nb-env-py37 -y --all
@@ -153,7 +153,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch,inference,automl]
-          source bigdl-nano-init
+          # source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "torch and not distributed and not diff_set_all"
           source deactivate
           conda remove -n chronos-nb-env-py37 -y --all
@@ -207,7 +207,7 @@ jobs:
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos[pytorch,inference,automl,distributed]
           export SPARK_LOCAL_HOSTNAME=localhost
           export KERAS_BACKEND=tensorflow
-          source bigdl-nano-init
+          # source bigdl-nano-init
           bash python/chronos/dev/test/run-installation-options.sh "torch and not automl and not diff_set_all"
           source deactivate
           conda remove -n chronos-nb-env-py37 -y --all

--- a/python/chronos/dev/test/run-installation-options.sh
+++ b/python/chronos/dev/test/run-installation-options.sh
@@ -21,6 +21,8 @@ cd ../..
 
 export PYSPARK_PYTHON=python
 export PYSPARK_DRIVER_PYTHON=python
+echo "test output"
+echo "${OMP_NUM_THREADS}"
 if [ -z "${OMP_NUM_THREADS}" ]; then
     export OMP_NUM_THREADS=1
 fi

--- a/python/chronos/dev/test/run-installation-options.sh
+++ b/python/chronos/dev/test/run-installation-options.sh
@@ -23,6 +23,8 @@ export PYSPARK_PYTHON=python
 export PYSPARK_DRIVER_PYTHON=python
 echo "test output1"
 echo "${OMP_NUM_THREADS}"
+export OMP_NUM_THREADS=1
+echo "${OMP_NUM_THREADS}"
 if [ -z "${OMP_NUM_THREADS}" ]; then
     export OMP_NUM_THREADS=1
     echo "test output2"

--- a/python/chronos/dev/test/run-installation-options.sh
+++ b/python/chronos/dev/test/run-installation-options.sh
@@ -26,6 +26,8 @@ if [ -z "${OMP_NUM_THREADS}" ]; then
 fi
 
 unset MALLOC_CONF
+unset KMP_AFFINITY
+unset OMP_NUM_THREADS
 
 # ray stop -f
 

--- a/python/chronos/dev/test/run-installation-options.sh
+++ b/python/chronos/dev/test/run-installation-options.sh
@@ -21,13 +21,14 @@ cd ../..
 
 export PYSPARK_PYTHON=python
 export PYSPARK_DRIVER_PYTHON=python
+
+# If init bigdl-nano, unset `MALLOC_CONF` and `OMP_NUM_THREADS` to avoid process kill
+unset MALLOC_CONF
+unset OMP_NUM_THREADS
+
 if [ -z "${OMP_NUM_THREADS}" ]; then
     export OMP_NUM_THREADS=1
 fi
-
-unset MALLOC_CONF
-export OMP_NUM_THREADS=2
-# unset OMP_NUM_THREADS
 
 # ray stop -f
 

--- a/python/chronos/dev/test/run-installation-options.sh
+++ b/python/chronos/dev/test/run-installation-options.sh
@@ -21,15 +21,11 @@ cd ../..
 
 export PYSPARK_PYTHON=python
 export PYSPARK_DRIVER_PYTHON=python
-echo "test output1"
-echo "${OMP_NUM_THREADS}"
-export OMP_NUM_THREADS=1
-echo "${OMP_NUM_THREADS}"
 if [ -z "${OMP_NUM_THREADS}" ]; then
     export OMP_NUM_THREADS=1
-    echo "test output2"
-    echo "${OMP_NUM_THREADS}"
 fi
+
+unset MALLOC_CONF
 
 # ray stop -f
 

--- a/python/chronos/dev/test/run-installation-options.sh
+++ b/python/chronos/dev/test/run-installation-options.sh
@@ -26,8 +26,7 @@ if [ -z "${OMP_NUM_THREADS}" ]; then
 fi
 
 unset MALLOC_CONF
-export OMP_NUM_THREADS=1
-# unset KMP_AFFINITY
+export OMP_NUM_THREADS=2
 # unset OMP_NUM_THREADS
 
 # ray stop -f

--- a/python/chronos/dev/test/run-installation-options.sh
+++ b/python/chronos/dev/test/run-installation-options.sh
@@ -26,7 +26,8 @@ if [ -z "${OMP_NUM_THREADS}" ]; then
 fi
 
 unset MALLOC_CONF
-unset KMP_AFFINITY
+export OMP_NUM_THREADS=1
+# unset KMP_AFFINITY
 # unset OMP_NUM_THREADS
 
 # ray stop -f

--- a/python/chronos/dev/test/run-installation-options.sh
+++ b/python/chronos/dev/test/run-installation-options.sh
@@ -27,7 +27,7 @@ fi
 
 unset MALLOC_CONF
 unset KMP_AFFINITY
-unset OMP_NUM_THREADS
+# unset OMP_NUM_THREADS
 
 # ray stop -f
 

--- a/python/chronos/dev/test/run-installation-options.sh
+++ b/python/chronos/dev/test/run-installation-options.sh
@@ -21,10 +21,12 @@ cd ../..
 
 export PYSPARK_PYTHON=python
 export PYSPARK_DRIVER_PYTHON=python
-echo "test output"
+echo "test output1"
 echo "${OMP_NUM_THREADS}"
 if [ -z "${OMP_NUM_THREADS}" ]; then
     export OMP_NUM_THREADS=1
+    echo "test output2"
+    echo "${OMP_NUM_THREADS}"
 fi
 
 # ray stop -f

--- a/python/chronos/test/bigdl/chronos/detector/anomaly/test_th_detector.py
+++ b/python/chronos/test/bigdl/chronos/detector/anomaly/test_th_detector.py
@@ -79,7 +79,7 @@ class TestThresholdDetector(TestCase):
                                     output_feature_num=1,
                                     hidden_dim=32,
                                     layer_num=2)
-        forecaster.fit(data=(x_train, y_train), batch_size=1024, epochs=50)
+        forecaster.fit(data=(x_train, y_train), batch_size=1024, epochs=5)
         y_predict = forecaster.predict(x_test, acceleration=False)
         y_predict = np.squeeze(y_predict, axis=1)
 


### PR DESCRIPTION
## Description

For most users, it's common to use `source bigdl-nano-init` to enable local accelerations.
Test this in nightly tests.
Besides, remove unnecessary dependencies in nightly tests.

### 4. How to test?
- [x] Unit test
