### PR TITLE
Nano/Chronos: add `packaging` to nano's setup to avoid no module error

### DIFF
--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -151,15 +151,15 @@ def setup_package():
     inference_requires = ["onnx==1.12.0",
                           "onnxruntime==1.12.1",
                           "onnxruntime-extensions==0.4.2; platform_system!='Darwin'",
-                          "onnxruntime-extensions==0.3.1; platform_machine=='x86_64' and \
+                          "onnxruntime-extensions==0.3.1; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
                           platform_system=='Darwin'",
                           "openvino-dev==2022.3.0",
                           "neural-compressor==2.0",
                           "onnxsim==0.4.8; platform_system!='Darwin'",
-                          "onnxsim==0.4.1; platform_machine=='x86_64' and \
+                          "onnxsim==0.4.1; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
                           platform_system=='Darwin'"]
 
-    install_requires = ["intel-openmp; platform_machine=='x86_64'",
+    install_requires = ["intel-openmp; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
                         "cloudpickle",
                         "protobuf==3.19.5",
                         "py-cpuinfo",

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -163,7 +163,8 @@ def setup_package():
                         "cloudpickle",
                         "protobuf==3.19.5",
                         "py-cpuinfo",
-                        "pyyaml"]
+                        "pyyaml",
+                        "packaging"]
 
     package_data = [
         "libs/libjemalloc.so",


### PR DESCRIPTION
## Description

### 1. Why the change?
There 2 kinds of users may meet `No module named 'packaging'` error (raised from nano's src) when they normally use Nano/Chronos
1. M-series chip users will install `pip install bigdl-nano[tensorflow]`
2. Chronos users who does not need deep-learning framework/inference optimization

### 2. User API changes
nothing

### 3. Summary of the change 
1. add a new (small) dependency to nano
2. fix some platform arch statement

### 4. How to test?
- [ ] Unit test

### 5. New dependencies
- [x] New Python dependencies
       - `packaging`
