### PR TITLE
Chronos: add better document for `space.Categorical` and `SamplerType.Grid`

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -148,7 +148,10 @@ class BasePytorchForecaster(Forecaster):
             effect if target_metric contains "latency". Default value is False.
         :param input_sample: A set of inputs for trace, defaults to None if you have
             trace before or model is a LightningModule with any dataloader attached.
+        :param kwargs: some other parameters could be used for tuning, most useful one is
+               `sampler` from SamplerType.Grid, SamplerType.Random and SamplerType.TPE so on.
         """
+
         invalidInputError(not self.distributed,
                           "HPO is not supported in distributed mode."
                           "Please use AutoTS instead.")

--- a/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
+++ b/python/nano/src/bigdl/nano/automl/pytorch/hposearcher.py
@@ -156,6 +156,11 @@ class HPOSearcher:
         _sampler_kwargs.update(user_sampler_kwargs)
         if "sampler" in kwargs and kwargs["sampler"] in [SamplerType.Grid]:
             search_kwargs["sampler_kwargs"] = _sampler_kwargs
+            # Following condition will be met when user state non-catagory problem
+            invalidInputError(len(model._lazyobj.kwspaces_) <= len(_sampler_kwargs),
+                              "Only `space.Categorical` is supported for `SamplerType.Grid` "
+                              "sampler. Please try replace other space to `space.Categorical` "
+                              "or use another SamplerType.")
 
         (self.create_kwargs, self.run_kwargs, self.fit_kwargs) \
             = _prepare_args(search_kwargs,


### PR DESCRIPTION
## Description

### 1. Why the change?
#7416 raised a good problem since users may be confused by the usage of `space.Categorical` and `SamplerType.Grid`.

### 2. User API changes
nothing, more explanation will be replied to $7416

### 3. Summary of the change 
1. Add API doc for `sampler` in `forecaster.tune`
2. Add better warning message for wrong usage of `space.Categorical` and `SamplerType.Grid`.

### 4. How to test?
- [ ] Unit test