### PR TITLE
Nano: update save&load of keras by changing to tf.save

### DIFF
--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -317,7 +317,7 @@ class TestChronosModelLSTMForecaster(TestCase):
         forecaster.fit(train_data, epochs=2)
         # quantization with tunning
         forecaster.quantize(train_data, val_data=val_data,
-                            metric="mse", relative_drop=0.1, max_trials=3,
+                            metric="mse", relative_drop=0.8, max_trials=3,
                             framework='onnxrt_qlinearops')
         pred_q = forecaster.predict_with_onnx(test_data[0], quantize=True)
         eval_q = forecaster.evaluate_with_onnx(test_data, quantize=True)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -143,7 +143,7 @@ class TestChronosNBeatsForecaster(TestCase):
                             val_data=val_loader,
                             metric="mae",
                             framework='onnxrt_qlinearops',
-                            relative_drop=0.5)
+                            relative_drop=0.8)
         q_onnx_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
         forecaster.evaluate_with_onnx(test_loader, batch_size=32, quantize=True)
         forecaster.evaluate_with_onnx(test_loader)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -135,7 +135,7 @@ class TestChronosNBeatsForecaster(TestCase):
                             val_data=val_loader,
                             metric="mae",
                             framework='pytorch_fx',
-                            relative_drop=0.2)
+                            relative_drop=0.5)
         q_yhat = forecaster.predict(data=test_loader, quantize=True, acceleration=False)
         yhat = forecaster.predict(data=test_loader, acceleration=False)
         forecaster.evaluate(test_loader, batch_size=32, acceleration=False)
@@ -143,7 +143,7 @@ class TestChronosNBeatsForecaster(TestCase):
                             val_data=val_loader,
                             metric="mae",
                             framework='onnxrt_qlinearops',
-                            relative_drop=0.2)
+                            relative_drop=0.5)
         q_onnx_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
         forecaster.evaluate_with_onnx(test_loader, batch_size=32, quantize=True)
         forecaster.evaluate_with_onnx(test_loader)
@@ -279,7 +279,7 @@ class TestChronosNBeatsForecaster(TestCase):
         forecaster.fit(train_data, epochs=2)
         # quantization with tunning
         forecaster.quantize(train_data, val_data=val_data,
-                            metric="mse", relative_drop=0.5, max_trials=3,
+                            metric="mse", relative_drop=0.8, max_trials=3,
                             framework='onnxrt_qlinearops')
         pred_q = forecaster.predict_with_onnx(test_data[0], quantize=True)
         eval_q = forecaster.evaluate_with_onnx(test_data, quantize=True)

--- a/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
@@ -19,7 +19,6 @@ import tensorflow as tf
 
 
 def BF16Model(model):
-    # TODO: check bf16 isa
     policy_bf16 = mixed_precision.Policy('mixed_bfloat16')
     for layer in model.layers:
         layer._dtype_policy = policy_bf16

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -798,12 +798,10 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             result = load_bf16_model(path)
             return patch_attrs(result, model)
         checkpoint_path = metadata.get('checkpoint', None)
-        if checkpoint_path:
-            checkpoint_path = path / metadata['checkpoint']
-            model = keras.models.load_model(checkpoint_path)
-            return model
-        else:
-            invalidInputError(False, "Key 'checkpoint' must be specified.")
+        invalidInputError(checkpoint_path is not None, "Key 'checkpoint' must be specified.")
+        checkpoint_path = path / metadata['checkpoint']
+        model = keras.models.load_model(checkpoint_path)
+        return model
 
 
 def _accuracy_calculate_helper(model, metric, data):

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -26,6 +26,7 @@ import numpy as np
 import traceback
 import inspect
 import tensorflow as tf
+import keras
 from typing import Dict, Optional, List, Union, Callable
 from bigdl.nano.utils.common import BaseInferenceOptimizer, available_acceleration_combination,\
     AccelerationOption, latency_calculate_helper, format_optimize_result
@@ -761,7 +762,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 }
                 yaml.safe_dump(metadata, f)
             checkpoint_path = path / metadata['checkpoint']
-            model.save_weights(checkpoint_path)
+            model.save(checkpoint_path)
 
     @staticmethod
     def load(path, model: Model, device=None):
@@ -796,20 +797,13 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         if model_type == 'BF16Model':
             result = load_bf16_model(path)
             return patch_attrs(result, model)
-        if isinstance(model, Model):
-            # typically for keras Model
-            model = copy.deepcopy(model)
-            checkpoint_path = metadata.get('checkpoint', None)
-            if checkpoint_path:
-                checkpoint_path = path / metadata['checkpoint']
-                model.load_weights(checkpoint_path)
-                return model
-            else:
-                invalidInputError(False, "Key 'checkpoint' must be specified.")
+        checkpoint_path = metadata.get('checkpoint', None)
+        if checkpoint_path:
+            checkpoint_path = path / metadata['checkpoint']
+            model = keras.models.load_model(checkpoint_path)
+            return model
         else:
