### PR TITLE
Scala3 support in branch scala-2.13

### DIFF
--- a/scala/common/spark-version/3.0/pom.xml
+++ b/scala/common/spark-version/3.0/pom.xml
@@ -100,7 +100,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.12</artifactId>
+            <artifactId>spark-core_${scala.major.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
             <exclusions>
@@ -144,7 +144,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-mllib_2.12</artifactId>
+            <artifactId>spark-mllib_${scala.major.version}</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
             <exclusions>

--- a/scala/common/spark-version/3.0_2.13/pom.xml
+++ b/scala/common/spark-version/3.0_2.13/pom.xml
@@ -198,7 +198,7 @@
             <plugin>
                 <groupId>org.scalastyle</groupId>
                 <artifactId>scalastyle-maven-plugin</artifactId>
-                <version>0.8.0</version>
+                <version>1.0.0</version>
                 <configuration>
                     <verbose>false</verbose>
                     <failOnViolation>true</failOnViolation>

--- a/scala/common/spark-version/3.0_2.13/pom.xml
+++ b/scala/common/spark-version/3.0_2.13/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.intel.analytics.bigdl.spark-version</groupId>
-    <artifactId>3.0</artifactId>
+    <artifactId>3.0_2.13</artifactId>
     <packaging>jar</packaging>
 
     <dependencies>
@@ -100,7 +100,7 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-core_2.12</artifactId>
+            <artifactId>spark-core_2.13</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
             <exclusions>
@@ -144,13 +144,13 @@
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
-            <artifactId>spark-mllib_2.12</artifactId>
+            <artifactId>spark-mllib_2.13</artifactId>
             <version>${spark.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.spark</groupId>
-                    <artifactId>spark-core_2.12</artifactId>
+                    <artifactId>spark-core_2.13</artifactId>
                 </exclusion>
                 <exclusion>
                     <groupId>com.fasterxml.jackson.core</groupId>

--- a/scala/common/spark-version/3.0_2.13/src/main/scala/org/apache/spark/ml/DLEstimatorBase.scala
+++ b/scala/common/spark-version/3.0_2.13/src/main/scala/org/apache/spark/ml/DLEstimatorBase.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.ml
+
+import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.ml.param.shared.HasLabelCol
+import org.apache.spark.ml.linalg.{Vector, VectorUDT}
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.{DataFrame, Dataset, Row}
+
+/**
+ * Handle different Vector types in Spark 1.5/1.6 and Spark 2.0+.
+ * Support both ML Vector and MLlib Vector for Spark 2.0+.
+ */
+trait VectorCompatibility {
+
+  val validVectorTypes = Seq(new VectorUDT, new org.apache.spark.mllib.linalg.VectorUDT)
+
+  def getVectorSeq(row: Row, colType: DataType, index: Int): Seq[AnyVal] = {
+    if (colType == new VectorUDT) {
+      row.getAs[Vector](index).toArray.toSeq
+    } else if (colType == new org.apache.spark.mllib.linalg.VectorUDT) {
+      row.getAs[org.apache.spark.mllib.linalg.Vector](index).toArray.toSeq
+    } else {
+      throw new IllegalArgumentException(
+        s"$colType is not a supported vector type.")
+    }
+  }
+}
+
+
+/**
+ *A wrapper from org.apache.spark.ml.Estimator
+ * Extends MLEstimator and override process to gain compatibility with
+ * both spark 1.5 and spark 2.0.
+ */
+abstract class DLEstimatorBase[Learner <: DLEstimatorBase[Learner, M],
+    M <: DLTransformerBase[M]]
+  extends Estimator[M] with HasLabelCol {
+
+  protected def internalFit(dataFrame: DataFrame): M
+
+  override def fit(dataset: Dataset[_]): M = {
+    transformSchema(dataset.schema, logging = true)
+    internalFit(dataset.toDF())
+  }
+
+  override def copy(extra: ParamMap): Learner = defaultCopy(extra)
+
+}
+
+
+

--- a/scala/common/spark-version/3.0_2.13/src/main/scala/org/apache/spark/ml/DLTransformerBase.scala
+++ b/scala/common/spark-version/3.0_2.13/src/main/scala/org/apache/spark/ml/DLTransformerBase.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.ml
+
+import org.apache.spark.ml.param.ParamMap
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.{DataFrame, Dataset}
+
+/**
+ * A wrapper for org.apache.spark.ml.Transformer.
+ * Extends MlTransformer and override process to gain compatibility with
+ * both spark 1.5 and spark 2.0.
+ */
+abstract class DLTransformerBase[M <: DLTransformerBase[M]]
+  extends Model[M] {
+
+  /**
+   * convert feature columns(MLlib Vectors or Array) to Seq format
+   */
+  protected def internalTransform(dataFrame: DataFrame): DataFrame
+
+  override def transform(dataset: Dataset[_]): DataFrame = {
+    transformSchema(dataset.schema, logging = true)
+    internalTransform(dataset.toDF())
+  }
+
+  override def copy(extra: ParamMap): M = defaultCopy(extra)
+}

--- a/scala/common/spark-version/3.0_2.13/src/main/scala/org/apache/spark/rdd/ZippedPartitionsWithLocalityRDD.scala
+++ b/scala/common/spark-version/3.0_2.13/src/main/scala/org/apache/spark/rdd/ZippedPartitionsWithLocalityRDD.scala
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.rdd
+
+import java.io.{IOException, ObjectOutputStream}
+
+import org.apache.logging.log4j.{LogManager, Logger}
+import org.apache.spark.util.Utils
+import org.apache.spark.{Partition, SparkContext}
+
+import scala.collection.mutable.ArrayBuffer
+import scala.reflect.ClassTag
+
+object ZippedPartitionsWithLocalityRDD {
+  def apply[T: ClassTag, B: ClassTag, V: ClassTag]
+  (rdd1: RDD[T], rdd2: RDD[B], preservesPartitioning: Boolean = false)
+    (f: (Iterator[T], Iterator[B]) => Iterator[V]): RDD[V] = rdd1.withScope {
+    val sc = rdd1.sparkContext
+    new ZippedPartitionsWithLocalityRDD(
+      sc, sc.clean(f), rdd1, rdd2, preservesPartitioning)
+  }
+
+  val logger: Logger = LogManager.getLogger(getClass)
+}
+
+/**
+ * Prefer to zip partitions of rdd1 and rdd2 in the same location.
+ * Remaining partitions not in same location will be zipped by order.
+ * For example:
+ * Say we have two RDDs, rdd1 and rdd2. The first partition of rdd1 is on node A, and the second
+ * is on node B. The first partition of rdd2 is on node B and the second one is on node A.
+ * If we just use rdd1.zipPartition(rdd2), the result will be the first partition of rdd1 is
+ * zipped with the first partition of rdd2, so there will be cross node communication. This is
+ * bad for performance. That's why we introduce the ZippedPartitionsWithLocalityRDD.
+ * In our method, the first partition of rdd1 will be zipped with the second partition of rdd2,
+ * as they are on the same node. This will reduce the network communication cost and result in
+ * a better performance.
+ * @param sc spark context
+ * @param _f
+ * @param _rdd1
+ * @param _rdd2
+ * @param preservesPartitioning
+ */
+class ZippedPartitionsWithLocalityRDD[A: ClassTag, B: ClassTag, V: ClassTag](
+  sc: SparkContext,
+  _f: (Iterator[A], Iterator[B]) => Iterator[V],
+  _rdd1: RDD[A],
+  _rdd2: RDD[B],
+  preservesPartitioning: Boolean = false)
+  extends ZippedPartitionsRDD2[A, B, V](sc, _f, _rdd1, _rdd2, preservesPartitioning) {
+
+  override def getPartitions: Array[Partition] = {
+    if (rdds.length != 2) {
+      throw new IllegalArgumentException("this is only for 2 rdd zip")
+    }
+    val numParts = rdds.head.partitions.length
+    if (!rdds.forall(rdd => rdd.partitions.length == numParts)) {
+      throw new IllegalArgumentException("Can't zip RDDs with unequal numbers of partitions")
+    }
+
+    val candidateLocs = new ArrayBuffer[(Int, Seq[String])]()
+    (0 until numParts).foreach(p => {
+      candidateLocs.append((p, rdds(1)
+        .context.getPreferredLocs(rdds(1), p)
+        .map(_.toString).distinct))
+    })
+    val nonmatchPartitionId = new ArrayBuffer[Int]()
+    val parts = new Array[Partition](numParts)
+
+    (0 until  numParts).foreach { i =>
+      val curPrefs = rdds(0).context.getPreferredLocs(rdds(0), i).map(_.toString).distinct
+      var p = 0
+      var matchPartition: (Int, Seq[String]) = null
+      var locs: Seq[String] = null
+      while (p < candidateLocs.length) {
+        locs = candidateLocs(p)._2.intersect(curPrefs)
+        if (!locs.isEmpty) {
+          matchPartition = candidateLocs.remove(p)
+          p = Integer.MAX_VALUE - 1
+        }
+        p += 1
+      }
+      if (matchPartition != null) {
+        parts(i) =
+          new ZippedPartitionsLocalityPartition(i, Array(i, matchPartition._1), rdds, locs)
+      } else {
+        ZippedPartitionsWithLocalityRDD.logger.warn(s"can't find locality partition" +
+          s"for partition $i Partition locations are (${curPrefs}) Candidate partition" +
+          s" locations are\n" + s"${candidateLocs.mkString("\n")}.")
+        nonmatchPartitionId.append(i)
+      }
+    }
+
+    if (nonmatchPartitionId.size != candidateLocs.size) {
+      throw new IllegalArgumentException("unmatched partition size" +
+        " should be the same with candidateLocs size")
+    }
+
+    nonmatchPartitionId.foreach { i =>
+      val locs = rdds(0).context.getPreferredLocs(rdds(0), i).map(_.toString).distinct
+      val matchPartition = candidateLocs.remove(0)
+      parts(i) = new ZippedPartitionsLocalityPartition(i, Array(i, matchPartition._1), rdds, locs)
+    }
+    parts
+  }
+}
+
+
+private[spark] class ZippedPartitionsLocalityPartition(
+  idx: Int,
+  @transient val indexes: Seq[Int],
+  @transient val rdds: Seq[RDD[_]],
+  @transient override val preferredLocations: Seq[String])
+  extends ZippedPartitionsPartition(idx, rdds, preferredLocations) {
+
+  override val index: Int = idx
+  var _partitionValues = rdds.zip(indexes).map{ case (rdd, i) => rdd.partitions(i) }
+  override def partitions: Seq[Partition] = _partitionValues
+
+  @throws(classOf[IOException])
+  private def writeObject(oos: ObjectOutputStream): Unit = Utils.tryOrIOException {
+    // Update the reference to parent split at the time of task serialization
+    _partitionValues = rdds.zip(indexes).map{ case (rdd, i) => rdd.partitions(i) }
+    oos.defaultWriteObject()
+  }
+}

--- a/scala/common/spark-version/3.0_2.13/src/main/scala/org/apache/spark/sql/OrcaArrowUtils.scala
+++ b/scala/common/spark-version/3.0_2.13/src/main/scala/org/apache/spark/sql/OrcaArrowUtils.scala
@@ -1,0 +1,119 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.sql
+
+import java.io.{DataOutputStream, FileInputStream, FileOutputStream}
+
+import org.apache.arrow.vector.VectorSchemaRoot
+import org.apache.arrow.vector.ipc.ArrowStreamWriter
+import org.apache.spark.{SparkEnv, TaskContext}
+import org.apache.spark.api.java.JavaRDD
+import org.apache.spark.rdd.RDD
+import org.apache.spark.sql.api.python.PythonSQLUtils
+import org.apache.spark.sql.catalyst.{CatalystTypeConverters, InternalRow}
+import org.apache.spark.sql.execution.arrow.{ArrowConverters, ArrowWriter}
+import org.apache.spark.sql.execution.python.BatchIterator
+import org.apache.spark.sql.types.{DataType, StructType}
+import org.apache.spark.sql.util.ArrowUtils
+import org.apache.spark.util.Utils
+
+import org.apache.spark.util.{ShutdownHookManager, Utils}
+
+import java.io._
+
+
+class OrcaArrowUtils() {
+  def orcaToDataFrame(jrdd: JavaRDD[String], schemaString: String,
+  sqlContext: SQLContext): DataFrame = {
+    val schema = DataType.fromJson(schemaString).asInstanceOf[StructType]
+    val timeZoneId = sqlContext.sessionState.conf.sessionLocalTimeZone
+    val rdd = jrdd.rdd.mapPartitions { iter =>
+      val context = TaskContext.get()
+      val file = iter.next()
+      val dir = new File(file)
+      ShutdownHookManager.registerShutdownDeleteDir(dir)
+
+      Utils.tryWithResource(new FileInputStream(file)) { fileStream =>
+        // Create array to consume iterator so that we can safely close the file
+        val batches = ArrowConverters.getBatchesFromStream(fileStream.getChannel)
+        ArrowConverters.fromBatchIterator(batches,
+          DataType.fromJson(schemaString).asInstanceOf[StructType], timeZoneId, context)
+      }
+    }
+    sqlContext.internalCreateDataFrame(rdd.setName("arrow"), schema)
+  }
+
+  // Below code is adapted from spark, https://github.com/apache/spark/blob/branch-3.1/sql/core/
+  // src/main/scala/org/apache/spark/sql/execution/python/ArrowPythonRunner.scala
+  def sparkdfTopdf(sdf: DataFrame, sqlContext: SQLContext, batchSize: Int = -1): RDD[String] = {
+    val schemaCaptured = sdf.schema
+    val maxRecordsPerBatch = if (batchSize == -1) {
+      sqlContext.sessionState.conf.arrowMaxRecordsPerBatch
+    } else batchSize
+    val timeZoneId = sqlContext.sessionState.conf.sessionLocalTimeZone
+
+
+    val schema = sdf.schema
+    sdf.rdd.mapPartitions {iter =>
+      val batchIter = if (maxRecordsPerBatch > 0) {
+        new BatchIterator(iter, maxRecordsPerBatch)
+      } else Iterator(iter)
+
+      val arrowSchema = ArrowUtils.toArrowSchema(schema, timeZoneId)
+      val allocator = ArrowUtils.rootAllocator.newChildAllocator("ItertoFile", 0, Long.MaxValue)
+      val root = VectorSchemaRoot.create(arrowSchema, allocator)
+
+      val conf = SparkEnv.get.conf
+      val sparkFilesDir =
+        Utils.createTempDir(Utils.getLocalDir(conf), "arrowCommunicate").getAbsolutePath
+
+      val filename = sparkFilesDir + "/arrowdata"
+      val fos = new FileOutputStream(filename)
+      val dataOutput = new DataOutputStream(fos)
+
+      Utils.tryWithSafeFinally {
+        val arrowWriter = ArrowWriter.create(root)
+        val writer = new ArrowStreamWriter(root, null, dataOutput)
+        writer.start()
+
+        while (batchIter.hasNext) {
+          val nextBatch = batchIter.next()
+
+          while (nextBatch.hasNext) {
+            val nxtIternalRow = CatalystTypeConverters.convertToCatalyst(nextBatch.next())
+            arrowWriter.write(nxtIternalRow.asInstanceOf[InternalRow])
+          }
+
+          arrowWriter.finish()
+          writer.writeBatch()
+          arrowWriter.reset()
+        }
+        writer.end()
+      } {
+        root.close()
+        allocator.close()
+        if (dataOutput != null) {
+          dataOutput.close()
+        }
+        if (fos != null) {
+          fos.close()
+        }
+      }
+      Iterator(filename)
+    }
+  }
+}

--- a/scala/common/spark-version/3.0_2.13/src/main/scala/org/apache/spark/sql/SqlAdapter.scala
+++ b/scala/common/spark-version/3.0_2.13/src/main/scala/org/apache/spark/sql/SqlAdapter.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.sql
+
+import org.apache.spark.sql.expressions.SparkUserDefinedFunction
+import org.apache.spark.sql.types.DataType
+
+object SqlAdapter {
+
+  def getUDF(f: AnyRef, dataType: DataType): SparkUserDefinedFunction = {
+    SparkUserDefinedFunction(f, dataType)
+  }
+
+}

--- a/scala/common/spark-version/3.0_2.13/src/main/scala/org/apache/spark/storage/BlockManagerWrapper.scala
+++ b/scala/common/spark-version/3.0_2.13/src/main/scala/org/apache/spark/storage/BlockManagerWrapper.scala
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.storage
+
+import java.lang.{Boolean => JBoolean}
+import java.nio.ByteBuffer
+
+import org.apache.spark.SparkEnv
+import org.apache.spark.util.io.ChunkedByteBuffer
+
+import scala.reflect.ClassTag
+
+object BlockManagerWrapper {
+
+  def putBytes( blockId: BlockId,
+                bytes: ByteBuffer,
+                level: StorageLevel): Unit = {
+    if (bytes == null) {
+      throw new Exception("Bytes is null")
+    }
+    putBytesFn(blockId, new ChunkedByteBuffer(bytes), level)
+  }
+
+  def getLocal(blockId: BlockId): Option[BlockResult] = {
+    SparkEnv.get.blockManager.getLocalValues(blockId)
+  }
+
+  def putSingle(blockId: BlockId,
+    value: Any,
+    level: StorageLevel,
+    tellMaster: Boolean = true): Unit = {
+    SparkEnv.get.blockManager.putSingle(blockId, value, level, tellMaster)
+  }
+
+  def removeBlock(blockId: BlockId): Unit = {
+    SparkEnv.get.blockManager.removeBlock(blockId)
+  }
+
+  def getLocalBytes(blockId: BlockId): Option[ByteBuffer] = {
+    getLocalBytesFn(blockId)
+  }
+
+  def getLocalOrRemoteBytes(blockId: BlockId): Option[ByteBuffer] = {
+    val maybeLocalBytes = getLocalBytesFn(blockId)
+    if (maybeLocalBytes.isDefined) {
+      maybeLocalBytes
+    } else {
+      SparkEnv.get.blockManager.getRemoteBytes(blockId).map(_.toByteBuffer)
+    }
+  }
+
+  def unlock(blockId : BlockId): Unit = {
+    val blockInfoManager = SparkEnv.get.blockManager.blockInfoManager
+    if (blockInfoManager.get(blockId).isDefined) {
+      unlockFn(blockId)
+    }
+  }
+
+  private val getLocalBytesFn: (BlockId) => Option[ByteBuffer] = {
+    val bmClass = classOf[BlockManager]
+    val getLocalBytesMethod = bmClass.getMethod("getLocalBytes", classOf[BlockId])
+
+    // Spark versions before 2.2.0 declare:
+    // def getLocalBytes(blockId: BlockId): Option[ChunkedByteBuffer]
+    // Spark 2.2.0+ declares:
+    // def getLocalBytes(blockId: BlockId): Option[BlockData]
+    // Because the latter change happened in the commit that introduced BlockData,
+    // and because you can't discover the generic type of the return type by reflection,
+    // distinguish the cases by seeing if BlockData exists.
+    try {
+      val blockDataClass = Class.forName("org.apache.spark.storage.BlockData")
+      // newer method, apply reflection to transform BlockData after invoking
+      val toByteBufferMethod = blockDataClass.getMethod("toByteBuffer")
+      (blockId: BlockId) =>
+        getLocalBytesMethod.invoke(SparkEnv.get.blockManager, blockId)
+          .asInstanceOf[Option[_]]
+          .map(blockData => toByteBufferMethod.invoke(blockData).asInstanceOf[ByteBuffer])
+    } catch {
+      case _: ClassNotFoundException =>
+        // older method, can be invoked directly
+        (blockId: BlockId) =>
+          getLocalBytesMethod.invoke(SparkEnv.get.blockManager, blockId)
+            .asInstanceOf[Option[ChunkedByteBuffer]]
+            .map(_.toByteBuffer)
+    }
+  }
+
+  private val putBytesFn: (BlockId, ChunkedByteBuffer, StorageLevel) => Unit = {
+    val bmClass = classOf[BlockManager]
+    // Spark 2.0.0 - 2.1.0, and 2.2.0+ (as of this writing), declare the method:
+    // def putBytes[T: ClassTag](
+    //   blockId: BlockId,
+    //   bytes: ChunkedByteBuffer,
+    //   level: StorageLevel,
+    //   tellMaster: Boolean = true): Boolean
+    val putBytesMethod =
+      try {
+        bmClass.getMethod("putBytes",
+          classOf[BlockId], classOf[ChunkedByteBuffer], classOf[StorageLevel],
+          classOf[Boolean], classOf[ClassTag[_]])
+      } catch {
+        case _: NoSuchMethodException =>
+          // But Spark 2.1.1 and distros like Cloudera 2.0.0 / 2.1.0 had an extra boolean
+          // param:
+          //   def putBytes[T: ClassTag](
+          //     blockId: BlockId,
+          //     bytes: ChunkedByteBuffer,
+          //     level: StorageLevel,
+          //     tellMaster: Boolean = true,
+          //     encrypt: Boolean = false): Boolean
+          bmClass.getMethod("putBytes",
+            classOf[BlockId], classOf[ChunkedByteBuffer], classOf[StorageLevel],
+            classOf[Boolean], classOf[Boolean], classOf[ClassTag[_]])
+      }
+    putBytesMethod.getParameterTypes.length match {
+      case 5 =>
+        (blockId: BlockId, bytes: ChunkedByteBuffer, level: StorageLevel) =>
+          putBytesMethod.invoke(SparkEnv.get.blockManager,
+            blockId, bytes, level, JBoolean.TRUE, null)
+      case 6 =>
+        (blockId: BlockId, bytes: ChunkedByteBuffer, level: StorageLevel) =>
+          putBytesMethod.invoke(SparkEnv.get.blockManager,
+            blockId, bytes, level, JBoolean.TRUE, JBoolean.FALSE, null)
+    }
+  }
+
+  private val unlockFn: (BlockId) => Unit = {
+    val bimClass = classOf[BlockInfoManager]
+    // Spark 2.0.0-2.0.2, 2.1.0-2.1.1 declare:
+    // def unlock(blockId: BlockId): Unit
+    val unlockMethod =
+      try {
+        bimClass.getMethod("unlock", classOf[BlockId])
+      } catch {
+        case _: NoSuchMethodException =>
+          // But 2.0.3+, 2.1.2+, 2.2.0+ declare:
+          // def unlock(blockId: BlockId, taskAttemptId: Option[TaskAttemptId] = None): Unit
+          bimClass.getMethod("unlock", classOf[BlockId], classOf[Option[_]])
+      }
+    unlockMethod.getParameterTypes.length match {
+      case 1 =>
+        (blockId: BlockId) =>
+          unlockMethod.invoke(SparkEnv.get.blockManager.blockInfoManager, blockId)
+      case 2 =>
+        (blockId: BlockId) =>
+          unlockMethod.invoke(SparkEnv.get.blockManager.blockInfoManager, blockId, None)
+    }
+  }
+
+}

--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -283,7 +283,7 @@
         </dependency>
 	<dependency>
             <groupId>ml.dmlc</groupId>
-            <artifactId>xgboost4j_${scala.major.version}</artifactId>
+            <artifactId>xgboost4j_2.12</artifactId>
             <version>1.1.2</version>
             <exclusions>
                 <exclusion>
@@ -298,7 +298,7 @@
         </dependency>
         <dependency>
             <groupId>ml.dmlc</groupId>
-            <artifactId>xgboost4j-spark_${scala.major.version}</artifactId>
+            <artifactId>xgboost4j-spark_2.12</artifactId>
             <version>1.1.2</version>
             <exclusions>
                 <exclusion>
@@ -344,7 +344,7 @@
         <dependency>
             <groupId>com.github.scopt</groupId>
             <artifactId>scopt_${scala.major.version}</artifactId>
-            <version>3.5.0</version>
+            <version>${scopt.version}</version>
         </dependency>
         <dependency>
             <groupId>it.unimi.dsi</groupId>

--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -130,6 +130,14 @@
                     <artifactId>netty-codec</artifactId>
 	    	</exclusion>
                 <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.slf4j</groupId>
                     <artifactId>slf4j-api</artifactId>
                 </exclusion>

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/common/PythonZoo.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/common/PythonZoo.scala
@@ -314,10 +314,10 @@ class PythonZoo[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonBigDLK
   }
 
   def createZooTriggerAnd(first: ZooTrigger, others: JList[ZooTrigger]): And = {
-    new And(first, others.asScala: _*)
+    new And(first, others.asScala.toSeq: _*)
   }
 
   def createZooTriggerOr(first: ZooTrigger, others: JList[ZooTrigger]): Or = {
-    new Or(first, others.asScala: _*)
+    new Or(first, others.asScala.toSeq: _*)
   }
 }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/utils/TextClassifier.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/example/utils/TextClassifier.scala
@@ -149,7 +149,7 @@ class TextClassifier(param: AbstractTextClassificationParams) extends Serializab
     val embeddingDim = param.embeddingDim
     val trainingSplit = param.trainingSplit
     // For large dataset, you might want to get such RDD[(String, Float)] from HDFS
-    val dataRdd = sc.parallelize(loadRawData(), param.partitionNum)
+    val dataRdd = sc.parallelize(loadRawData().toSeq, param.partitionNum)
     val (word2Meta, word2Vec) = analyzeTexts(dataRdd)
     val word2MetaBC = sc.broadcast(word2Meta)
     val word2VecBC = sc.broadcast(word2Vec)
@@ -200,7 +200,7 @@ class TextClassifier(param: AbstractTextClassificationParams) extends Serializab
     val trainingSplit = param.trainingSplit
 
     // For large dataset, you might want to get such RDD[(String, Float)] from HDFS
-    val dataRdd = sc.parallelize(loadRawData(), param.partitionNum).persist()
+    val dataRdd = sc.parallelize(loadRawData().toSeq, param.partitionNum).persist()
     val (word2Meta, word2Vec) = analyzeTexts(dataRdd)
     val word2MetaBC = sc.broadcast(word2Meta)
     val word2VecBC = sc.broadcast(word2Vec)
@@ -215,8 +215,8 @@ class TextClassifier(param: AbstractTextClassificationParams) extends Serializab
         label = label)
     }.persist()
 
