### PR TITLE
Chronos: remove redundant `no_grad` and change internal impl to `inference_mode`

### DIFF
--- a/python/chronos/src/bigdl/chronos/benchmark/benchmark_chronos.py
+++ b/python/chronos/src/bigdl/chronos/benchmark/benchmark_chronos.py
@@ -82,8 +82,7 @@ def throughput(args, model_path, forecaster, train_loader, test_loader, records)
     if 'torch' in args.inference_framework:
         import torch
         st = time.time()
-        with torch.no_grad():
-            yhat = forecaster.predict(test_loader, quantize=args.quantize)
+        yhat = forecaster.predict(test_loader, quantize=args.quantize)
         total_time = time.time()-st
         records['torch_infer_throughput'] = inference_sample_num / total_time
 
@@ -144,17 +143,16 @@ def latency(args, model_path, forecaster, train_loader, test_loader, records):
     # predict
     if 'torch' in args.inference_framework:
         import torch
-        with torch.no_grad():
-            if args.model == 'autoformer':
-                for x, y, x_, y_ in test_loader:
-                    st = time.time()
-                    yhat = forecaster.predict((x.numpy(), y.numpy(), x_.numpy(), y_.numpy()))
-                    latency.append(time.time()-st)
-            else:
-                for x, y in test_loader:
-                    st = time.time()
-                    yhat = forecaster.predict(x.numpy(), quantize=args.quantize)
-                    latency.append(time.time()-st)
+        if args.model == 'autoformer':
+            for x, y, x_, y_ in test_loader:
+                st = time.time()
+                yhat = forecaster.predict((x.numpy(), y.numpy(), x_.numpy(), y_.numpy()))
+                latency.append(time.time()-st)
+        else:
+            for x, y in test_loader:
+                st = time.time()
+                yhat = forecaster.predict(x.numpy(), quantize=args.quantize)
+                latency.append(time.time()-st)
         records['torch_latency'] = stats.trim_mean(latency, latency_trim_portion)
         records['torch_percentile_latency'] = np.percentile(latency, latency_percentile)
 

--- a/python/chronos/src/bigdl/chronos/pytorch/utils.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/utils.py
@@ -47,7 +47,7 @@ def _pytorch_fashion_inference(model, input_data, batch_size=None):
 
     :return: numpy ndarray
     '''
-    with torch.no_grad():
+    with torch.inference_mode():
         if isinstance(input_data, list):
             input_sample_list = list(map(lambda x: torch.from_numpy(x), input_data))
         elif isinstance(input_data, DataLoader):

--- a/python/chronos/use-case/electricity/autoformer.py
+++ b/python/chronos/use-case/electricity/autoformer.py
@@ -79,7 +79,7 @@ if __name__ == '__main__':
     forecaster.internal.eval()
     time_list = []
     torch.set_num_threads(8)
-    with torch.no_grad():
+    with torch.inference_mode():
         for i, batch in enumerate(pred_loader):
             st = time.time()
             forecaster.internal.predict_step(batch, i)
@@ -92,7 +92,7 @@ if __name__ == '__main__':
     forecaster.internal.eval()
     time_list = []
     torch.set_num_threads(1)
-    with torch.no_grad():
+    with torch.inference_mode():
         for i, batch in enumerate(pred_loader):
             st = time.time()
             forecaster.internal.predict_step(batch, i)

--- a/python/chronos/use-case/electricity/tcn.py
+++ b/python/chronos/use-case/electricity/tcn.py
@@ -65,22 +65,20 @@ if __name__ == '__main__':
 
     torch.set_num_threads(1)
     latency = []
-    with torch.no_grad():
-        for x, y in test_loader:
-            st = time.time()
-            yhat = forecaster.predict(x.numpy())
-            latency.append(time.time()-st)
+    for x, y in test_loader:
+        st = time.time()
+        yhat = forecaster.predict(x.numpy())
+        latency.append(time.time()-st)
     # latency is calculated the mean after ruling out the first 10% and last 10%
     latency = latency[int(0.1*len(latency)):int(0.9*len(latency))]
     print("Inference latency is:", np.mean(latency))
 
     forecaster.build_onnx(thread_num=1)
     onnx_latency = []
-    with torch.no_grad():
-        for x, y in test_loader:
-            st = time.time()
-            y_pred = forecaster.predict_with_onnx(x.numpy())
-            onnx_latency.append(time.time()-st)
+    for x, y in test_loader:
+        st = time.time()
+        y_pred = forecaster.predict_with_onnx(x.numpy())
+        onnx_latency.append(time.time()-st)
     # latency is calculated the mean after ruling out the first 10% and last 10%
     onnx_latency = onnx_latency[int(0.1*len(onnx_latency)):int(0.9*len(onnx_latency))]
     print("Inference latency with onnx is:", np.mean(onnx_latency))


### PR DESCRIPTION
## Description

### 1. Why the change?
`torch.inference_mode` has been involved by https://github.com/intel-analytics/BigDL/pull/7250 and this PR is to make Nano and Chronos aligned.

Recent benchmark results shows that

- code within `torch.no_grad()` for PT1.13(our default version) is ~10% slower than 1.12 (TCN is tested for this case)
- `torch.inference_mode` could effectively solve the problem

### 2. User API changes
nothing

### 3. Summary of the change 

- Some internal implementation is changed to `torch.inference_mode` (including utils and autoformer)
- Some external implementation's (e.g., benchmark tool & examples) `torch.no_grad` are deleted
- TCMF is not changed since we currently does not want to change legacy code.

### 4. How to test?
- [ ] Unit test
