### PR TITLE
Nano: add auto channels_last_3d support

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -69,7 +69,10 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             self.jit_method = jit_method
             self.weights_prepack = weights_prepack
             if self.channels_last:
-                self.model = self.model.to(memory_format=torch.channels_last)
+                try:
+                    self.model = self.model.to(memory_format=torch.channels_last)
+                except Exception as _e:
+                    self.model = self.model.to(memory_format=torch.channels_last_3d)
                 self.channels_last_available = channels_last_available
             self.enable_onednn = enable_onednn
             _accelerator = "jit" if use_jit is True else None
@@ -87,7 +90,10 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         self.weights_prepack = weights_prepack
         self.original_model = model
         if self.channels_last:
-            self.model = self.model.to(memory_format=torch.channels_last)
+            try:
+                self.model = self.model.to(memory_format=torch.channels_last)
+            except Exception as _e:
+                self.model = self.model.to(memory_format=torch.channels_last_3d)
             if channels_last_available:  # init from _load, the channels_last_available is not none
                 self.channels_last_available = channels_last_available
             else:
@@ -150,17 +156,19 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         return inputs
 
     def forward_step(self, *inputs):
-
-        if self.channels_last is True:
-            if self.channels_last_available:
-                for idx, input in enumerate(inputs):
-                    if self.channels_last_available[idx]:
-                        input.to(memory_format=torch.channels_last)
-            else:
+        if self.channels_last:
+            # generate channels_last_available list is possible
+            # this won't affect inference latency much since it will only run 1 time
+            if not self.channels_last_available:
                 self.channels_last_available = generate_channels_last_available(inputs)
-                for idx, input in enumerate(inputs):
-                    if self.channels_last_available[idx]:
-                        input.to(memory_format=torch.channels_last)
+
+            # change the data to suitable mem format
+            for idx, input in enumerate(inputs):
+                if self.channels_last_available[idx] == "channels_last":
+                    input.to(memory_format=torch.channels_last)
+                if self.channels_last_available[idx] == "channels_last_3d":
+                    input.to(memory_format=torch.channels_last_3d)
+
         return self.model(*inputs)
 
     def on_forward_end(self, outputs):

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -14,7 +14,8 @@
 # limitations under the License.
 #
 
-from bigdl.nano.utils.pytorch import generate_channels_last_available
+from bigdl.nano.utils.pytorch import generate_channels_last_available,\
+    apply_proper_channels_last
 from bigdl.nano.pytorch.model import AcceleratedLightningModule
 from bigdl.nano.pytorch.context_manager import generate_context_manager
 from bigdl.nano.deps.ipex.ipex_api import ipex_optimize
@@ -163,11 +164,9 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                 self.channels_last_available = generate_channels_last_available(inputs)
 
             # change the data to suitable mem format
-            for idx, input in enumerate(inputs):
-                if self.channels_last_available[idx] == "channels_last":
-                    input = input.to(memory_format=torch.channels_last)
-                if self.channels_last_available[idx] == "channels_last_3d":
-                    input = input.to(memory_format=torch.channels_last_3d)
+            inputs = tuple(map(lambda item: apply_proper_channels_last(
+                self.channels_last_available[item[0]], item[1]),
+                enumerate(inputs)))
 
         return self.model(*inputs)
 

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -165,9 +165,9 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
             # change the data to suitable mem format
             for idx, input in enumerate(inputs):
                 if self.channels_last_available[idx] == "channels_last":
-                    input.to(memory_format=torch.channels_last)
+                    input = input.to(memory_format=torch.channels_last)
                 if self.channels_last_available[idx] == "channels_last_3d":
-                    input.to(memory_format=torch.channels_last_3d)
+                    input = input.to(memory_format=torch.channels_last_3d)
 
         return self.model(*inputs)
 

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -126,9 +126,9 @@ class BF16Model(AcceleratedLightningModule):
             # change the data to suitable mem format
             for idx, input in enumerate(inputs):
                 if self.channels_last_available[idx] == "channels_last":