-    val Array(trainingRDD, valRDD) = sampleRDD.randomSplit(
-      Array(trainingSplit, 1 - trainingSplit))
+    val Array(trainingRDD, valRDD): Array[RDD[Sample[Float]]] =
+      sampleRDD.randomSplit(Array(trainingSplit, 1 - trainingSplit))
 
     val optimizer = Optimizer(
       model = buildModel(classNum),

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/common/MTSampleToMiniBatch.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/common/MTSampleToMiniBatch.scala
@@ -63,7 +63,7 @@ class MTSampleToMiniBatch[A: ClassTag, T: ClassTag] (
           }
 
           // multi thread processing
-          (0 until parallelism).toParArray.foreach{tid =>
+          collection.parallel.immutable.ParVector.range(0, parallelism).foreach{tid =>
             var j = tid
             while (j < count) {
               sampleData(j) = transformers(tid).apply(rawDataCache(j)).next()

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/common/Relations.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/common/Relations.scala
@@ -93,8 +93,8 @@ object Relations {
     val positive = relations.filter(_.label > 0).groupBy(_.id1)
     val negative = relations.filter(_.label == 0).groupBy(_.id1)
     positive.cogroup(negative).flatMap(x => {
-      val posIDs = x._2._1.flatten.toArray.map(_.id2)
-      val negIDs = x._2._2.flatten.toArray.map(_.id2)
+      val posIDs = x._2._1.flatten.map(_.id2)
+      val negIDs = x._2._2.flatten.map(_.id2)
       posIDs.flatMap(y => negIDs.map(z => RelationPair(x._1, y, z)))
     })
   }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/dataset/Sample.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/dataset/Sample.scala
@@ -233,12 +233,12 @@ class ArraySample[T: ClassTag] private[bigdl](
   override def equals(other: Any): Boolean = other match {
     case that: ArraySample[T] =>
       if (!(that canEqual this) ||
-        !(data.deep == that.data.deep) ||
-        !(featureSize.deep == that.featureSize.deep)) {
+        !(data sameElements that.data) ||
+        !featureSize.corresponds(that.featureSize) {_ sameElements _}) {
         return false
       }
       if (null != labelSize && null != that.labelSize) {
-        labelSize.deep == that.labelSize.deep
+        labelSize.corresponds(that.labelSize) {_ sameElements _}
       } else {
         null == labelSize & null == that.labelSize
       }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/dataset/datamining/RowTransformer.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/dataset/datamining/RowTransformer.scala
@@ -168,7 +168,7 @@ object RowTransformer {
     numericFields.foreach { case(key, fields) =>
       transSchemas += ColsToNumeric[T](key, fields)
     }
-    new RowTransformer(transSchemas)
+    new RowTransformer(transSchemas.toSeq)
   }
 
 }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/dataset/segmentation/MaskUtils.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/dataset/segmentation/MaskUtils.scala
@@ -113,7 +113,7 @@ class RLEMasks(val counts: Array[Int], val height: Int, val width: Int)
       return true
     }
 
-    this.counts.deep == other.counts.deep &&
+    this.counts.sameElements(other.counts) &&
       this.height == other.height &&
       this.width == other.width
   }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/transform/vision/image/MTImageFeatureToBatch.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/feature/transform/vision/image/MTImageFeatureToBatch.scala
@@ -322,7 +322,7 @@ class RoiMiniBatch(val input: Tensor[Float], val target: Array[RoiLabel],
       }
       ret
     }
-    T.seq(tables)
+    T.seq(tables.toSeq)
   }
 
   override def slice(offset: Int, length: Int): MiniBatch[Float] = {

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/Model.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/Model.scala
@@ -287,7 +287,7 @@ object Model extends KerasLayerSerializable {
     val labor = context.moduleData.module.
       asInstanceOf[KerasLayer[Activity, Activity, T]].labor
     val subModule = ModuleSerializer.serialize(SerializeContext(ModuleData(labor,
-      new ArrayBuffer[String](), new ArrayBuffer[String]()), context.storages,
+      Seq[String](), Seq[String]()), context.storages,
       context.storageType, _copyWeightAndBias))
     builder.addSubModules(subModule.bigDLModule)
   }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/Predictor.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/Predictor.scala
@@ -484,9 +484,9 @@ trait Predictable[T] extends VectorCompatibility{
         val predictions = toBatch(samples).flatMap { batch =>
           val batchResultActivity = localModel.forward(batch.getInput())
           val batchResults = if (batchResultActivity.isTensor) {
-            Array(batchResultActivity.toTensor)
+            Seq(batchResultActivity.toTensor)
           } else {
-            batchResultActivity.toTable.toSeq[Tensor[T]].toArray
+            batchResultActivity.toTable.toSeq[Tensor[T]]
           }
 
           batchResults.flatMap {batchResult => if (batchResult.size().length == 2) {

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/AveragePooling1D.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/AveragePooling1D.scala
@@ -51,7 +51,7 @@ class AveragePooling1D[T: ClassTag](
   extends Pooling1D[T](
     poolLength, stride, borderMode, inputShape) with Net {
 
-  override def doBuild(inputShape: Shape): AbstractModule[Activity, Activity, T] = {
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val input = inputShape.toSingle().toArray
     val pads = KerasUtils.getPadsFromBorderMode(borderMode)
     val model = TSequential[T]()
@@ -67,7 +67,7 @@ class AveragePooling1D[T: ClassTag](
       format = DataFormat.NHWC)
     model.add(layer)
     model.add(com.intel.analytics.bigdl.dllib.nn.Squeeze(3))
-    model.asInstanceOf[AbstractModule[Activity, Activity, T]]
+    model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/AveragePooling1D.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/AveragePooling1D.scala
@@ -16,10 +16,8 @@
 
 package com.intel.analytics.bigdl.dllib.keras.layers
 
-import com.intel.analytics.bigdl.dllib.nn._
-import com.intel.analytics.bigdl.dllib.nn.{Sequential => TSequential}
-import com.intel.analytics.bigdl.dllib.nn.internal.Pooling1D
-import com.intel.analytics.bigdl.dllib.nn.abstractnn.{AbstractModule, DataFormat, Activity}
+import com.intel.analytics.bigdl.dllib.nn.{SpatialAveragePooling, Sequential => TSequential}
+import com.intel.analytics.bigdl.dllib.nn.abstractnn.{AbstractModule, Activity, DataFormat}
 import com.intel.analytics.bigdl.dllib.tensor.Tensor
 import com.intel.analytics.bigdl.dllib.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.dllib.utils.Shape
@@ -48,10 +46,9 @@ class AveragePooling1D[T: ClassTag](
     override val stride: Int = -1,
     override val borderMode: String = "valid",
     override val inputShape: Shape = null)(implicit ev: TensorNumeric[T])
-  extends Pooling1D[T](
-    poolLength, stride, borderMode, inputShape) with Net {
+  extends Pooling1D[T](poolLength, stride, borderMode, inputShape) {
 
-  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+  override def doBuild(inputShape: Shape): AbstractModule[Activity, Activity, T] = {
     val input = inputShape.toSingle().toArray
     val pads = KerasUtils.getPadsFromBorderMode(borderMode)
     val model = TSequential[T]()

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/AveragePooling2D.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/AveragePooling2D.scala
@@ -18,11 +18,8 @@ package com.intel.analytics.bigdl.dllib.keras.layers
 
 import com.intel.analytics.bigdl.dllib.nn.SpatialAveragePooling
 import com.intel.analytics.bigdl.dllib.nn.abstractnn.{AbstractModule, Activity, DataFormat}
-import com.intel.analytics.bigdl.dllib.tensor.Tensor
-import com.intel.analytics.bigdl.dllib.nn.internal.{KerasLayer, Pooling2D}
 import com.intel.analytics.bigdl.dllib.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.dllib.utils.{Log4Error, Shape}
-import com.intel.analytics.bigdl.dllib.keras.Net
 import com.intel.analytics.bigdl.dllib.keras.layers.utils.KerasUtils
 
 import scala.reflect.ClassTag
@@ -48,8 +45,8 @@ class AveragePooling2D[T: ClassTag](
     override val poolSize: Array[Int] = Array(2, 2),
     override val strides: Array[Int] = null,
     override val borderMode: String = "valid",
-    override val inputShape: Shape = null,
     val dimOrdering: DataFormat = DataFormat.NCHW,
+    override val inputShape: Shape = null,
     val pads: Array[Int] = null,
     val countIncludePad: Boolean = false)(implicit ev: TensorNumeric[T])
   extends Pooling2D[T](poolSize, strides, borderMode, inputShape) {
@@ -91,6 +88,6 @@ object AveragePooling2D {
     }
     new AveragePooling2D[T](
       poolSizeArray, strideArray,
-      borderMode, inputShape, KerasUtils.toBigDLFormat(dimOrdering), pads, countIncludePad)
+      borderMode, KerasUtils.toBigDLFormat(dimOrdering), inputShape, pads, countIncludePad)
   }
 }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/AveragePooling2D.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/AveragePooling2D.scala
@@ -48,8 +48,8 @@ class AveragePooling2D[T: ClassTag](
     override val poolSize: Array[Int] = Array(2, 2),
     override val strides: Array[Int] = null,
     override val borderMode: String = "valid",
-    val dimOrdering: DataFormat = DataFormat.NCHW,
     override val inputShape: Shape = null,
+    val dimOrdering: DataFormat = DataFormat.NCHW,
     val pads: Array[Int] = null,
     val countIncludePad: Boolean = false)(implicit ev: TensorNumeric[T])
   extends Pooling2D[T](poolSize, strides, borderMode, inputShape) {
@@ -91,6 +91,6 @@ object AveragePooling2D {
     }
     new AveragePooling2D[T](
       poolSizeArray, strideArray,
-      borderMode, KerasUtils.toBigDLFormat(dimOrdering), inputShape, pads, countIncludePad)
+      borderMode, inputShape, KerasUtils.toBigDLFormat(dimOrdering), pads, countIncludePad)
   }
 }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/BERT.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/BERT.scala
@@ -375,7 +375,7 @@ object BERT extends KerasLayerSerializable {
 
     val embLabor = bert.embeddingLayer.labor.asInstanceOf[AbstractModule[Activity, Activity, T]]
     val subModule = ModuleSerializer.serialize(SerializeContext(ModuleData(embLabor,
-      new ArrayBuffer[String](), new ArrayBuffer[String]()), context.storages,
+      Seq[String](), Seq[String]()), context.storages,
       context.storageType, _copyWeightAndBias))
     bertBuilder.addSubModules(subModule.bigDLModule)
 
@@ -383,7 +383,7 @@ object BERT extends KerasLayerSerializable {
       asInstanceOf[KerasLayer[Activity, Activity, T]].labor
     val labor = model.asInstanceOf[KerasLayer[Activity, Activity, T]].labor
     val subModule2 = ModuleSerializer.serialize(SerializeContext(ModuleData(labor,
-      new ArrayBuffer[String](), new ArrayBuffer[String]()), context.storages,
+      Seq[String](), Seq[String]()), context.storages,
       context.storageType, _copyWeightAndBias))
     bertBuilder.addSubModules(subModule2.bigDLModule)
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/MaxPooling1D.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/MaxPooling1D.scala
@@ -16,10 +16,8 @@
 
 package com.intel.analytics.bigdl.dllib.keras.layers
 
-import com.intel.analytics.bigdl.dllib.nn._
-import com.intel.analytics.bigdl.dllib.nn.{Sequential => TSequential}
-import com.intel.analytics.bigdl.dllib.nn.abstractnn.{AbstractModule, DataFormat, Activity}
-import com.intel.analytics.bigdl.dllib.nn.internal.Pooling1D
+import com.intel.analytics.bigdl.dllib.nn.{SpatialMaxPooling, Sequential => TSequential}
+import com.intel.analytics.bigdl.dllib.nn.abstractnn.{AbstractModule, Activity, DataFormat}
 import com.intel.analytics.bigdl.dllib.tensor.Tensor
 import com.intel.analytics.bigdl.dllib.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.dllib.utils.Shape
@@ -49,10 +47,10 @@ class MaxPooling1D[T: ClassTag](
     override val inputShape: Shape = null,
     val pad: Int = 0)(implicit ev: TensorNumeric[T])
   extends Pooling1D[T](
-    poolLength, stride, borderMode, inputShape) with Net {
+    poolLength, stride, borderMode, inputShape) {
 
 
-  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
+  override def doBuild(inputShape: Shape): AbstractModule[Activity, Activity, T] = {
     val input = inputShape.toSingle().toArray
 
     val pads = KerasUtils.getPadsFromBorderMode(borderMode, if (pad == 0) {

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/MaxPooling1D.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/MaxPooling1D.scala
@@ -52,7 +52,7 @@ class MaxPooling1D[T: ClassTag](
     poolLength, stride, borderMode, inputShape) with Net {
 
 
-  override def doBuild(inputShape: Shape): AbstractModule[Activity, Activity, T] = {
+  override def doBuild(inputShape: Shape): AbstractModule[Tensor[T], Tensor[T], T] = {
     val input = inputShape.toSingle().toArray
 
     val pads = KerasUtils.getPadsFromBorderMode(borderMode, if (pad == 0) {
@@ -72,7 +72,7 @@ class MaxPooling1D[T: ClassTag](
       format = DataFormat.NHWC)
     model.add(layer)
     model.add(com.intel.analytics.bigdl.dllib.nn.Squeeze(3))
-    model.asInstanceOf[AbstractModule[Activity, Activity, T]]
+    model.asInstanceOf[AbstractModule[Tensor[T], Tensor[T], T]]
   }
 }
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/MaxPooling1D.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/MaxPooling1D.scala
@@ -24,7 +24,6 @@ import com.intel.analytics.bigdl.dllib.tensor.Tensor
 import com.intel.analytics.bigdl.dllib.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.dllib.utils.Shape
 import com.intel.analytics.bigdl.dllib.keras.Net
-import scala.tools.nsc.interpreter.JList
 import com.intel.analytics.bigdl.dllib.keras.layers.utils.KerasUtils
 
 import scala.reflect.ClassTag

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/MaxPooling2D.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/MaxPooling2D.scala
@@ -17,8 +17,6 @@ package com.intel.analytics.bigdl.dllib.keras.layers
 
 import com.intel.analytics.bigdl.dllib.nn.SpatialMaxPooling
 import com.intel.analytics.bigdl.dllib.nn.abstractnn.{AbstractModule, Activity, DataFormat}
-import com.intel.analytics.bigdl.dllib.nn.internal.Pooling2D
-import com.intel.analytics.bigdl.dllib.tensor.Tensor
 import com.intel.analytics.bigdl.dllib.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.dllib.utils.{Log4Error, Shape}
 import com.intel.analytics.bigdl.dllib.keras.Net

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/Merge.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/layers/Merge.scala
@@ -105,8 +105,8 @@ class Merge[T: ClassTag](
         if (j != axis && (input_i(j) != -1 || output(j) != -1)) {
           Log4Error.invalidInputError(input_i(j)==output(j),
             s"Incompatible input dimension for merge " +
-              s"mode concat: (${output.deep.mkString(", ")}), " +
-              s"(${input_i.deep.mkString(", ")})")
+              s"mode concat: (${output.mkString(", ")}), " +
+              s"(${input_i.mkString(", ")})")
         }
         j += 1
       }
@@ -125,8 +125,8 @@ class Merge[T: ClassTag](
       val input_i = input(i).toSingle().toArray
       Log4Error.invalidInputError(input_i.sameElements(input1),
         s"Incompatible input dimension for " +
-        s"merge mode $mergeMode: (${input1.deep.mkString(", ")}), " +
-        s"(${input_i.deep.mkString(", ")})")
+        s"merge mode $mergeMode: (${input1.mkString(", ")}), " +
+        s"(${input_i.mkString(", ")})")
       i += 1
     }
   }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/metrics/Accuracy.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/metrics/Accuracy.scala
@@ -85,8 +85,8 @@ class CategoricalAccuracy[T: ClassTag]()(implicit ev: TensorNumeric[T]) extends
 
     Log4Error.invalidInputError(_target.dim() == 2,
       "Target should have 2 dims with one-hot encoding")
-    Log4Error.invalidInputError(_target.size().deep == _output.size().deep,
-      s"${_target.size()} == ${_output.size()}")
+    Log4Error.invalidInputError(_target.size().sameElements(_output.size()),
+      s"(${_target.size().mkString(",")}) != (${_output.size().mkString(",")})")
 
     val bigdlTarget = if (_target.dim() == 2) {
       _target.max(2)._2

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/models/Topology.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/models/Topology.scala
@@ -1215,7 +1215,7 @@ private[bigdl] class InternalDistriOptimizer[T: ClassTag] (
   }
 
   def getTrainSummary(tag: String): Array[(Long, Float, Double)] = {
-    if (this.trainSummary isDefined) {
+    if (this.trainSummary.isDefined) {
       this.trainSummary.get.readScalar(tag)
     } else {
       null
@@ -1223,7 +1223,7 @@ private[bigdl] class InternalDistriOptimizer[T: ClassTag] (
   }
 
   def getValidationSummary(tag: String): Array[(Long, Float, Double)] = {
-    if (this.validationSummary isDefined) {
+    if (this.validationSummary.isDefined) {
       this.validationSummary.get.readScalar(tag)
     } else {
       null
@@ -1563,7 +1563,7 @@ object InternalDistriOptimizer {
           val stackSize = batch.size() / _subModelNumber
           val extraSize = batch.size() % _subModelNumber
           val parallelism = if (stackSize == 0) extraSize else _subModelNumber
-          (0 until parallelism).toParArray.map { b =>
+          collection.parallel.immutable.ParVector.range(0, parallelism).map { b =>
             val offset = b * stackSize + math.min(b, extraSize) + 1
             val length = stackSize + (if (b < extraSize) 1 else 0)
             val miniBatch = batch.slice(offset, length)
@@ -1721,7 +1721,7 @@ object InternalDistriOptimizerV2 {
           val stackSize = batch.size() / _subModelNumber
           val extraSize = batch.size() % _subModelNumber
           val parallelism = if (stackSize == 0) extraSize else _subModelNumber
-          (0 until parallelism).toParArray.map { b =>
+          collection.parallel.immutable.ParVector.range(0, parallelism).map { b =>
             val offset = b * stackSize + math.min(b, extraSize) + 1
             val length = stackSize + (if (b < extraSize) 1 else 0)
             val miniBatch = batch.slice(offset, length)

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/python/PythonZooKeras.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/keras/python/PythonZooKeras.scala
@@ -1227,7 +1227,7 @@ class PythonZooKeras[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
   def connectInputs(module: AbstractModule[Activity, Activity, T],
       x: JList[Variable[T]]): Variable[T] = {
     Log4Error.invalidInputError(!x.isEmpty, "We don't accept empty inputs")
-    Variable(module.inputs(x.asScala.map(_.node): _*))
+    Variable(module.inputs(x.asScala.toSeq.map(_.node): _*))
   }
 
   def createZooKerasSparseCategoricalCrossEntropy(

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/models/maskrcnn/MaskRCNN.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/models/maskrcnn/MaskRCNN.scala
@@ -29,6 +29,7 @@ import com.intel.analytics.bigdl.dllib.feature.transform.vision.image.util.BboxU
 import com.intel.analytics.bigdl.dllib.utils.serializer._
 import com.intel.analytics.bigdl.dllib.utils.serializer.converters.DataConverter
 import com.intel.analytics.bigdl.dllib.utils.{Log4Error, T, Table}
+import com.intel.analytics.bigdl.dllib.models.maskrcnn.Utils
 
 import scala.reflect.ClassTag
 import scala.reflect.runtime._

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/models/maskrcnn/Utils.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/models/maskrcnn/Utils.scala
@@ -17,13 +17,8 @@
 
 package com.intel.analytics.bigdl.dllib.models.maskrcnn
 
-import breeze.linalg.{*, dim, max}
-import com.intel.analytics.bigdl.dllib.nn.ResizeBilinear
-import com.intel.analytics.bigdl.dllib.nn.abstractnn.DataFormat
 import com.intel.analytics.bigdl.dllib.tensor.Tensor
 import com.intel.analytics.bigdl.dllib.utils.Log4Error
-
-import scala.collection.mutable.ArrayBuffer
 
 private[bigdl] object Utils {
   // box with 4 element (xyxy)

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/models/resnet/DataSet.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/models/resnet/DataSet.scala
@@ -16,7 +16,7 @@
 package com.intel.analytics.bigdl.dllib.models.resnet
 
 import com.intel.analytics.bigdl.DataSet
-import com.intel.analytics.bigdl.dllib.feature.dataset._
+import com.intel.analytics.bigdl.dllib.feature.dataset.{DataSet, MiniBatch}
 import com.intel.analytics.bigdl.dllib.feature.dataset.image._
 import com.intel.analytics.bigdl.dllib.feature.dataset.image.{HFlip => JHFlip}
 import com.intel.analytics.bigdl.dllib.feature.transform.vision.image.{MTImageFeatureToBatch, MatToTensor, PixelBytesToMat}

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/models/resnet/ResNet.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/models/resnet/ResNet.scala
@@ -109,7 +109,7 @@ object ResNet {
           val curModel = spatialShareConvolution.asInstanceOf[SpatialShareConvolution[Float]]
           curModel.fInput = Tensor[Float](cache.get("fInput").get)
           curModel.fGradInput = Tensor[Float](cache.get("fGradInput").get)
-        case _ => Unit
+        case _ => ()
       }
     }
     matchModels(model)
@@ -140,7 +140,7 @@ object ResNet {
           curModel.bias.apply1(_ => 0.0f)
         case linear if (linear.isInstanceOf[Linear[Float]]) =>
           linear.asInstanceOf[Linear[Float]].bias.apply1(_ => 0.0f)
-        case _ => Unit
+        case _ => ()
       }
     }
     initModules(model)

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/models/rnn/Test.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/models/rnn/Test.scala
@@ -37,7 +37,7 @@ object Test {
   Configurator.setLevel("akka", Level.ERROR)
   Configurator.setLevel("breeze", Level.ERROR)
 
-  import Utils._
+  import com.intel.analytics.bigdl.dllib.models.rnn.Utils._
   val logger = LogManager.getLogger(getClass)
 
   def main(args: Array[String]): Unit = {

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/models/utils/COCOSeqFileGenerator.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/models/utils/COCOSeqFileGenerator.scala
@@ -85,8 +85,6 @@ object COCOSeqFileGenerator {
           valid
         }).grouped(param.blockSize).zipWithIndex.toArray: _*
       )
-      tasks.tasksupport = new ForkJoinTaskSupport(
-        new scala.concurrent.forkjoin.ForkJoinPool(param.parallel))
       tasks.foreach { case (imgs, blkId) =>
         val outFile = new Path(param.output, s"coco-seq-$blkId.seq")
         val key = new BytesWritable

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/models/utils/ModelBroadcast.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/models/utils/ModelBroadcast.scala
@@ -304,7 +304,7 @@ object ModelInfo {
 object CachedModels {
   import java.util.concurrent.ConcurrentHashMap
   import scala.collection._
-  import scala.collection.convert.decorateAsScala._
+  import scala.collection.JavaConverters._
   import scala.language.existentials
 
   type Modles = ArrayBuffer[Module[_]]

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/net/NetUtils.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/net/NetUtils.scala
@@ -121,7 +121,7 @@ object GraphNet extends ContainerSerializable {
     val labor = context.moduleData.module.
       asInstanceOf[GraphNet[T]].labor
     val subModule = ModuleSerializer.serialize(SerializeContext(ModuleData(labor,
-      new ArrayBuffer[String](), new ArrayBuffer[String]()), context.storages,
+      Seq[String](), Seq[String]()), context.storages,
       context.storageType, _copyWeightAndBias))
     builder.addSubModules(subModule.bigDLModule)
   }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/net/python/PythonDllibNet.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/net/python/PythonDllibNet.scala
@@ -43,11 +43,11 @@ class PythonDllibNet[T: ClassTag](implicit ev: TensorNumeric[T]) extends PythonZ
 
   def newGraph(model: NetUtils[T, _],
                outputs: JList[String]): NetUtils[T, _] = {
-    model.newGraph(outputs.asScala).asInstanceOf[NetUtils[T, _]]
+    model.newGraph(outputs.asScala.toSeq).asInstanceOf[NetUtils[T, _]]
   }
 
   def freezeUpTo(model: NetUtils[T, _], names: JList[String]): Unit = {
-    model.freezeUpTo(names.asScala: _*)
+    model.freezeUpTo(names.asScala.toSeq: _*)
   }
 
   def netLoadBigDL(

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/Concat.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/Concat.scala
@@ -330,7 +330,7 @@ class Concat[T: ClassTag](val dimension: Int)(
       outputTuple = modules(i).getEndNodes(startNodes)
       outputs ++= outputTuple
     }
-    Array(JoinTable(dimension, -1).inputs(outputs: _*))
+    Array(JoinTable(dimension, -1).inputs(outputs.toSeq: _*))
   }
 }
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/FPN.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/FPN.scala
@@ -124,7 +124,7 @@ class FPN[T : ClassTag](
     case that: FPN[T] =>
       super.equals(that) &&
         (that canEqual this) &&
-        inChannels.deep == that.inChannels.deep &&
+        inChannels.sameElements(that.inChannels) &&
         outChannels == that.outChannels
     case _ => false
   }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/Graph.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/Graph.scala
@@ -640,7 +640,7 @@ trait GraphSerializable extends ContainerSerializable {
         .asInstanceOf[Boolean]
       Graph.dynamic[T](inputs.toArray, outputs.toArray, sharedVariables, generateBackward)
     } else {
-      new StaticGraph[T](inputs, outputs, sharedVariables, false)
+      new StaticGraph[T](inputs.toSeq, outputs.toSeq, sharedVariables, false)
     }
     var serializedStopGradientLayers : Array[String] = null
     // this is to keep backward compatible

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/SoftMin.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/SoftMin.scala
@@ -141,9 +141,10 @@ object SoftMin {
     results: Array[Future[Unit]], pos: Int = 1
     )(implicit ev: TensorNumeric[T]): Tensor[T] = {
 
-    Log4Error.invalidInputError(input.size().deep == gradOutput.size().deep,
+    Log4Error.invalidInputError(input.size().sameElements(gradOutput.size()),
       "input should have the same size with gradOutput" +
-        s"inputsize ${input.size().deep} gradOutput ${gradOutput.size().deep}")
+        s"inputSize (${input.size().mkString(",")}) " +
+        s"gradOutput (${gradOutput.size().mkString(",")})")
     // get nFrame, dim and stride value based on the output tensor and pos
     val (nFrame, dim, stride) = output.nDimension() - pos match {
       case 0 => (1, output.size(pos), 1)

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/SpatialShareConvolution.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/SpatialShareConvolution.scala
@@ -353,7 +353,7 @@ object SpatialShareConvolution {
           }
           i += 1
         }
-      case _ => Unit
+      case _ => ()
     }
   }
 }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/VolumetricAveragePooling.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/VolumetricAveragePooling.scala
@@ -21,7 +21,6 @@ import com.intel.analytics.bigdl.dllib.tensor.Tensor
 import com.intel.analytics.bigdl.dllib.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.dllib.utils.Log4Error
 import com.intel.analytics.bigdl.dllib.utils.serializer._
-import org.codehaus.jackson.map.DeserializationContext
 import com.intel.analytics.bigdl.serialization.Bigdl.{AttrValue, BigDLModule}
 
 import scala.reflect._

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/VolumetricMaxPooling.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/VolumetricMaxPooling.scala
@@ -22,7 +22,6 @@ import com.intel.analytics.bigdl.dllib.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.dllib.utils.Log4Error
 import com.intel.analytics.bigdl.dllib.utils.serializer._
 import com.intel.analytics.bigdl.dllib.utils.serializer.converters.DataConverter
-import org.codehaus.jackson.map.DeserializationContext
 import com.intel.analytics.bigdl.serialization.Bigdl.{AttrValue, BigDLModule}
 
 import scala.reflect._

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/internal/Bidirectional.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/internal/Bidirectional.scala
@@ -16,7 +16,7 @@
 
 package com.intel.analytics.bigdl.dllib.nn.internal
 
-import com.intel.analytics.bigdl.dllib.nn._
+import com.intel.analytics.bigdl.dllib.nn.{BiRecurrent, CAddTable, CAveTable, CMulTable, JoinTable}
 import com.intel.analytics.bigdl.dllib.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.dllib.tensor.Tensor
 import com.intel.analytics.bigdl.dllib.tensor.TensorNumericMath.TensorNumeric

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/internal/KerasUtils.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/internal/KerasUtils.scala
@@ -17,7 +17,7 @@
 package com.intel.analytics.bigdl.dllib.nn.internal
 
 import com.intel.analytics.bigdl.Criterion
-import com.intel.analytics.bigdl.dllib.nn._
+import com.intel.analytics.bigdl.dllib.nn.{AbsCriterion, BCECriterion, CategoricalCrossEntropy, ClassNLLCriterion, CosineProximityCriterion, HardSigmoid, InitializationMethod, KullbackLeiblerDivergenceCriterion, MSECriterion, MarginCriterion, MeanAbsolutePercentageCriterion, MeanSquaredLogarithmicCriterion, Ones, PoissonCriterion, RandomNormal, RandomUniform, ReLU, Sigmoid, SoftPlus, SoftSign, Tanh, Xavier, Zeros}
 import com.intel.analytics.bigdl.dllib.nn.abstractnn.{AbstractModule, DataFormat}
 import com.intel.analytics.bigdl.dllib.optim._
 import com.intel.analytics.bigdl.dllib.tensor.Tensor

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/internal/Merge.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/internal/Merge.scala
@@ -74,8 +74,8 @@ class Merge[T: ClassTag](
       while (j < input_i.length) {
         if (j != axis) Log4Error.invalidInputError(input_i(j)==output(j),
           s"Incompatible input dimension for merge " +
-          s"mode concat: (${output.deep.mkString(", ")}), " +
-          s"(${input_i.deep.mkString(", ")})")
+          s"mode concat: (${output.mkString(", ")}), " +
+          s"(${input_i.mkString(", ")})")
         j += 1
       }
       if (output(axis) == -1 || input_i(axis) == -1) {
@@ -95,8 +95,8 @@ class Merge[T: ClassTag](
       val input_i = input(i).toSingle().toArray
       Log4Error.invalidInputError(input_i.sameElements(input1),
         s"Incompatible input dimension for " +
-        s"merge mode $mergeMode: (${input1.deep.mkString(", ")}), " +
-        s"(${input_i.deep.mkString(", ")})")
+        s"merge mode $mergeMode: (${input1.mkString(", ")}), " +
+        s"(${input_i.mkString(", ")})")
       i += 1
     }
   }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/internal/Topology.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/internal/Topology.scala
@@ -244,7 +244,7 @@ object Model extends KerasLayerSerializable{
     val labor = context.moduleData.module.
       asInstanceOf[KerasLayer[Activity, Activity, T]].labor
     val subModule = ModuleSerializer.serialize(SerializeContext(ModuleData(labor,
-      new ArrayBuffer[String](), new ArrayBuffer[String]()), context.storages,
+      Seq[String](), Seq[String]()), context.storages,
       context.storageType, _copyWeightAndBias))
     builder.addSubModules(subModule.bigDLModule)
   }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/mkldnn/Perf.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/mkldnn/Perf.scala
@@ -17,9 +17,9 @@
 package com.intel.analytics.bigdl.dllib.nn.mkldnn
 
 import com.intel.analytics.bigdl.Module
+import com.intel.analytics.bigdl.dllib.nn.Graph.ModuleNode
+import com.intel.analytics.bigdl.dllib.nn.{Container, CrossEntropyCriterion, MsraFiller, Ones, RandomNormal, Zeros}
 import com.intel.analytics.bigdl.mkl.{MKL, Memory, MklDnn}
-import com.intel.analytics.bigdl.dllib.nn.Graph._
-import com.intel.analytics.bigdl.dllib.nn._
 import com.intel.analytics.bigdl.dllib.nn.abstractnn.Activity
 import com.intel.analytics.bigdl.dllib.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
 import com.intel.analytics.bigdl.dllib.nn.mkldnn.ResNet.DatasetType.ImageNet
@@ -285,13 +285,14 @@ object ResNet {
       graph.getSortedForwardExecutions.foreach(n => {
         n.element match {
           case conv: SpatialConvolution =>
-            val n: Float = conv.kernelW * conv.kernelW * conv.nOutputPlane
-            val weight = Tensor[Float].resize(conv.weight.size()).apply1 { _ =>
+            val conv2 = conv.asInstanceOf[SpatialConvolution]
+            val n: Float = conv2.kernelW * conv2.kernelW * conv2.nOutputPlane
+            val weight = Tensor[Float].resize(conv2.weight.size()).apply1 { _ =>
               RNG.normal(0, Math.sqrt(2.0f / n)).toFloat
             }
-            val bias = Tensor[Float].resize(conv.bias.size()).apply1(_ => 0.0f)
-            conv.weight.copy(weight)
-            conv.bias.copy(bias)
+            val bias = Tensor[Float].resize(conv2.bias.size()).apply1(_ => 0.0f)
+            conv2.weight.copy(weight)
+            conv2.bias.copy(bias)
 
           case bn: SpatialBatchNormalization =>
             val weightAndBias = Tensor[Float]().resize(Array(2, bn.nOutput))

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/mkldnn/SpatialBatchNormalization.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/mkldnn/SpatialBatchNormalization.scala
@@ -258,7 +258,7 @@ class SpatialBatchNormalization(
     // if the output is not null, it means we have initialized the primitives before.
     // so we do not need create weightAndBias native space again.
     if (output == null || output.isInstanceOf[DnnTensor[_]] &&
-      output.toTensor[Float].size().deep != outputFormats()(0).shape.deep) {
+      !output.toTensor[Float].size().sameElements(outputFormats()(0).shape)) {
       output = initTensor(outputFormats()(0))
     }
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/ops/CrossCol.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/ops/CrossCol.scala
@@ -121,9 +121,9 @@ class CrossCol[T: ClassTag](
     val stack = mutable.Stack[Array[String]]()
     stack.pushAll(input(0).map(Array(_)))
 
-    val mkBuilder = (a: Array[String]) => mutable.ArrayBuilder.make[String]() ++= a
+    val mkBuilder = (a: Array[String]) => mutable.ArrayBuilder.make[String].++=(a)
 
-    val result = mutable.ArrayBuilder.make[Array[String]]()
+    val result = mutable.ArrayBuilder.make[Array[String]]
 
     while (stack.nonEmpty) {
       val current = stack.pop()
@@ -134,7 +134,7 @@ class CrossCol[T: ClassTag](
       if (current.length == input.length - 1) {
         result ++= children
       } else {
-        stack.pushAll(children)
+        stack.pushAll(children.toIterable)
       }
     }
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/tf/ControlOps.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/tf/ControlOps.scala
@@ -190,7 +190,7 @@ sealed private[bigdl] class NextIteration[T: ClassTag, D: ClassTag] private[bigd
     output.resizeAs(input).copy(input)
   }
 
-  override def getClassTagNumerics(): (Array[ClassManifest[_]], Array[TensorNumeric[_]]) = {
+  override def getClassTagNumerics(): (Array[ClassTag[_]], Array[TensorNumeric[_]]) = {
     (Array[ClassTag[_]](scala.reflect.classTag[T], scala.reflect.classTag[D]),
       Array[TensorNumeric[_]](ev, ev2))
   }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/tf/DataFlowOps.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nn/tf/DataFlowOps.scala
@@ -213,7 +213,7 @@ private[bigdl] class TensorArrayCreator[T: ClassTag, D: ClassTag](
     }
   }
 
-  override def getClassTagNumerics(): (Array[ClassManifest[_]], Array[TensorNumeric[_]]) = {
+  override def getClassTagNumerics(): (Array[ClassTag[_]], Array[TensorNumeric[_]]) = {
     (Array[ClassTag[_]](scala.reflect.classTag[T], scala.reflect.classTag[D]),
       Array[TensorNumeric[_]](ev, ev2))
   }
@@ -276,7 +276,7 @@ private[bigdl] class TensorArrayWrite[T: ClassTag, D: ClassTag]()(
     output
   }
 
-  override def getClassTagNumerics(): (Array[ClassManifest[_]], Array[TensorNumeric[_]]) = {
+  override def getClassTagNumerics(): (Array[ClassTag[_]], Array[TensorNumeric[_]]) = {
     (Array[ClassTag[_]](scala.reflect.classTag[T], scala.reflect.classTag[D]),
       Array[TensorNumeric[_]](ev, ev2))
   }
@@ -309,7 +309,7 @@ private[bigdl] class TensorArrayRead[T: ClassTag, D: ClassTag]()(
     output
   }
 
-  override def getClassTagNumerics(): (Array[ClassManifest[_]], Array[TensorNumeric[_]]) = {
+  override def getClassTagNumerics(): (Array[ClassTag[_]], Array[TensorNumeric[_]]) = {
     (Array[ClassTag[_]](scala.reflect.classTag[T], scala.reflect.classTag[D]),
       Array[TensorNumeric[_]](ev, ev2))
   }
@@ -370,7 +370,7 @@ private[bigdl] class TensorArrayGather[T: ClassTag, D: ClassTag]()(
     output
   }
 
-  override def getClassTagNumerics(): (Array[ClassManifest[_]], Array[TensorNumeric[_]]) = {
+  override def getClassTagNumerics(): (Array[ClassTag[_]], Array[TensorNumeric[_]]) = {
     (Array[ClassTag[_]](scala.reflect.classTag[T], scala.reflect.classTag[D]),
       Array[TensorNumeric[_]](ev, ev2))
   }
@@ -416,7 +416,7 @@ private[bigdl] class TensorArrayScatter[T: ClassTag, D: ClassTag]()(
     output
   }
 
-  override def getClassTagNumerics(): (Array[ClassManifest[_]], Array[TensorNumeric[_]]) = {
+  override def getClassTagNumerics(): (Array[ClassTag[_]], Array[TensorNumeric[_]]) = {
     (Array[ClassTag[_]](scala.reflect.classTag[T], scala.reflect.classTag[D]),
       Array[TensorNumeric[_]](ev, ev2))
   }
@@ -477,7 +477,7 @@ private[bigdl] class TensorArrayConcat[T: ClassTag, D: ClassTag]()(
     output
   }
 
-  override def getClassTagNumerics(): (Array[ClassManifest[_]], Array[TensorNumeric[_]]) = {
+  override def getClassTagNumerics(): (Array[ClassTag[_]], Array[TensorNumeric[_]]) = {
     (Array[ClassTag[_]](scala.reflect.classTag[T], scala.reflect.classTag[D]),
       Array[TensorNumeric[_]](ev, ev2))
   }
@@ -531,7 +531,7 @@ private[bigdl] class TensorArraySplit[T: ClassTag, D: ClassTag]()(
     output
   }
 
-  override def getClassTagNumerics(): (Array[ClassManifest[_]], Array[TensorNumeric[_]]) = {
+  override def getClassTagNumerics(): (Array[ClassTag[_]], Array[TensorNumeric[_]]) = {
     (Array[ClassTag[_]](scala.reflect.classTag[T], scala.reflect.classTag[D]),
       Array[TensorNumeric[_]](ev, ev2))
   }
@@ -644,7 +644,7 @@ private[bigdl] class StackCreator[T: ClassTag, D: ClassTag](
     }
   }
 
-  override def getClassTagNumerics(): (Array[ClassManifest[_]], Array[TensorNumeric[_]]) = {
+  override def getClassTagNumerics(): (Array[ClassTag[_]], Array[TensorNumeric[_]]) = {
     (Array[ClassTag[_]](scala.reflect.classTag[T], scala.reflect.classTag[D]),
       Array[TensorNumeric[_]](ev, ev2))
   }
@@ -660,7 +660,7 @@ private[bigdl] class StackPop[T: ClassTag, D: ClassTag]()
     output
   }
 
-  override def getClassTagNumerics(): (Array[ClassManifest[_]], Array[TensorNumeric[_]]) = {
+  override def getClassTagNumerics(): (Array[ClassTag[_]], Array[TensorNumeric[_]]) = {
     (Array[ClassTag[_]](scala.reflect.classTag[T], scala.reflect.classTag[D]),
       Array[TensorNumeric[_]](ev, ev2))
   }
@@ -679,7 +679,7 @@ private[bigdl] class StackPush[T: ClassTag, D: ClassTag]()
     output
   }
 
-  override def getClassTagNumerics(): (Array[ClassManifest[_]], Array[TensorNumeric[_]]) = {
+  override def getClassTagNumerics(): (Array[ClassTag[_]], Array[TensorNumeric[_]]) = {
     (Array[ClassTag[_]](scala.reflect.classTag[T], scala.reflect.classTag[D]),
       Array[TensorNumeric[_]](ev, ev2))
   }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nnframes/NNClassifier.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/nnframes/NNClassifier.scala
@@ -207,7 +207,7 @@ class NNClassifierModel[T: ClassTag] private[bigdl] (
   setDefault(threshold, 0.5)
 
   protected override def outputToPrediction(output: Tensor[T]): Any = {
-    if (output.size().deep == Array(1).deep) {
+    if (output.size().sameElements(Array(1))) {
       val raw = ev.toType[Double](output.toArray().head)
       if (raw > 0.5) 1.0 else 0.0
     } else {

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/optim/DistriOptimizer.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/optim/DistriOptimizer.scala
@@ -244,7 +244,7 @@ object DistriOptimizer extends AbstractOptimizer {
               b += 1
             }
           })
-          Engine.default.sync(tasks)
+          Engine.default.sync(tasks.toSeq)
           weightsResults.waitResult()
           val weightSyncTime = System.nanoTime() - syWStart
           driverMetrics.add("get weights average", weightSyncTime)

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/optim/DistriOptimizerV2.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/optim/DistriOptimizerV2.scala
@@ -945,7 +945,7 @@ class TrainingContext[T: ClassTag](
         LossWithElapsedTime(i, loss, end - start)
       }
     ), Long.MaxValue)
-    trainingThreads.filter(!_.isCancelled).map(_.get())
+    trainingThreads.filter(!_.isCancelled).map(_.get()).toSeq
   }
 
   def update[T: ClassTag](

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/optim/LarsSGD.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/optim/LarsSGD.scala
@@ -268,7 +268,7 @@ object LarsSGD {
           // generate Seq for each sub-module
           createOptimSeqForModule(mod, lrScheGenerator, trust, learningRate, learningRateDecay,
             weightDecay, momentum)
-        })
+        }).toSeq
       case _ =>
         if (model.parameters() != null) {
           val (lrSche, isOwner) = lrScheGenerator(model)

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/optim/ValidationMethod.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/optim/ValidationMethod.scala
@@ -448,7 +448,7 @@ class MAPValidationResult(
   }
 
   private def sortPredictions(p: ArrayBuffer[(Float, Boolean)]): ArrayBuffer[(Float, Boolean)] = {
-    p.sortBy(v => v._1)(Ordering.Float.reverse) // decending order
+    p.sortBy(v => v._1)(Ordering[Float].reverse) // decending order
   }
 
   private[bigdl] def calculateClassAP(clz: Int): Float = {
@@ -751,7 +751,7 @@ class MeanAveragePrecisionObjectDetection[T: ClassTag](
               val mask = masks.map(_ (bboxIdx - 1)).orNull
               detections.append((label, score, x1, y1, x2, y2, mask))
             }
-            detections.sortBy(v => v._2)(Ordering.Float.reverse).foreach {
+            detections.sortBy(v => v._2)(Ordering[Float].reverse).foreach {
               case (label, score, x1, y1, x2, y2, mask) =>
                 MAPUtil.parseDetection(gtBbox, label, score, x1, y1, x2, y2, mask, classes,
                   iouThres, predictByClasses)

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/DenseTensor.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/DenseTensor.scala
@@ -246,7 +246,7 @@ private[tensor] class DenseTensor[@specialized T: ClassTag](
       val _storageOffset = storageOffset - 1
       val _size = if (size == null) Array(storage.length) else size
       val _stride = if (size == null) null else stride
-      DenseTensor.newWithStorage(this, storage, _storageOffset, _size, _stride, ev)
+      DenseTensor.newWithStorage[T](this, storage, _storageOffset, _size, _stride, ev)
     }
   }
 
@@ -258,7 +258,7 @@ private[tensor] class DenseTensor[@specialized T: ClassTag](
     val _storageOffset = other.storageOffset() - 1
     val _size = other.size()
     val _stride = other.stride()
-    DenseTensor.newWithStorage(this, _storage, _storageOffset, _size, _stride, ev)
+    DenseTensor.newWithStorage[T](this, _storage, _storageOffset, _size, _stride, ev)
   }
 
   private[tensor] def this()(implicit ev: TensorNumeric[T]) = this(null, 0, null, null, 0)

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/DenseTensor.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/DenseTensor.scala
@@ -2431,8 +2431,8 @@ object DenseTensor {
   }
 
   def apply[@specialized(Float, Double) T: ClassTag](
-        storage: ArrayStorage[T], storageOffset: Int, size: Array[Int] = null,
-        stride: Array[Int] = null)(implicit ev: TensorNumeric[T]): DenseTensor[T] = {
+        storage: ArrayStorage[T], storageOffset: Int, size: Array[Int],
+        stride: Array[Int])(implicit ev: TensorNumeric[T]): DenseTensor[T] = {
     val newT = new DenseTensor[T](null, 0, null, null, 0)
     if (storage != null) {
       val _storageOffset = storageOffset - 1
@@ -2441,6 +2441,12 @@ object DenseTensor {
       DenseTensor.newWithStorage[T](newT, storage, _storageOffset, _size, _stride, ev)
     }
     newT
+  }
+
+  def apply[@specialized(Float, Double) T: ClassTag](
+        storage: ArrayStorage[T], storageOffset: Int,
+        size: Array[Int])(implicit ev: TensorNumeric[T]): DenseTensor[T] = {
+    apply(storage, storageOffset, size, null)
   }
 
   def apply[@specialized(Float, Double) T: ClassTag](

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/DenseTensorMath.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/DenseTensorMath.scala
@@ -307,7 +307,7 @@ object DenseTensorMath {
 
       val result = ev.dot(self.nElement(), self.storage().array(), self.storageOffset() - 1,
         self.stride(1), t.storage().array(), t.storageOffset() - 1, t.stride(1))
-      new DenseTensor(new ArrayStorage(Array(result)))
+      DenseTensor(new ArrayStorage(Array(result)))
     } else if (self.nDimension() == 2 && t.nDimension() == 1) {
       val result = new DenseTensor[T](self.size(1))
       DenseTensorBLAS.gemv[T](ev.fromType[Int](1), self, t, ev.fromType[Int](0), result)

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/DnnTensor.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/DnnTensor.scala
@@ -132,7 +132,7 @@ class DnnTensor[T: ClassTag](
     }
     val other = obj.asInstanceOf[DnnTensor[T]]
 
-    if (this.size().deep != other.size().deep) {
+    if (!this.size().sameElements(other.size())) {
       return false
     }
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/DnnTensor.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/DnnTensor.scala
@@ -309,7 +309,7 @@ object DnnTensor {
     override def isSameSizeAs(other: Tensor[_]): Boolean = ???
     override def emptyInstance(): Tensor[T] = ???
     override def resizeAs(src: Tensor[_]): Tensor[T] = ???
-    override def cast[D: ClassManifest](castTensor: Tensor[D])(implicit ev: TensorNumeric[D]): Tensor[D] = ???
+    override def cast[D: ClassTag](castTensor: Tensor[D])(implicit ev: TensorNumeric[D]): Tensor[D] = ???
     override def resize(sizes: Array[Int], strides: Array[Int]): Tensor[T] = ???
     override def resize(size1: Int): Tensor[T] = ???
     override def resize(size1: Int, size2: Int): Tensor[T] = ???
@@ -325,9 +325,9 @@ object DnnTensor {
     override def set(): Tensor[T] = ???
     override def narrow(dim: Int, index: Int, size: Int): Tensor[T] = ???
     override def copy(other: Tensor[T]): Tensor[T] = ???
-    override def applyFun[A: ClassManifest](t: Tensor[A], func: (A) => T): Tensor[T] = ???
+    override def applyFun[A: ClassTag](t: Tensor[A], func: (A) => T): Tensor[T] = ???
     override def apply1(func: (T) => T): Tensor[T] = ???
-    override def zipWith[A: ClassManifest, B: ClassManifest](t1: Tensor[A], t2: Tensor[B], func: (A, B) => T): Tensor[T] = ???
+    override def zipWith[A: ClassTag, B: ClassTag](t1: Tensor[A], t2: Tensor[B], func: (A, B) => T): Tensor[T] = ???
     override def map(other: Tensor[T], func: (T, T) => T): Tensor[T] = ???
     override def squeeze(): Tensor[T] = ???
     override def squeeze(dim: Int): Tensor[T] = ???

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/QuantizedTensor.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/QuantizedTensor.scala
@@ -245,7 +245,7 @@ private[bigdl] class QuantizedTensor[T: ClassTag](
    * @return current tensor
    */
   override def copy(other: Tensor[T]): Tensor[T] = {
-    if (other.isInstanceOf[QuantizedTensor[T]] && other.size().deep == this.size().deep) {
+    if (other.isInstanceOf[QuantizedTensor[T]] && other.size().sameElements(this.size())) {
       val quantizedTensor = other.asInstanceOf[QuantizedTensor[T]]
 
       if (internalStorage != null) {

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/SparseTensor.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/SparseTensor.scala
@@ -1108,9 +1108,9 @@ private[tensor] class SparseTensor[@specialized(Float, Double) T: ClassTag](
       d += 1
     }
 
-    _indices.map(_.array()).deep == other._indices.map(_.array()).deep &&
-      _values.array().deep == other._values.array().deep &&
-      this._shape.deep == other._shape.deep &&
+    _indices.map(_.array()).corresponds(other._indices.map(_.array())) {_ sameElements _} &&
+      _values.array().sameElements(other._values.array()) &&
+      this._shape.sameElements(other._shape) &&
       this._nElement == other._nElement
   }
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/Tensor.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/tensor/Tensor.scala
@@ -981,7 +981,7 @@ object Tensor {
     implicit ev: TensorNumeric[T]): Tensor[T] = {
     Log4Error.unKnowExceptionError(storage.isInstanceOf[ArrayStorage[_]],
       "Only support array storage in this operaiton")
-    new DenseTensor(storage.asInstanceOf[ArrayStorage[T]])
+    DenseTensor(storage.asInstanceOf[ArrayStorage[T]])
   }
 
   /**
@@ -1029,7 +1029,7 @@ object Tensor {
     storageOffset: Int,
     size: Array[Int] = null,
     stride: Array[Int] = null)(implicit ev: TensorNumeric[T]): Tensor[T] = {
-    new DenseTensor(storage.asInstanceOf[ArrayStorage[T]], storageOffset, size, stride)
+    DenseTensor(storage.asInstanceOf[ArrayStorage[T]], storageOffset, size, stride)
   }
 
   /**
@@ -1042,7 +1042,15 @@ object Tensor {
    * @return
    */
   def apply[@specialized(Float, Double) T: ClassTag](other: Tensor[T])(
-    implicit ev: TensorNumeric[T]): Tensor[T] = new DenseTensor(other)
+    implicit ev: TensorNumeric[T]): Tensor[T] = {
+    val newT = new DenseTensor[T](null, 0, null, null, 0)
+    val _storage = other.storage().asInstanceOf[ArrayStorage[T]]
+    val _storageOffset = other.storageOffset() - 1
+    val _size = other.size()
+    val _stride = other.stride()
+    DenseTensor.newWithStorage[T](newT, _storage, _storageOffset, _size, _stride, ev)
+    newT
+  }
 
   /**
    * create a tensor with a given breeze vector. The tensor will have the same size

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/DirectedGraph.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/DirectedGraph.scala
@@ -192,37 +192,37 @@ class Node[T](var element: T) extends Serializable {
    * The nodes pointed by current node
    * @return
    */
-  def nextNodes: Seq[Node[T]] = nexts.map(_._1)
+  def nextNodes: Seq[Node[T]] = nexts.map(_._1).toSeq
 
   /**
    * The edges start from this node
    * @return
    */
-  def nextEdges: Seq[Edge] = nexts.map(_._2)
+  def nextEdges: Seq[Edge] = nexts.map(_._2).toSeq
 
   /**
    * The nodes pointed by current node with the connect edges
    * @return
    */
-  def nextNodesAndEdges: Seq[(Node[T], Edge)] = nexts
+  def nextNodesAndEdges: Seq[(Node[T], Edge)] = nexts.toSeq
 
   /**
    * The nodes point to current node
    * @return
    */
-  def prevNodes: Seq[Node[T]] = prevs.map(_._1)
+  def prevNodes: Seq[Node[T]] = prevs.map(_._1).toSeq
 
   /**
    * The edges connect to this node
    * @return
    */
-  def prevEdges: Seq[Edge] = prevs.map(_._2)
+  def prevEdges: Seq[Edge] = prevs.map(_._2).toSeq
 
   /**
    * The nodes pointed to current node with the connect edges
    * @return
    */
-  def prevNodesAndEdges: Seq[(Node[T], Edge)] = prevs
+  def prevNodesAndEdges: Seq[(Node[T], Edge)] = prevs.toSeq
 
   // scalastyle:off methodName
   // scalastyle:off noSpaceBeforeLeftBracket

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/Table.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/Table.scala
@@ -136,8 +136,8 @@ class Table private[bigdl](
     }
     this.state.keys.foreach(key => {
       if (this.state(key).isInstanceOf[Array[_]] && other.state(key).isInstanceOf[Array[_]]) {
-        return (this.state(key).asInstanceOf[Array[_]].deep ==
-          other.state(key).asInstanceOf[Array[_]].deep)
+        return this.state(key).asInstanceOf[Array[_]].sameElements(
+          other.state(key).asInstanceOf[Array[_]])
       } else if (this.state(key) != other.state(key)) {
         return false
       }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/caffe/LayerConverter.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/caffe/LayerConverter.scala
@@ -642,7 +642,7 @@ class LayerConverter[T: ClassTag](implicit ev: TensorNumeric[T]) extends Convert
       nextedLayers(nextedLayers.size - 1).
         asInstanceOf[LayerParameter].getTopList.asScala.foreach(lastBottoms.append(_))
     })
-    res
+    res.toSeq
   }
 
   private def toCaffeWithWeightAndBiasOnly(module : AbstractModule[Activity, Activity, T],

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/caffe/V1LayerConverter.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/caffe/V1LayerConverter.scala
@@ -563,7 +563,7 @@ class V1LayerConverter[T: ClassTag](implicit ev: TensorNumeric[T]) extends Conve
       nextedLayers(nextedLayers.size - 1).
         asInstanceOf[V1LayerParameter].getTopList.asScala.foreach(lastBottoms.append(_))
     })
-    res
+    res.toSeq
   }
 
   private def toCaffeWithWeightAndBiasOnly(module : AbstractModule[Activity, Activity, T],

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/serializer/ModuleLoader.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/serializer/ModuleLoader.scala
@@ -254,7 +254,7 @@ object ModulePersister {
   private def serializeModule[T : ClassTag](module: AbstractModule[Activity, Activity, T],
     storageType: StorageType)(implicit ev: TensorNumeric[T]): SerializeResult = {
     val bigDLModule = ModuleData(module
-      , new ArrayBuffer[String](), new ArrayBuffer[String]())
+      , Seq[String](), Seq[String]())
     val storages = new mutable.HashMap[Int, Any]()
     val context = SerializeContext(bigDLModule, storages, storageType)
     ModuleSerializer.serialize(context)
@@ -343,7 +343,7 @@ object ModulePersister {
   def saveModelDefinitionToFile[T: ClassTag](definitionPath : String,
     module : AbstractModule[Activity, Activity, T],
     overwrite : Boolean = false)(implicit ev: TensorNumeric[T]) : Unit = {
-    val bigDLModule = ModuleData(module, new ArrayBuffer[String](), new ArrayBuffer[String]())
+    val bigDLModule = ModuleData(module, Seq[String](), Seq[String]())
     val storages = new mutable.HashMap[Int, Any]()
     val context = SerializeContext(bigDLModule, storages, ProtoStorageType)
     val bigDLModel = ModuleSerializer.serialize(context).bigDLModule

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/serializer/ModuleSerializable.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/serializer/ModuleSerializable.scala
@@ -239,8 +239,8 @@ trait ModuleSerializable extends Loadable with Savable{
                                               (implicit ev: TensorNumeric[T])
   : ModuleData[T] = {
     val model = context.bigdlModule
-    val preModules = model.getPreModulesList.asScala
-    val nextModules = model.getNextModulesList.asScala
+    val preModules = model.getPreModulesList.asScala.toSeq
+    val nextModules = model.getNextModulesList.asScala.toSeq
     val bigDLModule = ModuleData(module, preModules, nextModules)
     if (model.getName != "") {
       module.setName(model.getName)
@@ -506,7 +506,7 @@ trait ContainerSerializable extends ModuleSerializable {
       asInstanceOf[Container[Activity, Activity, T]].modules
     subModulesData.foreach(module => {
       val subModule = ModuleSerializer.serialize(SerializeContext(ModuleData(module,
-        new ArrayBuffer[String](), new ArrayBuffer[String]()), context.storages,
+        Seq[String](), Seq[String]()), context.storages,
         context.storageType, _copyWeightAndBias))
       containerBuilder.addSubModules(subModule.bigDLModule)
     })

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/BigDLToTensorflow.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/BigDLToTensorflow.scala
@@ -375,7 +375,7 @@ object JoinTableToTF extends BigDLToTensorflow {
     val updateInputs = new ArrayBuffer[NodeDef]()
     updateInputs ++= inputs.reverse
     updateInputs.append(axis)
-    Seq(concat(updateInputs, layer.getName()), axis)
+    Seq(concat(updateInputs.toSeq, layer.getName()), axis)
   }
 }
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/Session.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/Session.scala
@@ -392,7 +392,7 @@ class BigDLSessionImpl[T: ClassTag](graph: Seq[NodeDef], context: Context[T],
         s"Cannot find enqueue node for queue: ${queueNode.element}")
       null
     } else {
-      enqueNodes
+      enqueNodes.toSeq
     }
   }
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/Session.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/Session.scala
@@ -375,7 +375,7 @@ class BigDLSessionImpl[T: ClassTag](graph: Seq[NodeDef], context: Context[T],
   private def findEnqueueNodes(queueNode: Node[NodeDef]): Seq[Node[NodeDef]] = {
     val queue = mutable.Queue[Node[NodeDef]]()
     val enqueNodes = mutable.ArrayBuffer[Node[NodeDef]]()
-    queue.enqueue(queueNode.nextNodes: _*)
+    queueNode.nextNodes.foreach(queue.enqueue(_))
     val visited = mutable.HashSet[Node[NodeDef]]()
     while(queue.nonEmpty) {
       val node = queue.dequeue()
@@ -383,7 +383,7 @@ class BigDLSessionImpl[T: ClassTag](graph: Seq[NodeDef], context: Context[T],
         if (node.element != null && enqueueOp(node.element.getOp)) {
           enqueNodes += node
         } else if (node.element != null && identityOp(node.element.getOp)) {
-          queue.enqueue(node.nextNodes: _*)
+          node.nextNodes.foreach(queue.enqueue(_))
         }
       }
     }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/TensorflowLoader.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/TensorflowLoader.scala
@@ -247,7 +247,7 @@ object TensorflowLoader{
     val originInputs = new mutable.ArrayBuffer[String]()
 
     // Do a BFS to connect the nodes
-    queue.enqueue(nodes: _*)
+    nodes.foreach(queue.enqueue(_))
     while(queue.nonEmpty) {
       val node = queue.dequeue()
       if (!visited(node)) {
@@ -451,7 +451,7 @@ object TensorflowLoader{
     def connect(outputModuleNode: Seq[Node[AbstractModule[Activity, Activity, T]]]) = {
       val queue = new mutable.Queue[Node[AbstractModule[Activity, Activity, T]]]()
       val visited = mutable.Set[Node[AbstractModule[Activity, Activity, T]]]()
-      queue.enqueue(outputModuleNode: _*)
+      outputModuleNode.foreach(queue.enqueue(_))
 
       while (queue.nonEmpty) {
         val currNode = queue.dequeue()
@@ -465,7 +465,7 @@ object TensorflowLoader{
             .filterNot(n => allNodes(n._1))
             .map(n => (convertedNode(n._1), n._2.newInstance())).filter(n => n._1 != currNode)
           inputModuleNodes.foreach(n => n._1.add(currNode, n._2))
-          queue.enqueue(inputModuleNodes.map(_._1): _*)
+          inputModuleNodes.map(_._1).foreach(queue.enqueue(_))
         }
       }
     }

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/TensorflowLoader.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/TensorflowLoader.scala
@@ -81,7 +81,7 @@ object TensorflowLoader{
     val context = binFile.map(loadBinFiles(_))
 
     // Build BigDL model from the tf node graph
-    buildBigDLModel(tfGraph, newInputs, outputs, byteOrder, graphPrototxt,
+    buildBigDLModel(tfGraph, newInputs.toSeq, outputs.toSeq, byteOrder, graphPrototxt,
       context, generatedBackward)
   }
 
@@ -90,7 +90,7 @@ object TensorflowLoader{
     // Get node list
     val nodeList = parse(graphFile)
 
-    new BigDLSessionImpl[T](nodeList.asScala, loadBinFiles(binFile), byteOrder)
+    new BigDLSessionImpl[T](nodeList.asScala.toSeq, loadBinFiles(binFile), byteOrder)
   }
 
   /**
@@ -312,7 +312,7 @@ object TensorflowLoader{
         }
       }
     }
-    (newInputs, originInputs)
+    (newInputs, originInputs.toSeq)
   }
 
   private def pushPreNode(name: String, name2Node: Map[String, Node[NodeDef]],
@@ -418,7 +418,7 @@ object TensorflowLoader{
           module.setName(removeColon(nodes.get(0).element.getName()))
         } else {
           // Many to one map
-          val name = removeColon(findCommonPrefix(nodes.asScala.map(_.element.getName)))
+          val name = removeColon(findCommonPrefix(nodes.asScala.map(_.element.getName).toSeq))
           if (name == "") {
             // Use a name combine nodes
             module.setName(s"[${nodes.asScala.map(_.element.getName).map(_.replaceAll("/", "\\\\"))
@@ -601,7 +601,7 @@ object TensorflowLoader{
       }
     })
     import scala.collection.JavaConverters._
-    return (patternToGraph.valuesIterator.toList.asJava, inputs)
+    return (patternToGraph.valuesIterator.toList.asJava, inputs.toSeq)
   }
 
   private def findCommonPrefix(data: Seq[String]): String = {

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/TensorflowSaver.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/TensorflowSaver.scala
@@ -64,7 +64,7 @@ object TensorflowSaver {
 
     model.getSortedForwardExecutions.foreach(n => {
       val nodeDefs = maps(n.element.getClass.getName).toTFDef(n.element,
-        inputNodeCache(n.element.getName()),
+        inputNodeCache(n.element.getName()).toSeq,
         byteOrder)
       nodeDefs.foreach(nDef => {
         graphBuilder.addNode(nDef)

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/TensorflowToBigDL.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/TensorflowToBigDL.scala
@@ -92,7 +92,7 @@ trait TensorflowToBigDL {
   }
 
   protected def getIntList(attrMap: util.Map[String, AttrValue], key: String): Seq[Int] = {
-    attrMap.get(key).getList.getIList.asScala.map(_.toInt)
+    attrMap.get(key).getList.getIList.asScala.map(_.toInt).toSeq
   }
 
   protected def getBoolean(attrMap: util.Map[String, AttrValue], key: String): Boolean = {

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/loaders/DataFlowOps.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/loaders/DataFlowOps.scala
@@ -30,7 +30,7 @@ import scala.reflect.ClassTag
 
 private[bigdl] class TensorArrayV3 extends TensorflowOpsLoader {
 
-  override def build[T: ClassManifest](
+  override def build[T: ClassTag](
     nodeDef: NodeDef,
     byteOrder: ByteOrder,
     context: Context[T]
@@ -75,7 +75,7 @@ private[bigdl] class TensorArrayV3 extends TensorflowOpsLoader {
 
 private[bigdl] class TensorArrayGradV3 extends TensorflowOpsLoader {
 
-  override def build[T: ClassManifest](
+  override def build[T: ClassTag](
     nodeDef: NodeDef,
     byteOrder: ByteOrder,
     context: Context[T]
@@ -86,7 +86,7 @@ private[bigdl] class TensorArrayGradV3 extends TensorflowOpsLoader {
 }
 
 class TensorArrayGatherV3 extends TensorflowOpsLoader {
-  override def build[T: ClassManifest](
+  override def build[T: ClassTag](
     nodeDef: NodeDef,
     byteOrder: ByteOrder,
     context: Context[T]
@@ -107,7 +107,7 @@ class TensorArrayGatherV3 extends TensorflowOpsLoader {
 }
 
 private[bigdl] class TensorArrayScatterV3 extends TensorflowOpsLoader {
-  override def build[T: ClassManifest](
+  override def build[T: ClassTag](
     nodeDef: NodeDef,
     byteOrder: ByteOrder,
     context: Context[T]
@@ -128,7 +128,7 @@ private[bigdl] class TensorArrayScatterV3 extends TensorflowOpsLoader {
 }
 
 private[bigdl] class TensorArrayConcatV3 extends TensorflowOpsLoader {
-  override def build[T: ClassManifest](
+  override def build[T: ClassTag](
     nodeDef: NodeDef,
     byteOrder: ByteOrder,
     context: Context[T]
@@ -149,7 +149,7 @@ private[bigdl] class TensorArrayConcatV3 extends TensorflowOpsLoader {
 }
 
 private[bigdl] class TensorArraySplitV3 extends TensorflowOpsLoader {
-  override def build[T: ClassManifest](
+  override def build[T: ClassTag](
     nodeDef: NodeDef,
     byteOrder: ByteOrder,
     context: Context[T]
@@ -170,7 +170,7 @@ private[bigdl] class TensorArraySplitV3 extends TensorflowOpsLoader {
 }
 
 private[bigdl] class TensorArrayReadV3 extends TensorflowOpsLoader {
-  override def build[T: ClassManifest](
+  override def build[T: ClassTag](
     nodeDef: NodeDef,
     byteOrder: ByteOrder,
     context: Context[T]
@@ -191,7 +191,7 @@ private[bigdl] class TensorArrayReadV3 extends TensorflowOpsLoader {
 }
 
 private[bigdl] class TensorArrayWriteV3 extends TensorflowOpsLoader {
-  override def build[T: ClassManifest](
+  override def build[T: ClassTag](
     nodeDef: NodeDef,
     byteOrder: ByteOrder,
     context: Context[T]
@@ -212,7 +212,7 @@ private[bigdl] class TensorArrayWriteV3 extends TensorflowOpsLoader {
 }
 
 private[bigdl] class TensorArraySizeV3 extends TensorflowOpsLoader {
-  override def build[T: ClassManifest](
+  override def build[T: ClassTag](
     nodeDef: NodeDef,
     byteOrder: ByteOrder,
     context: Context[T]

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/loaders/ParseExample.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/loaders/ParseExample.scala
@@ -53,7 +53,7 @@ class ParseExample extends TensorflowOpsLoader {
         shapeProto.getDimList.asScala.map(_.getSize.toInt).toArray
       }
 
-    new ParseExampleOperation[T](Ndense, Tdense, denseShapes)
+    new ParseExampleOperation[T](Ndense, Tdense.toSeq, denseShapes.toSeq)
   }
 }
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/loaders/ParseSingleExample.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/loaders/ParseSingleExample.scala
@@ -56,7 +56,7 @@ class ParseSingleExample extends TensorflowOpsLoader {
         shapeProto.getDimList.asScala.map(_.getSize.toInt).toArray
       }
 
-    new ParseSingleExampleOperation[T](Tdense, denseKeys, denseShapes)
+    new ParseSingleExampleOperation[T](Tdense.toSeq, denseKeys.toSeq, denseShapes.toSeq)
   }
 }
 

--- a/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/loaders/Utils.scala
+++ b/scala/dllib/src/main/scala/com/intel/analytics/bigdl/dllib/utils/tf/loaders/Utils.scala
@@ -90,7 +90,7 @@ object Utils {
   private[loaders] def getIntList(attrMap: util.Map[String, AttrValue], key: String): Seq[Int] = {
     Log4Error.invalidInputError(attrMap.containsKey(key),
       s"Operation doesn't contain attributed $key")
-    attrMap.get(key).getList.getIList.asScala.map(_.toInt)
+    attrMap.get(key).getList.getIList.asScala.map(_.toInt).toSeq
   }
 
   private[loaders] def getType(attrMap: util.Map[String, AttrValue], key: String): DataType = {

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/feature/FeatureSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/feature/FeatureSpec.scala
@@ -156,8 +156,8 @@ class FeatureSpec extends FlatSpec with Matchers with BeforeAndAfter {
       .array.head.apply[Tensor[Float]](ImageFeature.imageTensor)
 
     TestUtils.conditionFailTest(
-      nchw.transpose(1, 2).transpose(2, 3).contiguous().storage().array().deep
-      == nhwc.storage().array().deep)
+      nchw.transpose(1, 2).transpose(2, 3).contiguous().storage()
+        .array().sameElements(nhwc.storage().array()))
   }
 
   ignore should "ImageChannelNormalize with std not 1 work properly" in {

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/integration/torch/AddSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/integration/torch/AddSpec.scala
@@ -18,7 +18,6 @@ package com.intel.analytics.bigdl.dllib.integration.torch
 import com.intel.analytics.bigdl.dllib.nn.Add
 import com.intel.analytics.bigdl.dllib.tensor.Tensor
 import com.intel.analytics.bigdl.dllib.utils.RandomGenerator._
-import spire.syntax.module
 
 @com.intel.analytics.bigdl.tags.Serial
 class AddSpec extends TorchSpec {

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/keras/layers/ExpandDimSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/keras/layers/ExpandDimSpec.scala
@@ -34,7 +34,7 @@ class Expand_dimSpec extends KerasBaseSpec {
     seq.getOutputShape().toSingle().toArray should be(Array(1, 3))
     val inputData = Tensor[Float](Array(3)).randn()
     val out = seq.forward(inputData).toTensor[Float]
-    TestUtils.conditionFailTest(out.size().deep == Array(1, 3).deep)
+    TestUtils.conditionFailTest(out.size().sameElements(Array(1, 3)))
     out.toTensor[Float].almostEqual(inputData.addSingletonDimension(dim = 1), 1e-4)
   }
 
@@ -45,7 +45,7 @@ class Expand_dimSpec extends KerasBaseSpec {
     seq.getOutputShape().toSingle().toArray should be(Array(3, 1, 4))
     val inputData = Tensor[Float](Array(2, 1, 6)).rand()
     val out = seq.forward(inputData).toTensor[Float]
-    TestUtils.conditionFailTest(out.size().deep == Array(3, 1, 4).deep)
+    TestUtils.conditionFailTest(out.size().sameElements(Array(3, 1, 4)))
     out.toTensor[Float].almostEqual(inputData.addSingletonDimension(dim = 1), 1e-4)
   }
 }

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/keras/layers/TransformerLayerSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/keras/layers/TransformerLayerSpec.scala
@@ -434,14 +434,14 @@ class TransformerLayerSpec extends ZooSpecHelper {
     KerasUtils.tril(data)
     val expect = Array[Float](1, 0, 0, 1, 1, 0, 1, 1, 1)
     val res = data.storage().array()
-    TestUtils.conditionFailTest(expect.deep == res.deep)
+    TestUtils.conditionFailTest(expect.sameElements(res))
 
     val data2 = Tensor.ones[Float](4, 6)
     KerasUtils.tril(data2)
     val expect2 = Array[Float](1, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0,
       1, 1, 1, 0, 0, 0, 1, 1, 1, 1, 0, 0)
     val res2 = data2.storage().array()
-    TestUtils.conditionFailTest(expect2.deep == res2.deep)
+    TestUtils.conditionFailTest(expect2.sameElements(res2))
   }
 
   "Conv1D" should "be generate the same result with pytorch-openai conv1d" in {

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/keras/models/TrainingSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/keras/models/TrainingSpec.scala
@@ -21,17 +21,12 @@ import com.intel.analytics.bigdl.dllib.optim._
 import com.intel.analytics.bigdl.dllib.utils.python.api.PythonBigDL
 import com.intel.analytics.bigdl.dllib.tensor.TensorNumericMath.TensorNumeric
 import com.intel.analytics.bigdl.dllib.tensor.{Storage, Tensor}
-import com.intel.analytics.bigdl.dllib.feature.transform.vision.image.opencv.OpenCVMat
-import com.intel.analytics.bigdl.dllib.feature.transform.vision.image.{ImageFeature, ImageFrame}
-import com.intel.analytics.bigdl.dllib.utils.RandomGenerator.RNG
 import com.intel.analytics.bigdl.dllib.utils.{RandomGenerator, Shape, T, TestUtils}
 import com.intel.analytics.bigdl.dllib.NNContext
 import com.intel.analytics.bigdl.dllib.feature.image._
 import com.intel.analytics.bigdl.dllib.keras.autograd.{Variable, AutoGrad => A}
-import com.intel.analytics.bigdl.dllib.keras.{Sequential, ZooSpecHelper}
+import com.intel.analytics.bigdl.dllib.keras.ZooSpecHelper
 import com.intel.analytics.bigdl.dllib.keras.layers._
-import com.intel.analytics.bigdl.dllib.keras.models.Sequential
-import com.intel.analytics.bigdl.dllib.keras.models.Model
 import com.intel.analytics.bigdl.dllib.keras.objectives.{BinaryCrossEntropy, ZooClassNLLCriterion}
 import com.intel.analytics.bigdl.dllib.keras.python.PythonZooKeras
 import com.intel.analytics.bigdl.dllib.nn.Graph._

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/nn/mkldnn/RNNSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/nn/mkldnn/RNNSpec.scala
@@ -20,9 +20,8 @@ import org.scalatest.{FlatSpec, Matchers}
 import com.intel.analytics.bigdl.mkl.{AlgKind, Direction, Memory}
 import com.intel.analytics.bigdl.dllib.nn.mkldnn.Phase.{InferencePhase, TrainingPhase}
 import com.intel.analytics.bigdl.dllib.tensor.Tensor
-import com.intel.analytics.bigdl._
 import com.intel.analytics.bigdl.dllib.nn
-import com.intel.analytics.bigdl.dllib.nn._
+import com.intel.analytics.bigdl.dllib.nn.StaticGraph
 import com.intel.analytics.bigdl.dllib.nn.abstractnn.AbstractModule
 import com.intel.analytics.bigdl.dllib.tensor.TensorNumericMath.TensorNumeric.NumericFloat
 import com.intel.analytics.bigdl.dllib.utils.RandomGenerator._

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/nn/mkldnn/ReorderMemorySpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/nn/mkldnn/ReorderMemorySpec.scala
@@ -251,8 +251,8 @@ class ReorderMemorySpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     println(reorder.gradInput.toTensor[Float].size().mkString("\t"))
 
-    output.toTensor[Float].size().deep == Array(24, 1, 5, 5).deep should be (true)
-    gradInput.toTensor[Float].size().deep == Array(20, 1, 5, 5).deep should be (true)
+    output.toTensor[Float].size().sameElements(Array(24, 1, 5, 5)) should be (true)
+    gradInput.toTensor[Float].size().sameElements(Array(20, 1, 5, 5)) should be (true)
 
     gradInput should be (input)
   }

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/nnframes/NNClassifierSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/nnframes/NNClassifierSpec.scala
@@ -228,7 +228,7 @@ class NNClassifierSpec extends ZooSpecHelper {
     (0 until 10).foreach(i =>
       tensorBuffer.append(
         Data(targetArr(i), inputArr.slice(i * 28 * 28, (i + 1) * 28 * 28).map(_.toDouble))))
-    val rowRDD = sc.parallelize(tensorBuffer)
+    val rowRDD = sc.parallelize(tensorBuffer.toSeq)
     val testData = sqlContext.createDataFrame(rowRDD)
     TestUtils.conditionFailTest(
       valTrans.transform(testData).where("prediction=label").count() == testData.count())
@@ -355,7 +355,7 @@ class NNClassifierSpec extends ZooSpecHelper {
     val copiedVal = copied.getValidation.get
     TestUtils.conditionFailTest(estVal._1 == copiedVal._1)
     TestUtils.conditionFailTest(estVal._2 == copiedVal._2)
-    TestUtils.conditionFailTest(estVal._3.deep == copiedVal._3.deep)
+    TestUtils.conditionFailTest(estVal._3.corresponds(copiedVal._3)(_ == _))
     TestUtils.conditionFailTest(estVal._4 == copiedVal._4)
 
     // train Summary and validation Summary are not copied since they are not thread-safe and cannot

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/nnframes/NNEstimatorSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/nnframes/NNEstimatorSpec.scala
@@ -532,7 +532,7 @@ class NNEstimatorSpec extends ZooSpecHelper {
     val copiedVal = copied.getValidation.get
     TestUtils.conditionFailTest(estVal._1 == copiedVal._1)
     TestUtils.conditionFailTest(estVal._2 == copiedVal._2)
-    TestUtils.conditionFailTest(estVal._3.deep == copiedVal._3.deep)
+    TestUtils.conditionFailTest(estVal._3.corresponds(copiedVal._3)(_ == _))
     TestUtils.conditionFailTest(estVal._4 == copiedVal._4)
 
     // train Summary and validation Summary are not copied since they are not thread-safe and cannot

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/optim/PredictionServiceSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/optim/PredictionServiceSpec.scala
@@ -137,7 +137,7 @@ class PredictionServiceSpec extends FlatSpec with Matchers {
 
     RNG.setSeed(100)
 
-    val sumResults = (1 to 100).par.map { _ =>
+    val sumResults = collection.parallel.immutable.ParVector(1 to 100).map { _ =>
       val tensor = Tensor[Float](2, 10).randn()
       val output = service.predict(tensor).asInstanceOf[Tensor[Float]]
       val output2 = service2.predict(tensor).asInstanceOf[Tensor[Float]]

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/optim/PredictionServiceSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/optim/PredictionServiceSpec.scala
@@ -137,7 +137,7 @@ class PredictionServiceSpec extends FlatSpec with Matchers {
 
     RNG.setSeed(100)
 
-    val sumResults = collection.parallel.immutable.ParVector(1 to 100).map { _ =>
+    val sumResults = collection.parallel.immutable.ParVector.range(1, 100).map { _ =>
       val tensor = Tensor[Float](2, 10).randn()
       val output = service.predict(tensor).asInstanceOf[Tensor[Float]]
       val output2 = service2.predict(tensor).asInstanceOf[Tensor[Float]]

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/tensor/DenseTensorMathSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/tensor/DenseTensorMathSpec.scala
@@ -22,29 +22,29 @@ import org.scalatest.{FlatSpec, Matchers}
 @com.intel.analytics.bigdl.tags.Parallel
 class DenseTensorMathSpec extends FlatSpec with Matchers {
   "a.dist(b, 1)" should "be correct" in {
-    val a: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
-    val b: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(2.0, 3.0, 4.0)))
+    val a: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val b: Tensor[Double] = DenseTensor(new ArrayStorage(Array(2.0, 3.0, 4.0)))
 
     a.dist(b, 1) should equal(3)
   }
 
   "a.dist(b, 2)" should "be correct" in {
-    val a: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
-    val b: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(3.0, 4.0, 5.0)))
+    val a: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val b: Tensor[Double] = DenseTensor(new ArrayStorage(Array(3.0, 4.0, 5.0)))
 
     a.dist(b, 2) should equal(math.sqrt(12))
   }
 
   "a.dist(b, 3)" should "be correct" in {
-    val a: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
-    val b: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(3.0, 4.0, 5.0)))
+    val a: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val b: Tensor[Double] = DenseTensor(new ArrayStorage(Array(3.0, 4.0, 5.0)))
 
     a.dist(b, 3) should equal(math.pow(24, 1.0 / 3))
   }
 
   "vector + scalar" should "be correct" in {
     val s = 2.0
-    val v: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val v: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
     val r = v + s
     r(Array(1)) should be(3.0)
     r(Array(2)) should be(4.0)
@@ -52,8 +52,8 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
   }
 
   "vector + vector" should "be correct" in {
-    val v1: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
-    val v2: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val v1: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val v2: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
     val r = v1 + v2
     r(Array(1)) should be(2.0)
     r(Array(2)) should be(4.0)
@@ -63,7 +63,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
   "vector + vector which is not contiguous" should "be correct" in {
     val v1: Tensor[Double] = new DenseTensor[Double](2, 4).fill(1)
     v1.t()
-    val v2: Tensor[Double] = new DenseTensor(new ArrayStorage(
+    val v2: Tensor[Double] = DenseTensor(new ArrayStorage(
       Array(1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0)))
     val r = v1 + v2
     r(Array(1, 1)) should be(2.0)
@@ -78,7 +78,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
 
   "vector - scalar" should "be correct" in {
     val s = 2.0
-    val v: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val v: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
     val r = v - s
     r(Array(1)) should be(-1.0)
     r(Array(2)) should be(0.0)
@@ -86,8 +86,8 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
   }
 
   "vector - vector" should "be correct" in {
-    val v1: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
-    val v2: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(2.0, 0.0, -1.0)))
+    val v1: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val v2: Tensor[Double] = DenseTensor(new ArrayStorage(Array(2.0, 0.0, -1.0)))
     val r = v1 - v2
     r(Array(1)) should be(-1.0)
     r(Array(2)) should be(2.0)
@@ -96,7 +96,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
 
   "vector * scalar" should "be correct" in {
     val s = 2.0
-    val v: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val v: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
     val r = v * s
     r(Array(1)) should be(2.0)
     r(Array(2)) should be(4.0)
@@ -104,8 +104,8 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
   }
 
   "vector * vector" should "be correct" in {
-    val v1: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
-    val v2: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(2.0, 0.0, -1.0)))
+    val v1: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val v2: Tensor[Double] = DenseTensor(new ArrayStorage(Array(2.0, 0.0, -1.0)))
     val r = v1 * v2
     r(Array(1)) should be(-1.0)
   }
@@ -119,7 +119,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
     mat(Array(2, 2)) = 6
     mat(Array(2, 3)) = 1
 
-    val vec: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(3.0, 1, 1)))
+    val vec: Tensor[Double] = DenseTensor(new ArrayStorage(Array(3.0, 1, 1)))
     val r = mat * vec
     r(Array(1)) should be(13.0)
     r(Array(2)) should be(22.0)
@@ -136,7 +136,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
 
     val mat1 = mat.t
 
-    val vec: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(3.0, 1, 1)))
+    val vec: Tensor[Double] = DenseTensor(new ArrayStorage(Array(3.0, 1, 1)))
     val r = mat1 * vec
     r(Array(1)) should be(15.0)
     r(Array(2)) should be(18.0)
@@ -153,7 +153,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
 
     val matrix = tensor(T(T(), T(), 1)).t()
 
-    val vec: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(3.0, 1, 1)))
+    val vec: Tensor[Double] = DenseTensor(new ArrayStorage(Array(3.0, 1, 1)))
     val r = matrix * vec
     r(Array(1)) should be(15.0)
     r(Array(2)) should be(18.0)
@@ -260,7 +260,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
 
   "vector / scalar" should "be correct" in {
     val s = 2.0
-    val v: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val v: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
     val r = v / s
     r(Array(1)) should be(0.5)
     r(Array(2)) should be(1.0)
@@ -268,8 +268,8 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
   }
 
   "vector / vector" should "be correct" in {
-    val v1: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
-    val v2: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(2.0, 1.0, -1.0)))
+    val v1: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val v2: Tensor[Double] = DenseTensor(new ArrayStorage(Array(2.0, 1.0, -1.0)))
     val r = v1 / v2
     r(Array(1)) should be(0.5)
     r(Array(2)) should be(2.0)
@@ -277,7 +277,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
   }
 
   "-vector" should "be correct" in {
-    val v: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val v: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
     val r = -v
     r(Array(1)) should be(-1.0)
     r(Array(2)) should be(-2.0)
@@ -345,7 +345,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
       1, 2, 3, 4,
       1, 2, 3, 4
     )
-    val a = new DenseTensor[Double](new ArrayStorage(a_data), 1, Array(3, 4))
+    val a = DenseTensor[Double](new ArrayStorage(a_data), 1, Array(3, 4))
 
 
     val b_data = Array(
@@ -354,7 +354,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
       1, 2,
       1, 2
     )
-    val b = new DenseTensor[Double](new ArrayStorage(b_data), 1, Array(4, 2))
+    val b = DenseTensor[Double](new ArrayStorage(b_data), 1, Array(4, 2))
 
     val c = Tensor[Double]()
     c.resize(Array(3, 2))
@@ -366,7 +366,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
       10, 20
     )
 
-    val expect_c = new DenseTensor[Double](new ArrayStorage(expect_c_data), 1, Array(3, 2))
+    val expect_c = DenseTensor[Double](new ArrayStorage(expect_c_data), 1, Array(3, 2))
     c.map(expect_c, (a, b) => {
       a should be(b +- 1e-6)
       a
@@ -379,7 +379,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
       1, 2, 3, 4,
       1, 2, 3, 4
     )
-    val a = new DenseTensor[Double](new ArrayStorage(a_data), 1, Array(3, 4))
+    val a = DenseTensor[Double](new ArrayStorage(a_data), 1, Array(3, 4))
 
 
     val b_data = Array(
@@ -388,14 +388,14 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
       1, 2,
       1, 2
     )
-    val b = new DenseTensor[Double](new ArrayStorage(b_data), 1, Array(4, 2))
+    val b = DenseTensor[Double](new ArrayStorage(b_data), 1, Array(4, 2))
 
     val m_data = Array(
       1.0, 2,
       1, 2,
       1, 2
     )
-    val m = new DenseTensor[Double](new ArrayStorage(m_data), 1, Array(3, 2))
+    val m = DenseTensor[Double](new ArrayStorage(m_data), 1, Array(3, 2))
 
     val c = Tensor[Double]()
     c.addmm(m, a, b)
@@ -406,7 +406,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
       11, 22
     )
 
-    val expect_c = new DenseTensor[Double](new ArrayStorage(expect_c_data), 1, Array(3, 2))
+    val expect_c = DenseTensor[Double](new ArrayStorage(expect_c_data), 1, Array(3, 2))
     c.map(expect_c, (a, b) => {
       a should be(b +- 1e-6)
       a
@@ -414,8 +414,8 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
   }
 
   "addr transpose" should "return correct value" in {
-    val v1: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
-    val v2: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(2.0, 0.0, -1.0)))
+    val v1: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val v2: Tensor[Double] = DenseTensor(new ArrayStorage(Array(2.0, 0.0, -1.0)))
     val tensor: Tensor[Double] = new DenseTensor(3, 3)
     tensor(Array(1, 1)) = 1
     tensor(Array(1, 2)) = 2
@@ -430,26 +430,26 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
     val r = Tensor[Double]()
     r.resize(Array(3, 3))
     r.addr(1.0, mat, 1.0, v1, v2)
-    val expect_r = new DenseTensor(new ArrayStorage(Array(3.0, 3.0, 4.0,
+    val expect_r = DenseTensor(new ArrayStorage(Array(3.0, 3.0, 4.0,
       6.0, 4.0, 4.0,
       8.0, 4.0, 3.0)), 1, Array(3, 3))
     r should be (expect_r)
   }
 
   "addr" should "return correct value" in {
-    val v1: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
-    val v2: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(2.0, 0.0, -1.0)))
+    val v1: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val v2: Tensor[Double] = DenseTensor(new ArrayStorage(Array(2.0, 0.0, -1.0)))
     val r = Tensor[Double]()
     r.resize(Array(3, 3))
     r.addr(v1, v2)
-    r should be (new DenseTensor[Double](new ArrayStorage(Array(2.0, 0.0, -1.0,
+    r should be (DenseTensor[Double](new ArrayStorage(Array(2.0, 0.0, -1.0,
       4.0, 0.0, -2.0,
       6.0, 0.0, -3.0)), 1, Array(3, 3)))
   }
 
   "addr noncontiguous" should "return correct value" in {
-    val v1: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
-    val v2: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(2.0, 0.0, -1.0)))
+    val v1: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    val v2: Tensor[Double] = DenseTensor(new ArrayStorage(Array(2.0, 0.0, -1.0)))
     val tensor: Tensor[Double] = new DenseTensor(3, 3, 2)
     tensor(Array(1, 1, 1)) = 1
     tensor(Array(1, 2, 1)) = 2
@@ -465,7 +465,7 @@ class DenseTensorMathSpec extends FlatSpec with Matchers {
     val r = Tensor[Double]()
     r.resize(Array(3, 3))
     r.addr(1, mat, 1, v1, v2)
-    r should be (new DenseTensor[Double](new ArrayStorage(Array(3.0, 3.0, 4.0,
+    r should be (DenseTensor[Double](new ArrayStorage(Array(3.0, 3.0, 4.0,
       6.0, 4.0, 4.0,
       8.0, 4.0, 3.0)), 1, Array(3, 3)))
   }

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/tensor/DenseTensorSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/tensor/DenseTensorSpec.scala
@@ -21,7 +21,6 @@ import com.intel.analytics.bigdl.dllib.nn.Linear
 import com.intel.analytics.bigdl.dllib.utils.T
 import org.apache.spark.mllib.linalg.{DenseMatrix, DenseVector}
 import org.scalatest.{FlatSpec, Matchers}
-import spire.syntax.module
 
 @com.intel.analytics.bigdl.tags.Parallel
 class DenseTensorSpec extends FlatSpec with Matchers {
@@ -52,7 +51,7 @@ class DenseTensorSpec extends FlatSpec with Matchers {
 
   "Construct with storage" should "return 1D vector" in {
     val storage = Array(1.0, 2.0, 3.0)
-    val t: Tensor[Double] = new DenseTensor(new ArrayStorage(storage))
+    val t: Tensor[Double] = DenseTensor(new ArrayStorage(storage))
     t.nDimension should be(1)
     t.size().length should be(1)
     t.size(1) should be(3)
@@ -85,7 +84,7 @@ class DenseTensorSpec extends FlatSpec with Matchers {
 
   "Construct with another tensor" should "use same storage and separate views" in {
     val other = new DenseTensor[Double](1, 2, 3)
-    val t: Tensor[Double] = new DenseTensor(other)
+    val t: Tensor[Double] = DenseTensor(other)
     t.nDimension() should be(3)
     t.size(1) should be(1)
     t.size(2) should be(2)
@@ -146,7 +145,7 @@ class DenseTensorSpec extends FlatSpec with Matchers {
   }
 
   "One index on a 1d-dimension tensor" should "return value" in {
-    val t: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(3.0, 4, 5)))
+    val t: Tensor[Double] = DenseTensor(new ArrayStorage(Array(3.0, 4, 5)))
     t.valueAt(2) should be(4.0)
   }
 
@@ -185,7 +184,7 @@ class DenseTensorSpec extends FlatSpec with Matchers {
   "One index update a multi-dimension tensor with tensor" should
     "copy the tensor to the subset" in {
     val t: Tensor[Double] = new DenseTensor[Double](3, 2).fill(1)
-    val src: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(8.0, 9)))
+    val src: Tensor[Double] = DenseTensor(new ArrayStorage(Array(8.0, 9)))
     t(2) = src
     t(Array(1, 1)) should be(1)
     t(Array(1, 2)) should be(1)
@@ -196,7 +195,7 @@ class DenseTensorSpec extends FlatSpec with Matchers {
   }
 
   "One index update a 1d-dimension tensor" should "update the value" in {
-    val t: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(3.0, 4, 5)))
+    val t: Tensor[Double] = DenseTensor(new ArrayStorage(Array(3.0, 4, 5)))
     t(2) = 6
     t.valueAt(1) should be(3.0)
     t.valueAt(2) should be(6.0)
@@ -238,7 +237,7 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     t(Array(3, 1)) should be(7)
     t(Array(3, 2)) should be(6)
 
-    val src: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(9.0, 10)))
+    val src: Tensor[Double] = DenseTensor(new ArrayStorage(Array(9.0, 10)))
 
     t(T(T(2, 3), 1)) = src
     t(Array(1, 1)) should be(1)
@@ -290,7 +289,7 @@ class DenseTensorSpec extends FlatSpec with Matchers {
   }
 
   "clone" should "get a seperated tensor" in {
-    val t: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2, 3)))
+    val t: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2, 3)))
     val t1 = t.clone()
     t.isSameSizeAs(t1) should be(true)
     t1.isContiguous() should be(true)
@@ -468,18 +467,18 @@ class DenseTensorSpec extends FlatSpec with Matchers {
   }
 
   "equals" should "be correct" in {
-    val t: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2, 3)))
-    val t1: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2, 3)))
-    val t2: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2, 4)))
+    val t: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2, 3)))
+    val t1: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2, 3)))
+    val t2: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2, 4)))
 
     t == t1 should be(true)
     t == t2 should be(false)
   }
 
   "hashCode" should "be correct" in {
-    val t: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2, 3)))
-    val t1: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2, 3)))
-    val t2: Tensor[Double] = new DenseTensor(new ArrayStorage(Array(1.0, 2, 4)))
+    val t: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2, 3)))
+    val t1: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2, 3)))
+    val t2: Tensor[Double] = DenseTensor(new ArrayStorage(Array(1.0, 2, 4)))
 
     t.hashCode() == t1.hashCode() should be(true)
     t.hashCode() == t2.hashCode() should be(false)
@@ -494,7 +493,7 @@ class DenseTensorSpec extends FlatSpec with Matchers {
     t = Tensor.scalar[Double](1)
     t.toString should be("Scalar(1.0)")
 
-    t = new DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
+    t = DenseTensor(new ArrayStorage(Array(1.0, 2.0, 3.0)))
     val OneD_STRING =
       "1.0\n" +
         "2.0\n" +
@@ -692,7 +691,7 @@ class DenseTensorSpec extends FlatSpec with Matchers {
   }
 
   "Tensor to BreezeMatrix" should "correct" in {
-    val tensor = new DenseTensor[Double](
+    val tensor = DenseTensor[Double](
       new ArrayStorage[Double](Array(1.0, 2, 3, 4)), 1, Array(2, 2))
     val matrix = tensor.toBreezeMatrix()
     matrix.isTranspose should be(true)
@@ -728,7 +727,7 @@ class DenseTensorSpec extends FlatSpec with Matchers {
   }
 
   "Tensor to BreezeVector" should "correct" in {
-    val tensor = new DenseTensor[Double](new ArrayStorage(Array(1.0, 2, 3, 4)))
+    val tensor = DenseTensor[Double](new ArrayStorage(Array(1.0, 2, 3, 4)))
     val vector = tensor.toBreezeVector()
     vector(0) should be(1.0)
     vector(1) should be(2.0)
@@ -746,7 +745,7 @@ class DenseTensorSpec extends FlatSpec with Matchers {
   }
 
   "Tensor to MLMatrix" should "correct" in {
-    val tensor = new DenseTensor(new ArrayStorage(Array(1.0, 2, 3, 4)), 1, Array(2, 2))
+    val tensor = DenseTensor(new ArrayStorage(Array(1.0, 2, 3, 4)), 1, Array(2, 2))
     val matrix = tensor.toMLlibMatrix()
     matrix.isTransposed should be(true)
     matrix(0, 0) should be(1.0)
@@ -781,7 +780,7 @@ class DenseTensorSpec extends FlatSpec with Matchers {
   }
 
   "Tensor to MLVector" should "correct" in {
-    val tensor = new DenseTensor(new ArrayStorage(Array(1.0, 2, 3, 4)))
+    val tensor = DenseTensor(new ArrayStorage(Array(1.0, 2, 3, 4)))
     val vector = tensor.toMLlibVector()
     vector(0) should be(1.0)
     vector(1) should be(2.0)

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/transform/vision/image/MTImageFeatureToBatchSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/transform/vision/image/MTImageFeatureToBatchSpec.scala
@@ -195,7 +195,7 @@ class MTImageFeatureToBatchSpec extends FlatSpec with Matchers with BeforeAndAft
       Array[RoiLabel](RoiLabel(Tensor[Float](), Tensor[Float]())),
       Array[Tensor[Float]](Tensor[Float]()),
       Tensor())
-    val result = sc.parallelize(Array(batch, batch, batch, batch, batch), 3)
+    val result = sc.parallelize(Seq(batch, batch, batch, batch, batch), 3)
       .coalesce(2, true)
       .takeSample(false, 3).head
   }

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/transform/vision/image/opencv/OpenCVMatSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/transform/vision/image/opencv/OpenCVMatSpec.scala
@@ -167,7 +167,7 @@ class OpenCVMatSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val img = OpenCVMat.read(resource.getFile)
     val bytes = OpenCVMat.toBytePixels(img)
     val shape = img.shape()
-    val rdd = sc.parallelize(Array(img))
+    val rdd = sc.parallelize(Seq(img))
     val collect = rdd.collect()
     collect(0).`type`() should be (CvType.CV_8UC3)
     val bytes2 = OpenCVMat.toBytePixels(collect(0))
@@ -179,7 +179,7 @@ class OpenCVMatSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val img = OpenCVMat.read(resource.getFile)
     val floats = OpenCVMat.toFloatPixels(img)
     val shape = img.shape()
-    val rdd = sc.parallelize(Array(img))
+    val rdd = sc.parallelize(Seq(img))
     val collect = rdd.collect()
     collect(0).`type`() should be (CvType.CV_32FC3)
     val floats2 = OpenCVMat.toFloatPixels(collect(0))
@@ -197,7 +197,7 @@ class OpenCVMatSpec extends FlatSpec with Matchers with BeforeAndAfter {
   "empty serialize" should "work properly" in {
     OpenCV.isOpenCVLoaded
     val img = new OpenCVMat()
-    val rdd = sc.parallelize(Array(img))
+    val rdd = sc.parallelize(Seq(img))
     val out = rdd.collect()
     OpenCVMat.toBytePixels(out(0))._1.length should be (0)
   }

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/utils/UtilSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/utils/UtilSpec.scala
@@ -56,7 +56,7 @@ class UtilSpec extends FlatSpec with Matchers with BeforeAndAfter{
       parameterSynchronizer = null)
 
     val model2 = new TestModule[Float]()
-    val modelRDD = sc.parallelize(Array(model)).map(_.asInstanceOf[Cache[Float]])
+    val modelRDD = sc.parallelize(Seq(model)).map(_.asInstanceOf[Cache[Float]])
     setExtraParametersFromModelRDD[Float](modelRDD, model2, 500000)
   }
 

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/utils/tf/SessionSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/utils/tf/SessionSpec.scala
@@ -65,7 +65,7 @@ class SessionSpec extends FlatSpec with Matchers with BeforeAndAfter {
 
     import scala.collection.JavaConverters._
     val context = new Context[Float]()
-    val session = new BigDLSessionImpl[Float](nodes.asScala, context)
+    val session = new BigDLSessionImpl[Float](nodes.asScala.toSeq, context)
 
     val data = new Array[Tensor[Float]](100)
     val label = new Array[Tensor[Float]](100)
@@ -101,7 +101,7 @@ class SessionSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val lenetModel = getLenetModel("lenet_batch_2.pbtxt")
 
     val context = new Context[Float]()
-    val session = new BigDLSessionImpl[Float](lenetModel, context)
+    val session = new BigDLSessionImpl[Float](lenetModel.toSeq, context)
 
     val endpoints = Seq(
       "fifo_queue_Dequeue"
@@ -123,7 +123,7 @@ class SessionSpec extends FlatSpec with Matchers with BeforeAndAfter {
     val lenetModel = getLenetModel("lenet_with_batch_3.pbtxt")
 
     val context = new Context[Float]()
-    val session = new BigDLSessionImpl[Float](lenetModel, context)
+    val session = new BigDLSessionImpl[Float](lenetModel.toSeq, context)
 
     val endpoints = Seq(
       "fifo_queue_Dequeue"

--- a/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/utils/tf/TensorflowLoaderSpec.scala
+++ b/scala/dllib/src/test/scala/com/intel/analytics/bigdl/dllib/utils/tf/TensorflowLoaderSpec.scala
@@ -727,7 +727,7 @@ class TensorflowLoaderSpec extends TensorflowSpecHelper{
     }
 
     tmpLocation.deleteOnExit()
-    comparePair
+    comparePair.toSeq
   }
 
 

--- a/scala/orca/src/main/scala/com/intel/analytics/bigdl/orca/tfpark/TFModelBroadcast.scala
+++ b/scala/orca/src/main/scala/com/intel/analytics/bigdl/orca/tfpark/TFModelBroadcast.scala
@@ -194,8 +194,7 @@ private[bigdl] object CachedModels {
 
   import java.util.concurrent.ConcurrentHashMap
 
-  import scala.collection._
-  import scala.collection.convert.decorateAsScala._
+  import scala.collection.JavaConverters._
   import scala.language.existentials
 
   type Modles = ArrayBuffer[Module[_]]

--- a/scala/orca/src/main/scala/com/intel/analytics/bigdl/orca/utils/PythonInterpreter.scala
+++ b/scala/orca/src/main/scala/com/intel/analytics/bigdl/orca/utils/PythonInterpreter.scala
@@ -16,12 +16,12 @@
 package com.intel.analytics.bigdl.orca.utils
 
 import java.util.concurrent.{ExecutorService, Executors, ThreadFactory}
-
 import jep.{JepConfig, JepException, NamingConventionClassEnquirer, SharedInterpreter}
 import org.apache.logging.log4j.LogManager
 
 import scala.concurrent.{Await, ExecutionContext, Future}
 import scala.concurrent.duration.Duration
+import scala.reflect.ClassTag
 
 object PythonInterpreter {
   protected val logger = LogManager.getLogger(this.getClass)
@@ -81,7 +81,7 @@ object PythonInterpreter {
     threadExecute(createInterp)
   }
 
-  private def threadExecute[T](task: () => T,
+  private def threadExecute[T: ClassTag](task: () => T,
                                timeout: Duration = Duration("100s")): T = {
     try {
       val re = Array(task).map(t => Future {

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -112,7 +112,7 @@
         <scala.major.version>2.11</scala.major.version>
         <scala.version>2.11.12</scala.version>
         <scala.macros.version>2.1.0</scala.macros.version>
-        <scalatest.version>3.0.7</scalatest.version>
+        <scalatest.version>3.0.9</scalatest.version>
 
         <!-- platform encoding override -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -715,7 +715,7 @@
             <properties>
                 <java.version>1.8</java.version>
                 <javac.version>1.8</javac.version>
-                <spark-version.project>2.0</spark-version.project>
+                <s.asJavapark-version.project>2.0</s.asJavapark-version.project>
                 <spark.version>2.4.6</spark.version>
                 <scala.major.version>2.11</scala.major.version>
                 <scala.version>2.11.8</scala.version>
@@ -880,9 +880,81 @@
                 <scala.version>2.13.5</scala.version>
                 <scala.macros.version>2.1.0</scala.macros.version>
                 <breeze.version>1.2</breeze.version>
-                <scalatest.version>3.2.9</scalatest.version>
                 <scopt.version>3.7.1</scopt.version>
+                <spark-version.project>3.0_2.13</spark-version.project>
+                <spark.version>3.2.3</spark.version>
+                <lightgbm.scope>compile</lightgbm.scope>
+                <maven.compiler.source>${java.version}</maven.compiler.source>
+                <maven.compiler.target>${java.version}</maven.compiler.target>
             </properties>
+            <build>
+                <plugins>
+                    <!-- Redefine the plugin to enable fatal warninings -->
+                    <plugin>
+                        <groupId>net.alchim31.maven</groupId>
+                        <artifactId>scala-maven-plugin</artifactId>
+                        <version>3.4.2</version>
+                        <executions>
+                            <execution>
+                                <id>eclipse-add-source</id>
+                                <goals>
+                                    <goal>add-source</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>scala-compile-first</id>
+                                <phase>process-resources</phase>
+                                <goals>
+                                    <goal>compile</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>scala-test-compile-first</id>
+                                <phase>process-test-resources</phase>
+                                <goals>
+                                    <goal>testCompile</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>attach-scaladocs</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>doc-jar</goal>
+                                </goals>
+                                <configuration>
+                                    <args>
+                                        <!-- Do not change the arg orders. It is a weird way to pass in
+                                        this arg. Maybe it is a bug of the plugin. -->
+                                        <arg>-skip-packages</arg>
+                                        <arg>caffe:org.tensorflow:netty:org.apache.spark.sparkExtension:org.apache.spark.rdd:org.apache.spark.storage:org.apache.spark.bigdl</arg>
+                                    </args>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <scalaVersion>${scala.version}</scalaVersion>
+                            <recompileMode>incremental</recompileMode>
+                            <useZincServer>false</useZincServer>
+                            <args>
+                                <arg>-unchecked</arg>
+                                <!-- Too many deprecation usage, let's suspend it temporary-->
+                                <arg>-deprecation:false</arg>
+                                <arg>-feature</arg>
+                                <!--<arg>-Xfatal-warnings</arg>-->
+                            </args>
+                            <!-- The following plugin is required to use quasiquotes in Scala 2.10 and is used
+                                 by Spark SQL for code generation. -->
+                            <!--                            <compilerPlugins>-->
+                            <!--                                <compilerPlugin>-->
+                            <!--                                    <groupId>org.scalamacros</groupId>-->
+                            <!--                                    <artifactId>paradise_${scala.version}</artifactId>-->
+                            <!--                                    <version>${scala.macros.version}</version>-->
+                            <!--                                </compilerPlugin>-->
+                            <!--                            </compilerPlugins>-->
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
         <profile>
             <id>scala_2.12</id>

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -181,6 +181,7 @@
         <spark-version.project>2.0</spark-version.project>
         <spark.version>2.4.6</spark.version>
         <breeze.version>0.13.2</breeze.version>
+        <scopt.version>3.5.0</scopt.version>
         <spark-scope>provided</spark-scope>
         <bigdl.basedir>${project.basedir}</bigdl.basedir>
 	    <bigdl-core-all-scope>compile</bigdl-core-all-scope>
@@ -583,13 +584,13 @@
                     </args>
                     <!-- The following plugin is required to use quasiquotes in Scala 2.10 and is used
                          by Spark SQL for code generation. -->
-                    <compilerPlugins>
-                        <compilerPlugin>
-                            <groupId>org.scalamacros</groupId>
-                            <artifactId>paradise_${scala.version}</artifactId>
-                            <version>${scala.macros.version}</version>
-                        </compilerPlugin>
-                    </compilerPlugins>
+<!--                    <compilerPlugins>-->
+<!--                        <compilerPlugin>-->
+<!--                            <groupId>org.scalamacros</groupId>-->
+<!--                            <artifactId>paradise_${scala.version}</artifactId>-->
+<!--                            <version>${scala.macros.version}</version>-->
+<!--                        </compilerPlugin>-->
+<!--                    </compilerPlugins>-->
                 </configuration>
             </plugin>
             <plugin>
@@ -777,13 +778,13 @@
                             </args>
                             <!-- The following plugin is required to use quasiquotes in Scala 2.10 and is used
                                  by Spark SQL for code generation. -->
-                            <compilerPlugins>
-                                <compilerPlugin>
-                                    <groupId>org.scalamacros</groupId>
-                                    <artifactId>paradise_${scala.version}</artifactId>
-                                    <version>${scala.macros.version}</version>
-                                </compilerPlugin>
-                            </compilerPlugins>
+<!--                            <compilerPlugins>-->
+<!--                                <compilerPlugin>-->
+<!--                                    <groupId>org.scalamacros</groupId>-->
+<!--                                    <artifactId>paradise_${scala.version}</artifactId>-->
+<!--                                    <version>${scala.macros.version}</version>-->
+<!--                                </compilerPlugin>-->
+<!--                            </compilerPlugins>-->
                         </configuration>
                     </plugin>
                 </plugins>
@@ -860,17 +861,28 @@
                             </args>
                             <!-- The following plugin is required to use quasiquotes in Scala 2.10 and is used
                                  by Spark SQL for code generation. -->
-                            <compilerPlugins>
-                                <compilerPlugin>
-                                    <groupId>org.scalamacros</groupId>
-                                    <artifactId>paradise_${scala.version}</artifactId>
-                                    <version>${scala.macros.version}</version>
-                                </compilerPlugin>
-                            </compilerPlugins>
+<!--                            <compilerPlugins>-->
+<!--                                <compilerPlugin>-->
+<!--                                    <groupId>org.scalamacros</groupId>-->
+<!--                                    <artifactId>paradise_${scala.version}</artifactId>-->
+<!--                                    <version>${scala.macros.version}</version>-->
+<!--                                </compilerPlugin>-->
+<!--                            </compilerPlugins>-->
                         </configuration>
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>scala_2.13</id>
+            <properties>
+                <scala.major.version>2.13</scala.major.version>
+                <scala.version>2.13.5</scala.version>
+                <scala.macros.version>2.1.0</scala.macros.version>
+                <breeze.version>1.2</breeze.version>
+                <scalatest.version>3.2.9</scalatest.version>
+                <scopt.version>3.7.1</scopt.version>
+            </properties>
         </profile>
         <profile>
             <id>scala_2.12</id>


### PR DESCRIPTION
## Description

scala 2.13 support on branch scala-2.13
TODO: 
1. orca build failed
2. spark 2.4 scala2.10 build failed due to scala java conversion 

### 1. Why the change?

scala 2.13 support

### 2. User API changes

None

### 3. Summary of the change 

scala 2.13 support

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