-            invalidInputError(False,
-                              "ModelType {} or argument 'model={}' is not acceptable for tensorflow"
-                              " loading.".format(model_type, type(model)))
+            invalidInputError(False, "Key 'checkpoint' must be specified.")
 
 
 def _accuracy_calculate_helper(model, metric, data):

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -450,6 +450,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                   If x is a dataset, y will be ignored (since targets will be obtained from x).
         :param precision:       Global precision of quantized model,
                                 supported type: 'int8', 'bf16', 'fp16', defaults to 'int8'.
+                                Note that, mixed bf16 precision only works for ``keras.Model`` with
+                                explict input and output definition(e.g.,
+                                model = keras.Model(inputs=inputs, outputs=outputs)).
         :param accelerator:     Use accelerator 'None', 'onnxruntime', 'openvino', defaults to None.
                                 None means staying in tensorflow.
         :param input_spec:      (optional) A (tuple or list of) ``tf.TensorSpec``

--- a/python/nano/test/tf/inference/test_trace_and_quantize.py
+++ b/python/nano/test/tf/inference/test_trace_and_quantize.py
@@ -208,15 +208,15 @@ class TestTraceAndQuantize(TestCase):
 
         traced_model = InferenceOptimizer.quantize(model, precision="bf16")
 
-        from bigdl.nano.utils.common import _bf16_checker
-        if _bf16_checker():
-            output = model(x)
+        from bigdl.nano.utils.common import _avx512_checker
+        if _avx512_checker():
+            output = traced_model(x)
             assert output.dtype == tf.bfloat16
 
         with tempfile.TemporaryDirectory() as tmp_dir_name:
-            InferenceOptimizer.save(model, tmp_dir_name)
+            InferenceOptimizer.save(traced_model, tmp_dir_name)
             load_model = InferenceOptimizer.load(tmp_dir_name, model)
 
-        if _bf16_checker():
+        if _avx512_checker():
             output = load_model(x)
             assert output.dtype == tf.bfloat16

--- a/python/nano/test/tf/inference/test_trace_and_quantize.py
+++ b/python/nano/test/tf/inference/test_trace_and_quantize.py
@@ -20,6 +20,7 @@ import numpy as np
 import tensorflow as tf
 from tensorflow.keras.metrics import MeanSquaredError, CategoricalAccuracy
 from tensorflow.keras import layers, Model
+from tensorflow.keras.applications import MobileNetV2
 
 from bigdl.nano.tf.keras import InferenceOptimizer
 
@@ -35,7 +36,7 @@ class MyModel(tf.keras.Model):
     def call(self, inputs):
         x = self.dense1(inputs)
         return self.dense2(x)
-        
+
     def get_x(self):
         return self.x
 
@@ -211,7 +212,7 @@ class TestTraceAndQuantize(TestCase):
 
         from bigdl.nano.utils.common import _avx512_checker
         if _avx512_checker():
-            output = traced_model(x)
+            output = bf16_model(x)
             assert output.dtype == tf.float32
 
         with tempfile.TemporaryDirectory() as tmp_dir_name:
@@ -223,7 +224,7 @@ class TestTraceAndQuantize(TestCase):
             assert output.dtype == tf.float32
 
         # test standard model, quantized model still return bf16 output
-        model = keras.applications.MobileNetV2(weights="imagenet")
+        model = MobileNetV2(weights="imagenet")
         x = np.random.rand(32, 224, 224, 3)
         model(x)
 
@@ -231,7 +232,7 @@ class TestTraceAndQuantize(TestCase):
 
         from bigdl.nano.utils.common import _avx512_checker
         if _avx512_checker():
-            output = traced_model(x)
+            output = bf16_model(x)
             assert output.dtype == tf.bfloat16
 
         with tempfile.TemporaryDirectory() as tmp_dir_name:
@@ -241,5 +242,3 @@ class TestTraceAndQuantize(TestCase):
         if _avx512_checker():
             output = load_model(x)
             assert output.dtype == tf.bfloat16
-
-

--- a/python/nano/test/tf/inference/test_trace_and_quantize.py
+++ b/python/nano/test/tf/inference/test_trace_and_quantize.py
@@ -210,7 +210,13 @@ class TestTraceAndQuantize(TestCase):
 
         from bigdl.nano.utils.common import _bf16_checker
         if _bf16_checker():
-            model(x)
+            output = model(x)
+            assert output.dtype == tf.bfloat16
 
-        InferenceOptimizer.save(model, "save_bf16")
-        model = InferenceOptimizer.load("save_bf16", model)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model)
+
+        if _bf16_checker():
+            output = load_model(x)
+            assert output.dtype == tf.bfloat16


### PR DESCRIPTION
## Description

update save & load of keras model by replace `model.save_weight` with `model.save` and update keras bf16's ut.

### 1. Why the change?

update save & load of keras model by replace `model.save_weight` with `model.save` as Keras recommends saving the model in this way.

### 2. User API changes

No change.

### 3. Summary of the change 

- replace `model.save_weight` with `model.save` in `keras InferenceOptimizer`'s save/load
- Improve the unittest of keras bf16

### 4. How to test?
- [x] Unit test

Note:
During this PR, find a potential problem, that is seems our keras bf16 can't be apply to custom model, related issue is here:
https://github.com/analytics-zoo/nano/issues/279