### PR TITLE
[PPML] fix dataframe crypto issue

### DIFF
--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/PPMLContext.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/PPMLContext.scala
@@ -270,16 +270,6 @@ object PPMLContext{
   }
 
   /**
-   * init ppml context with an existed SparkSession
-   * @param sparkSession a SparkSession
-   * @return a PPMLContext
-   */
-  def initPPMLContext(sparkSession: SparkSession): PPMLContext = {
-    val ppmlSc = loadPPMLContext(sparkSession)
-    ppmlSc
-  }
-
-  /**
    * init ppml context with app name, SparkConf
    * @param sparkConf a SparkConf, ppml arguments are passed by this sparkconf.
    * @param appName the name of this Application

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/dataframe/EncryptedDataFrameReader.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/dataframe/EncryptedDataFrameReader.scala
@@ -41,11 +41,15 @@ class EncryptedDataFrameReader(
   }
 
   def csv(path: String): DataFrame = {
-    sparkSession.read.options(extraOptions).csv(path)
+    val df = sparkSession.read.options(extraOptions).csv(path)
+    df.cache.count
+    df
   }
 
   def json(path: String): DataFrame = {
-    sparkSession.read.options(extraOptions).json(path)
+    val df = sparkSession.read.options(extraOptions).json(path)
+    df.cache.count
+    df
   }
 
   def parquet(path: String): DataFrame = {

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/examples/MultiPartySparkEncryptExample.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/examples/MultiPartySparkEncryptExample.scala
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2016 The BigDL Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.intel.analytics.bigdl.ppml.examples
+
+import com.intel.analytics.bigdl.ppml.PPMLContext
+import com.intel.analytics.bigdl.ppml.utils.Supportive
+import com.intel.analytics.bigdl.ppml.crypto.{CryptoMode, AES_CBC_PKCS5PADDING, PLAIN_TEXT}
+import org.apache.spark.sql.SparkSession
+
+object MultiPartySparkEncryptExample extends Supportive {
+  def main(args: Array[String]): Unit = {
+
+    val ppmlArgs = Map(
+      "spark.bigdl.enableMultiKms" -> "true",
+      "spark.bigdl.kms.amyKms.type" -> "EHSMKeyManagementService",
+      "spark.bigdl.kms.amyKms.ip" -> args(0),
+      "spark.bigdl.kms.amyKms.port" -> args(1),
+      "spark.bigdl.kms.amyKms.appId" -> args(2),
+      "spark.bigdl.kms.amyKms.apiKey" -> args(3),
+      "spark.bigdl.kms.bobKms.type" -> "EHSMKeyManagementService",
+      "spark.bigdl.kms.bobKms.ip" -> args(4),
+      "spark.bigdl.kms.bobKms.port" -> args(5),
+      "spark.bigdl.kms.bobKms.appId" -> args(6),
+      "spark.bigdl.kms.bobKms.apiKey" -> args(7)
+    )
+    val sc = PPMLContext.initPPMLContext("MultiPartySparkEncryptExample", ppmlArgs)
+
+    timing("loading") {
+      // load csv file to data frame with ppmlcontext.
+      val amyDf = timing("1/4 read Amy's plaintext data source into data frame") {
+        // read encrypted data
+        sc.read(PLAIN_TEXT, // crypto mode
+                "amyKms", // name of kms which data key is retrieved from
+                "./amy_encrypted_primary_key", // primary key file path
+                "./amy_encrypted_data_key") // data key file path
+          .option("header", "true")
+          .csv("./amyDataSource.csv") // input file path
+      }
+
+      val bobDf = timing("2/4 read Bob's plaintext data source") {
+        sc.read(PLAIN_TEXT, "bobKms",
+                "./bob_encrypted_primary_key", "./bob_encrypted_data_key")
+          .option("header", "true")
+          .csv("./bobDataSource.csv")
+      }
+
+      timing("3/4 encrypt and save amy data") {
+        // save data frame using spark kms context
+        // write encrypted data
+        sc.write(amyDf, // target data frame
+                 AES_CBC_PKCS5PADDING, // encrypt mode
+                 "amyKms", // name of kms which data key is retrieved from
+                 "./amy_encrypted_primary_key", // primary key file path
+                 "./amy_encrypted_data_key") // data key file path
+          .mode("overwrite")
+          .option("header", true)
+          .csv("./encrypted_amy_data")
+      }
+
+      timing("4/4 encrypt and save Bob encrypted data") {
+        sc.write(bobDf, AES_CBC_PKCS5PADDING, "bobKms",
+                 "./bob_encrypted_primary_key", "./bob_encrypted_data_key")
+          .mode("overwrite").option("header", true).csv("./encrypted_bob_data")
+      }
+    }
+  }
+}
+

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/python/PPMLContextPython.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/python/PPMLContextPython.scala
@@ -34,12 +34,6 @@ object PPMLContextPython {
 class PPMLContextPython[T]() {
   val logger: Logger = LoggerFactory.getLogger(getClass)
 
-  def createPPMLContext(sparkSession: SparkSession): PPMLContext = {
-    logger.debug("createPPMLContext with SparkSession" + "confs:\n" +
-      sparkSession.sparkContext.getConf.getAll.mkString("Array(", ", ", ")"))
-    PPMLContext.initPPMLContext(sparkSession)
-  }
-
   def read(sc: PPMLContext, cryptoModeStr: String,
            kmsName: String = "", primaryKey: String = "",
            dataKey: String = ""): EncryptedDataFrameReader = {


### PR DESCRIPTION
## Description

1. CryptoCodec has not been registered correctly in PPMLContext. There is a difference between DataFrameReader and DataFrameWriter that the latter provides a "compression" option interface to register codec for each writer, while all DataFrameReaders share a global codec which is immutable after SparkSession is initialized, and this cause codec set for reader invalid in initPPMLContext.

    In conclusion, we need to remove initPPMLContext(SparkSession) API for correct codec registration.

2. CryptoCodec for EncryptedDataFrameReader can cause key conflict and decryption failure: this is because all reader instances shares the same key filed in global hadoop conf (since CryptoCodec does not accepts any input parameter), and it is difficult to express non-peer such a crypto computation in RDD programming model.

    We can fix it by wrap a df.cache.count action in backend reader.csv method which splits read operations into different stages, while this also degrades to serial execution.

### 1. Why the change?

#7400 

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

fix dataframe crypto issue

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...