-                    input.to(memory_format=torch.channels_last)
+                    input = input.to(memory_format=torch.channels_last)
                 if self.channels_last_available[idx] == "channels_last_3d":
-                    input.to(memory_format=torch.channels_last_3d)
+                    input = input.to(memory_format=torch.channels_last_3d)
 
         return self.model(*inputs)
 

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -18,7 +18,8 @@
 from logging import warning
 import torch
 import os
-from bigdl.nano.utils.pytorch import generate_channels_last_available
+from bigdl.nano.utils.pytorch import generate_channels_last_available,\
+    apply_proper_channels_last
 from bigdl.nano.pytorch.model import AcceleratedLightningModule
 from bigdl.nano.utils.common import invalidInputError
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10, TORCH_VERSION_LESS_1_12

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -50,7 +50,10 @@ class BF16Model(AcceleratedLightningModule):
         self.channels_last = channels_last
         self.thread_num = thread_num
         if self.channels_last is True:
-            self.model = self.model.to(memory_format=torch.channels_last)
+            try:
+                self.model = self.model.to(memory_format=torch.channels_last)
+            except Exception as _e:
+                self.model = self.model.to(memory_format=torch.channels_last_3d)
             if channels_last_available:  # init from load
                 self.channels_last_available = channels_last_available
             else:  # init without channels_last_available loaded

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -124,11 +124,9 @@ class BF16Model(AcceleratedLightningModule):
                 self.channels_last_available = generate_channels_last_available(inputs)
 
             # change the data to suitable mem format
-            for idx, input in enumerate(inputs):
-                if self.channels_last_available[idx] == "channels_last":
-                    input = input.to(memory_format=torch.channels_last)
-                if self.channels_last_available[idx] == "channels_last_3d":
-                    input = input.to(memory_format=torch.channels_last_3d)
+            inputs = tuple(map(lambda item: apply_proper_channels_last(
+                self.channels_last_available[item[0]], item[1]),
+                enumerate(inputs)))
 
         return self.model(*inputs)
 

--- a/python/nano/src/bigdl/nano/utils/pytorch/__init__.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/__init__.py
@@ -15,7 +15,8 @@
 #
 
 
-from .channel_last import generate_channels_last_available
+from .channel_last import generate_channels_last_available,\
+    apply_proper_channels_last
 
 from .dataset import RepeatDataset
 from .dataset import remove_batch_dim_fn

--- a/python/nano/src/bigdl/nano/utils/pytorch/channel_last.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/channel_last.py
@@ -28,7 +28,9 @@ def generate_channels_last_available(inputs):
     no change: "original"
     '''
     # try channels_last available
-    if inputs:  # to avoid the situation of inputs == None
+    if inputs is not None:  # to avoid the situation of inputs == None
+        if isinstance(inputs, torch.Tensor):
+            inputs = tuple([inputs])  # make it an tuple for later process
         channels_last_available = ["original"] * len(inputs)
         for idx, input in enumerate(inputs):
             try:
@@ -43,3 +45,19 @@ def generate_channels_last_available(inputs):
     else:
         channels_last_available = []
     return channels_last_available
+
+
+def apply_proper_channels_last(flag, input_item):
+    '''
+    This function will apply proper channes_last to
+    input item. flag has 3 possible values:
+
+    channel_last: "channel_last"
+    channel_last_3d: "channel_last_3d"
+    no change: "original"
+    '''
+    if flag == "channels_last":
+        return input_item.to(memory_format=torch.channels_last)
+    if flag == "channels_last_3d":
+        return input_item.to(memory_format=torch.channels_last_3d)
+    return input_item

--- a/python/nano/src/bigdl/nano/utils/pytorch/channel_last.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/channel_last.py
@@ -20,21 +20,26 @@ import torch
 
 def generate_channels_last_available(inputs):
     '''
-    This function will generate a list of true and false to decide if the
-    elements of input can be converted to channels_last
+    This function will generate a list of string to decide if the
+    elements of input can be converted to
+
+    channel_last: "channel_last"
+    channel_last_3d: "channel_last_3d"
+    no change: "original"
     '''
     # try channels_last available
-    if isinstance(inputs, torch.Tensor):
-        inputs = [inputs]
-    if inputs is not None:  # to avoid the situation of inputs == None
-        channels_last_available = [True] * len(inputs)
+    if inputs:  # to avoid the situation of inputs == None
+        channels_last_available = ["original"] * len(inputs)
         for idx, input in enumerate(inputs):
             try:
                 input.to(memory_format=torch.channels_last)
+                channels_last_available[idx] = "channels_last"
             except Exception as _e:
-                channels_last_available[idx] = False
-            else:
-                channels_last_available[idx] = True
+                try:
+                    input.to(memory_format=torch.channels_last_3d)
+                    channels_last_available[idx] = "channels_last_3d"
+                except Exception as _e:
+                    pass
     else:
         channels_last_available = []
     return channels_last_available

--- a/python/nano/test/pytorch/tests/inference/test_bf16.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16.py
@@ -216,6 +216,33 @@ class Pytorch1_12:
             load_model = InferenceOptimizer.load(tmp_dir_name, model)
             load_model(x1, x2, x3)
 
+    def test_bf16_channels_last_3d_various_input_sample(self):
+
+        class DummyModelWith3d(nn.Module):
+            """
+            A simple model for test various inputs of channels last format
+            """
+            def __init__(self):
+                super(DummyModelWith3d, self).__init__()
+                self.conv3d_1 = nn.Conv3d(3, 33, 3, stride=2)
+
+            def forward(self, x1, x2:int):
+                return self.conv3d_1(x1), x2
+
+        model = DummyModelWith3d()
+        x1 = torch.rand(32, 3, 3, 224, 224) # 5-dim input test
+        x2 = 3
+
+        bf16_channels_3d_last_model = InferenceOptimizer.quantize(model, precision='bf16',
+                                                                  channels_last=True)
+
+        with InferenceOptimizer.get_context(bf16_channels_3d_last_model):
+            bf16_channels_3d_last_model(x1, x2)
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(bf16_channels_3d_last_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model)
+            load_model(x1, x2)
 
 
 TORCH_VERSION_CLS = Pytorch1_12

--- a/python/nano/test/pytorch/tests/inference/test_bf16.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16.py
@@ -217,6 +217,7 @@ class Pytorch1_12:
             load_model(x1, x2, x3)
 
     def test_bf16_channels_last_3d_various_input_sample(self):
+        import torch.nn as nn
 
         class DummyModelWith3d(nn.Module):
             """

--- a/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
@@ -341,7 +341,8 @@ class Pytorch1_11:
         ipex_jit_channels_last_model = InferenceOptimizer.trace(model, accelerator="jit", 
                                                                 use_ipex=True, precision='bf16',
                                                                 input_sample=(x1, x2),
-                                                                enable_onednn=True)
+                                                                enable_onednn=True,
+                                                                channels_last=True)
         with InferenceOptimizer.get_context(ipex_jit_channels_last_model):
             ipex_jit_channels_last_model(x1, x2)
         with tempfile.TemporaryDirectory() as tmp_dir_name:

--- a/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
@@ -33,6 +33,7 @@ class CaseWithoutAVX512:
                            match="Applying IPEX BF16 optimization needs the cpu support avx512."):
             bf16_model = InferenceOptimizer.quantize(model, precision='bf16', use_ipex=True)
 
+
 class DummyMultiInputModel(nn.Module):
     """
     A simple model for test various inputs of channels last format
@@ -42,6 +43,19 @@ class DummyMultiInputModel(nn.Module):
 
     def forward(self, x1, x2, x3: List[float]):
         return x1, x2, x3
+
+
+class DummyModelWith3d(nn.Module):
+    """
+    A simple model for test various inputs of channels last format
+    """
+    def __init__(self):
+        super(DummyModelWith3d, self).__init__()
+        self.conv3d_1 = nn.Conv3d(3, 33, 3, stride=2)
+
+    def forward(self, x1, x2:int):
+        return self.conv3d_1(x1), x2
+
 
 class Pytorch1_11:
     @patch('bigdl.nano.deps.ipex.ipex_inference_bf16_model.PytorchIPEXJITBF16Model._check_cpu_isa', new_callable=PropertyMock)
@@ -319,6 +333,21 @@ class Pytorch1_11:
         with InferenceOptimizer.get_context(new_model):
             new_model(x)
             assert new_model.enable_onednn is True
+
+    def test_ipex_jit_channels_last_3d_inference(self):
+        model = DummyModelWith3d()
+        x1 = torch.rand(32, 3, 3, 224, 224) # 5-dim input test
+        x2 = 3
+        ipex_jit_channels_last_model = InferenceOptimizer.trace(model, accelerator="jit", 
+                                                                use_ipex=True, precision='bf16',
+                                                                input_sample=(x1, x2),
+                                                                enable_onednn=True)
+        with InferenceOptimizer.get_context(ipex_jit_channels_last_model):
+            ipex_jit_channels_last_model(x1, x2)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(ipex_jit_channels_last_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model)
+            load_model(x1, x2)
 
 
 TORCH_VERSION_CLS = Pytorch1_11

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -67,6 +67,19 @@ class DummyMultiInputModel(nn.Module):
     def forward(self, x1, x2, x3: List[float]):
         return x1, x2, x3
 
+
+class DummyModelWith3d(nn.Module):
+    """
+    A simple model for test various inputs of channels last format
+    """
+    def __init__(self):
+        super(DummyModelWith3d, self).__init__()
+        self.conv3d_1 = nn.Conv3d(3, 33, 3, stride=2)
+
+    def forward(self, x1, x2:int):
+        return self.conv3d_1(x1), x2
+
+
 class MultipleInputWithKwargsNet(nn.Module):
     def __init__(self):
         super().__init__()
@@ -129,6 +142,19 @@ class IPEXJITInference_gt_1_10:
             load_model = InferenceOptimizer.load(tmp_dir_name, model)
             load_model(x1, x2, x3)
 
+    def test_ipex_channels_last_3d_inference(self):
+        model = DummyModelWith3d()
+        x1 = torch.rand(32, 3, 3, 224, 224) # 5-dim input test
+        x2 = 3
+        ipex_channels_last_model = InferenceOptimizer.trace(model, accelerator=None, 
+                                                            channels_last=True, use_ipex=True)
+        with InferenceOptimizer.get_context(ipex_channels_last_model):
+            ipex_channels_last_model(x1, x2)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(ipex_channels_last_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model)
+            load_model(x1, x2)
+
     def test_jit_channels_last_inference(self):
         model = DummyMultiInputModel()
         x1 = torch.rand(1, 1) # 3-dim input test
@@ -143,6 +169,19 @@ class IPEXJITInference_gt_1_10:
             load_model = InferenceOptimizer.load(tmp_dir_name, model)
             load_model(x1, x2, x3)
 
+    def test_jit_channels_last_3d_inference(self):
+        model = DummyModelWith3d()
+        x1 = torch.rand(32, 3, 3, 224, 224) # 5-dim input test
+        x2 = 3
+        jit_channels_last_model = InferenceOptimizer.trace(model, accelerator="jit", 
+                                                           use_ipex=False)
+        with InferenceOptimizer.get_context(jit_channels_last_model):
+            jit_channels_last_model(x1, x2)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(jit_channels_last_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model)
+            load_model(x1, x2)
+
     def test_ipex_jit_channels_last_inference(self):
         model = DummyMultiInputModel()
         x1 = torch.rand(1, 1) # 3-dim input test
@@ -156,6 +195,19 @@ class IPEXJITInference_gt_1_10:
             InferenceOptimizer.save(ipex_jit_channels_last_model, tmp_dir_name)
             load_model = InferenceOptimizer.load(tmp_dir_name, model)
             load_model(x1, x2, x3)
+
+    def test_ipex_jit_channels_last_3d_inference(self):
+        model = DummyModelWith3d()
+        x1 = torch.rand(32, 3, 3, 224, 224) # 5-dim input test
+        x2 = 3
+        ipex_jit_channels_last_model = InferenceOptimizer.trace(model, accelerator="jit", 
+                                                                use_ipex=True)
+        with InferenceOptimizer.get_context(ipex_jit_channels_last_model):
+            ipex_jit_channels_last_model(x1, x2)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(ipex_jit_channels_last_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model)
+            load_model(x1, x2)
 
     def test_ipex_jit_inference_additional_attrs(self):
         model = ResNet18(10, pretrained=False, include_top=False, freeze=True)

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -174,7 +174,7 @@ class IPEXJITInference_gt_1_10:
         x1 = torch.rand(32, 3, 3, 224, 224) # 5-dim input test
         x2 = 3
         jit_channels_last_model = InferenceOptimizer.trace(model, accelerator="jit", 
-                                                           use_ipex=False)
+                                                           use_ipex=False, channels_last=True)
         with InferenceOptimizer.get_context(jit_channels_last_model):
             jit_channels_last_model(x1, x2)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
@@ -188,7 +188,7 @@ class IPEXJITInference_gt_1_10:
         x2 = torch.rand(1, 3, 8 ,8) # 4-dim input test
         x3 = [1, 2, 3, 4] # input without .to() method
         ipex_jit_channels_last_model = InferenceOptimizer.trace(model, accelerator="jit", 
-                                                                use_ipex=True)
+                                                                use_ipex=True, channels_last=True)
         with InferenceOptimizer.get_context(ipex_jit_channels_last_model):
             ipex_jit_channels_last_model(x1, x2, x3)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
@@ -201,7 +201,7 @@ class IPEXJITInference_gt_1_10:
         x1 = torch.rand(32, 3, 3, 224, 224) # 5-dim input test
         x2 = 3
         ipex_jit_channels_last_model = InferenceOptimizer.trace(model, accelerator="jit", 
-                                                                use_ipex=True)
+                                                                use_ipex=True, channels_last=True)
         with InferenceOptimizer.get_context(ipex_jit_channels_last_model):
             ipex_jit_channels_last_model(x1, x2)
         with tempfile.TemporaryDirectory() as tmp_dir_name:

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -150,6 +150,7 @@ class IPEXJITInference_gt_1_10:
                                                             channels_last=True, use_ipex=True)
         with InferenceOptimizer.get_context(ipex_channels_last_model):
             ipex_channels_last_model(x1, x2)
+        assert ipex_channels_last_model.channels_last_available == ["channels_last_3d", "original"]
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(ipex_channels_last_model, tmp_dir_name)
             load_model = InferenceOptimizer.load(tmp_dir_name, model)
@@ -177,6 +178,7 @@ class IPEXJITInference_gt_1_10:
                                                            use_ipex=False, channels_last=True)
         with InferenceOptimizer.get_context(jit_channels_last_model):
             jit_channels_last_model(x1, x2)
+        assert jit_channels_last_model.channels_last_available == ["channels_last_3d", "original"]
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(jit_channels_last_model, tmp_dir_name)
             load_model = InferenceOptimizer.load(tmp_dir_name, model)
@@ -204,6 +206,7 @@ class IPEXJITInference_gt_1_10:
                                                                 use_ipex=True, channels_last=True)
         with InferenceOptimizer.get_context(ipex_jit_channels_last_model):
             ipex_jit_channels_last_model(x1, x2)
+        assert ipex_jit_channels_last_model.channels_last_available == ["channels_last_3d", "original"]
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(ipex_jit_channels_last_model, tmp_dir_name)
             load_model = InferenceOptimizer.load(tmp_dir_name, model)


### PR DESCRIPTION
## Description

### 1. Why the change?
`torch.channels_last_3d ` could be used for 5-dim tensor and some 3d conv layers'. This PR tries to automatically handle
1. which data should be transformed to channels_last/channels_last_3d/remains original
2. which of channels_last/channels_last_3d should be used on users' model

### 2. User API changes
nothing, what's new please find it in ut.

### 3. Summary of the change 
1. change `channels_last_available` to be a string list to support 3d
2. related change to transform data/model

### 4. How to test?
- [ ] Unit test
