### PR TITLE
[Nano] Revise outdated info in PyTorch Inference how-to guides

### DIFF
--- a/docs/readthedocs/source/_toc.yml
+++ b/docs/readthedocs/source/_toc.yml
@@ -156,10 +156,10 @@ subtrees:
                           title: "PyTorch"
                           subtrees:
                             - entries: 
+                              - file: doc/Nano/Howto/Inference/PyTorch/inference_optimizer_optimize
                               - file: doc/Nano/Howto/Inference/PyTorch/accelerate_pytorch_inference_onnx
                               - file: doc/Nano/Howto/Inference/PyTorch/accelerate_pytorch_inference_openvino
                               - file: doc/Nano/Howto/Inference/PyTorch/accelerate_pytorch_inference_jit_ipex
-                              - file: doc/Nano/Howto/Inference/PyTorch/multi_instance_pytorch_inference
                               - file: doc/Nano/Howto/Inference/PyTorch/quantize_pytorch_inference_inc
                               - file: doc/Nano/Howto/Inference/PyTorch/quantize_pytorch_inference_pot
                               - file: doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager
@@ -167,7 +167,7 @@ subtrees:
                               - file: doc/Nano/Howto/Inference/PyTorch/pytorch_save_and_load_jit
                               - file: doc/Nano/Howto/Inference/PyTorch/pytorch_save_and_load_onnx
                               - file: doc/Nano/Howto/Inference/PyTorch/pytorch_save_and_load_openvino
-                              - file: doc/Nano/Howto/Inference/PyTorch/inference_optimizer_optimize
+                              - file: doc/Nano/Howto/Inference/PyTorch/multi_instance_pytorch_inference
                         - file: doc/Nano/Howto/Inference/TensorFlow/index
                           title: "TensorFlow"
                           subtrees:

--- a/docs/readthedocs/source/doc/Nano/Howto/Inference/PyTorch/index.rst
+++ b/docs/readthedocs/source/doc/Nano/Howto/Inference/PyTorch/index.rst
@@ -1,15 +1,15 @@
 Inference Optimization: For PyTorch Users
 =============================================
 
-* `How to find accelerated method with minimal latency using InferenceOptimizer <Inference/PyTorch/inference_optimizer_optimize.html>`_
-* `How to accelerate a PyTorch inference pipeline through ONNXRuntime <Inference/PyTorch/accelerate_pytorch_inference_onnx.html>`_
-* `How to accelerate a PyTorch inference pipeline through OpenVINO <Inference/PyTorch/accelerate_pytorch_inference_openvino.html>`_
-* `How to accelerate a PyTorch inference pipeline through JIT/IPEX <Inference/PyTorch/accelerate_pytorch_inference_jit_ipex.html>`_
-* `How to quantize your PyTorch model in INT8 for inference using Intel Neural Compressor <Inference/PyTorch/quantize_pytorch_inference_inc.html>`_
-* `How to quantize your PyTorch model in INT8 for inference using OpenVINO Post-training Optimization Tools <Inference/PyTorch/quantize_pytorch_inference_pot.html>`_
-* `How to enable automatic context management for PyTorch inference on Nano optimized models <Inference/PyTorch/pytorch_context_manager.html>`_
-* `How to save and load optimized ONNXRuntime model <Inference/PyTorch/pytorch_save_and_load_onnx.html>`_
-* `How to save and load optimized OpenVINO model <Inference/PyTorch/pytorch_save_and_load_openvino.html>`_
-* `How to save and load optimized JIT model <Inference/PyTorch/pytorch_save_and_load_jit.html>`_
-* `How to save and load optimized IPEX model <Inference/PyTorch/pytorch_save_and_load_ipex.html>`_
-* `How to accelerate a PyTorch inference pipeline through multiple instances <Inference/PyTorch/multi_instance_pytorch_inference.html>`_
+* `How to find accelerated method with minimal latency using InferenceOptimizer <inference_optimizer_optimize.html>`_
+* `How to accelerate a PyTorch inference pipeline through ONNXRuntime <accelerate_pytorch_inference_onnx.html>`_
+* `How to accelerate a PyTorch inference pipeline through OpenVINO <accelerate_pytorch_inference_openvino.html>`_
+* `How to accelerate a PyTorch inference pipeline through JIT/IPEX <accelerate_pytorch_inference_jit_ipex.html>`_
+* `How to quantize your PyTorch model in INT8 for inference using Intel Neural Compressor <quantize_pytorch_inference_inc.html>`_
+* `How to quantize your PyTorch model in INT8 for inference using OpenVINO Post-training Optimization Tools <quantize_pytorch_inference_pot.html>`_
+* `How to enable automatic context management for PyTorch inference on Nano optimized models <pytorch_context_manager.html>`_
+* `How to save and load optimized ONNXRuntime model <pytorch_save_and_load_onnx.html>`_
+* `How to save and load optimized OpenVINO model <pytorch_save_and_load_openvino.html>`_
+* `How to save and load optimized JIT model <pytorch_save_and_load_jit.html>`_
+* `How to save and load optimized IPEX model <pytorch_save_and_load_ipex.html>`_
+* `How to accelerate a PyTorch inference pipeline through multiple instances <multi_instance_pytorch_inference.html>`_

--- a/docs/readthedocs/source/doc/Nano/Howto/Inference/PyTorch/index.rst
+++ b/docs/readthedocs/source/doc/Nano/Howto/Inference/PyTorch/index.rst
@@ -1,18 +1,15 @@
 Inference Optimization: For PyTorch Users
 =============================================
 
-* `How to accelerate a PyTorch inference pipeline through ONNXRuntime <accelerate_pytorch_inference_onnx.html>`_
-* `How to accelerate a PyTorch inference pipeline through OpenVINO <accelerate_pytorch_inference_openvino.html>`_
-* `How to accelerate a PyTorch inference pipeline through JIT/IPEX <accelerate_pytorch_inference_jit_ipex.html>`_
-* `How to accelerate a PyTorch inference pipeline through multiple instances <multi_instance_pytorch_inference.html>`_
-* `How to quantize your PyTorch model for inference using Intel Neural Compressor <quantize_pytorch_inference_inc.html>`_
-* `How to quantize your PyTorch model for inference using OpenVINO Post-training Optimization Tools <quantize_pytorch_inference_pot.html>`_
-* |pytorch_inference_context_manager_link|_
-* `How to save and load optimized IPEX model <pytorch_save_and_load_ipex.html>`_
-* `How to save and load optimized JIT model <pytorch_save_and_load_jit.html>`_
-* `How to save and load optimized ONNXRuntime model <pytorch_save_and_load_onnx.html>`_
-* `How to save and load optimized OpenVINO model <pytorch_save_and_load_openvino.html>`_
-* `How to find accelerated method with minimal latency using InferenceOptimizer <inference_optimizer_optimize.html>`_
-
-.. |pytorch_inference_context_manager_link| replace:: How to use context manager through ``get_context``
-.. _pytorch_inference_context_manager_link: pytorch_context_manager.html
+* `How to find accelerated method with minimal latency using InferenceOptimizer <Inference/PyTorch/inference_optimizer_optimize.html>`_
+* `How to accelerate a PyTorch inference pipeline through ONNXRuntime <Inference/PyTorch/accelerate_pytorch_inference_onnx.html>`_
+* `How to accelerate a PyTorch inference pipeline through OpenVINO <Inference/PyTorch/accelerate_pytorch_inference_openvino.html>`_
+* `How to accelerate a PyTorch inference pipeline through JIT/IPEX <Inference/PyTorch/accelerate_pytorch_inference_jit_ipex.html>`_
+* `How to quantize your PyTorch model for inference using Intel Neural Compressor <Inference/PyTorch/quantize_pytorch_inference_inc.html>`_
+* `How to quantize your PyTorch model for inference using OpenVINO Post-training Optimization Tools <Inference/PyTorch/quantize_pytorch_inference_pot.html>`_
+* `How to enable automatic context management for PyTorch inference on Nano optimized models <Inference/PyTorch/pytorch_context_manager.html>`_
+* `How to save and load optimized ONNXRuntime model <Inference/PyTorch/pytorch_save_and_load_onnx.html>`_
+* `How to save and load optimized OpenVINO model <Inference/PyTorch/pytorch_save_and_load_openvino.html>`_
+* `How to save and load optimized JIT model <Inference/PyTorch/pytorch_save_and_load_jit.html>`_
+* `How to save and load optimized IPEX model <Inference/PyTorch/pytorch_save_and_load_ipex.html>`_
+* `How to accelerate a PyTorch inference pipeline through multiple instances <Inference/PyTorch/multi_instance_pytorch_inference.html>`_

--- a/docs/readthedocs/source/doc/Nano/Howto/Inference/PyTorch/index.rst
+++ b/docs/readthedocs/source/doc/Nano/Howto/Inference/PyTorch/index.rst
@@ -5,8 +5,8 @@ Inference Optimization: For PyTorch Users
 * `How to accelerate a PyTorch inference pipeline through ONNXRuntime <Inference/PyTorch/accelerate_pytorch_inference_onnx.html>`_
 * `How to accelerate a PyTorch inference pipeline through OpenVINO <Inference/PyTorch/accelerate_pytorch_inference_openvino.html>`_
 * `How to accelerate a PyTorch inference pipeline through JIT/IPEX <Inference/PyTorch/accelerate_pytorch_inference_jit_ipex.html>`_
-* `How to quantize your PyTorch model for inference using Intel Neural Compressor <Inference/PyTorch/quantize_pytorch_inference_inc.html>`_
-* `How to quantize your PyTorch model for inference using OpenVINO Post-training Optimization Tools <Inference/PyTorch/quantize_pytorch_inference_pot.html>`_
+* `How to quantize your PyTorch model in INT8 for inference using Intel Neural Compressor <Inference/PyTorch/quantize_pytorch_inference_inc.html>`_
+* `How to quantize your PyTorch model in INT8 for inference using OpenVINO Post-training Optimization Tools <Inference/PyTorch/quantize_pytorch_inference_pot.html>`_
 * `How to enable automatic context management for PyTorch inference on Nano optimized models <Inference/PyTorch/pytorch_context_manager.html>`_
 * `How to save and load optimized ONNXRuntime model <Inference/PyTorch/pytorch_save_and_load_onnx.html>`_
 * `How to save and load optimized OpenVINO model <Inference/PyTorch/pytorch_save_and_load_openvino.html>`_

--- a/docs/readthedocs/source/doc/Nano/Howto/index.rst
+++ b/docs/readthedocs/source/doc/Nano/Howto/index.rst
@@ -67,8 +67,8 @@ PyTorch
 * `How to accelerate a PyTorch inference pipeline through ONNXRuntime <Inference/PyTorch/accelerate_pytorch_inference_onnx.html>`_
 * `How to accelerate a PyTorch inference pipeline through OpenVINO <Inference/PyTorch/accelerate_pytorch_inference_openvino.html>`_
 * `How to accelerate a PyTorch inference pipeline through JIT/IPEX <Inference/PyTorch/accelerate_pytorch_inference_jit_ipex.html>`_
-* `How to quantize your PyTorch model for inference using Intel Neural Compressor <Inference/PyTorch/quantize_pytorch_inference_inc.html>`_
-* `How to quantize your PyTorch model for inference using OpenVINO Post-training Optimization Tools <Inference/PyTorch/quantize_pytorch_inference_pot.html>`_
+* `How to quantize your PyTorch model in INT8 for inference using Intel Neural Compressor <Inference/PyTorch/quantize_pytorch_inference_inc.html>`_
+* `How to quantize your PyTorch model in INT8 for inference using OpenVINO Post-training Optimization Tools <Inference/PyTorch/quantize_pytorch_inference_pot.html>`_
 * `How to enable automatic context management for PyTorch inference on Nano optimized models <Inference/PyTorch/pytorch_context_manager.html>`_
 * `How to save and load optimized ONNXRuntime model <Inference/PyTorch/pytorch_save_and_load_onnx.html>`_
 * `How to save and load optimized OpenVINO model <Inference/PyTorch/pytorch_save_and_load_openvino.html>`_

--- a/docs/readthedocs/source/doc/Nano/Howto/index.rst
+++ b/docs/readthedocs/source/doc/Nano/Howto/index.rst
@@ -63,21 +63,18 @@ OpenVINO
 PyTorch
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 
+* `How to find accelerated method with minimal latency using InferenceOptimizer <Inference/PyTorch/inference_optimizer_optimize.html>`_
 * `How to accelerate a PyTorch inference pipeline through ONNXRuntime <Inference/PyTorch/accelerate_pytorch_inference_onnx.html>`_
 * `How to accelerate a PyTorch inference pipeline through OpenVINO <Inference/PyTorch/accelerate_pytorch_inference_openvino.html>`_
 * `How to accelerate a PyTorch inference pipeline through JIT/IPEX <Inference/PyTorch/accelerate_pytorch_inference_jit_ipex.html>`_
-* `How to accelerate a PyTorch inference pipeline through multiple instances <Inference/PyTorch/multi_instance_pytorch_inference.html>`_
 * `How to quantize your PyTorch model for inference using Intel Neural Compressor <Inference/PyTorch/quantize_pytorch_inference_inc.html>`_
 * `How to quantize your PyTorch model for inference using OpenVINO Post-training Optimization Tools <Inference/PyTorch/quantize_pytorch_inference_pot.html>`_
-* |pytorch_inference_context_manager_link|_
-* `How to save and load optimized IPEX model <Inference/PyTorch/pytorch_save_and_load_ipex.html>`_
-* `How to save and load optimized JIT model <Inference/PyTorch/pytorch_save_and_load_jit.html>`_
+* `How to enable automatic context management for PyTorch inference on Nano optimized models <Inference/PyTorch/pytorch_context_manager.html>`_
 * `How to save and load optimized ONNXRuntime model <Inference/PyTorch/pytorch_save_and_load_onnx.html>`_
 * `How to save and load optimized OpenVINO model <Inference/PyTorch/pytorch_save_and_load_openvino.html>`_
-* `How to find accelerated method with minimal latency using InferenceOptimizer <Inference/PyTorch/inference_optimizer_optimize.html>`_
-
-.. |pytorch_inference_context_manager_link| replace:: How to use context manager through ``get_context``
-.. _pytorch_inference_context_manager_link: Inference/PyTorch/pytorch_context_manager.html
+* `How to save and load optimized JIT model <Inference/PyTorch/pytorch_save_and_load_jit.html>`_
+* `How to save and load optimized IPEX model <Inference/PyTorch/pytorch_save_and_load_ipex.html>`_
+* `How to accelerate a PyTorch inference pipeline through multiple instances <Inference/PyTorch/multi_instance_pytorch_inference.html>`_
 
 TensorFlow
 ~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_jit_ipex.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_jit_ipex.ipynb
@@ -15,27 +15,33 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "> 📝 **Note**\n",
-        ">\n",
-        "> * `jit`: You can use `InferenceOptimizer.trace(..., accelerator=\"jit\")` API to enable the jit acceleration for PyTorch inference.\n",
-        "> * `ipex`: You can use`InferenceOptimizer.trace(...,use_ipex=True)` API to enable the ipex acceleration for PyTorch inference. It only takes a few lines.\n",
-        "> * `jit + ipex`: It is recommended to use JIT and IPEX together. You can user `InferenceOptimizer.trace(..., acclerator=\"jit\", use_ipex=True`) to enable both for PyTorch inference."
+        "* JIT: You can use `InferenceOptimizer.trace(..., accelerator=\"jit\")` API to enable the TorchScript acceleration for PyTorch inference.\n",
+        "* IPEX: You can use `InferenceOptimizer.trace(...,use_ipex=True)` API to enable the IPEX (Intel® Extension for PyTorch*) acceleration for PyTorch inference.\n",
+        "* JIT + IPEX: It is recommended to use JIT and IPEX together. You can user `InferenceOptimizer.trace(..., acclerator=\"jit\", use_ipex=True`) to enable both for PyTorch inference.\n",
+        "\n",
+        "All of the above accelerations only take a few lines to apply."
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "nbsphinx": "hidden"
+      },
       "source": [
-        "To apply JIT/IPEX acceleration, the following dependencies need to be installed first："
+        "To apply JIT/IPEX acceleration only, you could install BigDL-Nano for PyTorch first："
       ]
     },
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "nbsphinx": "hidden"
+      },
       "outputs": [],
       "source": [
         "!pip install --pre --upgrade bigdl-nano[pytorch] # install the nightly-built version\n",
@@ -44,7 +50,9 @@
     },
     {
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "nbsphinx": "hidden"
+      },
       "source": [
         "> 📝 **Note**\n",
         ">\n",
@@ -71,26 +79,11 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Then we set it in evaluation mode:"
-      ]
-    },
-    {
-      "cell_type": "code",
-      "execution_count": null,
-      "metadata": {},
-      "outputs": [],
-      "source": [
-        "model_ft.eval()"
-      ]
-    },
-    {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "To accelerate inference using JIT/IPEX/JIT+IPEX, we need to import `InferenceOptimizer` first:"
+        "To accelerate inference using JIT / IPEX / JIT + IPEX, we need to import `InferenceOptimizer` first:"
       ]
     },
     {
@@ -148,10 +141,11 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "### Accelerate Inference Using IPEX + JIT"
+        "### Accelerate Inference Using JIT + IPEX"
       ]
     },
     {
@@ -172,6 +166,7 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
@@ -179,23 +174,28 @@
         ">\n",
         "> `input_sample` is the parameter for accelerators to know the **shape** of the model input. So both the batch size and the specific values are not important to `input_sample`. If we want our test dataset to consist of images with $224 \\times 224$ pixels, we could use `torch.rand(1, 3, 224, 224)` for `input_sample` here.\n",
         ">\n",
-        "> Please refer to [API documentation](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/pytorch.html#bigdl.nano.pytorch.InferenceOptimizer.trace) for more information on `InferenceOptimizer.trace`."
+        "> Please refer to [API documentation](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/pytorch.html#bigdl.nano.pytorch.InferenceOptimizer.trace) for more information on `InferenceOptimizer.trace`.\n",
+        ">\n",
+        "> Also note that for all Nano optimized models by `InferenceOptimizer.trace`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.htm) for more detailed usage of the context manager."
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
         "> 📚 **Related Readings**\n",
         ">\n",
         "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)\n",
-        "> - [How to install BigDL-Nano in Google Colab](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Install/install_in_colab.html)"
+        "> - [How to enable automatic context management for PyTorch inference on Nano optimized models](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.html)\n",
+        "> - [How to save and load optimized JIT model](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_save_and_load_jit.html)\n",
+        "> - [How to save and load optimized IPEX model](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_save_and_load_ipex.html)"
       ]
     }
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "Python 3.7.10 ('ruonan_nano')",
+      "display_name": "nano-pytorch",
       "language": "python",
       "name": "python3"
     },
@@ -209,12 +209,12 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.7.10"
+      "version": "3.7.15 (default, Nov 24 2022, 21:12:53) \n[GCC 11.2.0]"
     },
     "orig_nbformat": 4,
     "vscode": {
       "interpreter": {
-        "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
+        "hash": "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1"
       }
     }
   },

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_jit_ipex.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_jit_ipex.ipynb
@@ -176,7 +176,7 @@
         ">\n",
         "> Please refer to [API documentation](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/pytorch.html#bigdl.nano.pytorch.InferenceOptimizer.trace) for more information on `InferenceOptimizer.trace`.\n",
         ">\n",
-        "> Also note that for all Nano optimized models by `InferenceOptimizer.trace`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.htm) for more detailed usage of the context manager."
+        "> Also note that for all Nano optimized models by `InferenceOptimizer.trace`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.html) for more detailed usage of the context manager."
       ]
     },
     {

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_jit_ipex.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_jit_ipex.ipynb
@@ -33,7 +33,7 @@
         "nbsphinx": "hidden"
       },
       "source": [
-        "To apply JIT/IPEX acceleration only, you could install BigDL-Nano for PyTorch first："
+        "To apply JIT/IPEX acceleration, you should install BigDL-Nano for PyTorch first："
       ]
     },
     {

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_jit_ipex.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_jit_ipex.ipynb
@@ -83,7 +83,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "To accelerate inference using JIT/IPEX/JIT + IPEX, we need to import `InferenceOptimizer` first:"
+        "To accelerate inference using JIT, IPEX, or JIT together with IPEX, we need to import `InferenceOptimizer` first:"
       ]
     },
     {

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_jit_ipex.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_jit_ipex.ipynb
@@ -83,7 +83,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "To accelerate inference using JIT / IPEX / JIT + IPEX, we need to import `InferenceOptimizer` first:"
+        "To accelerate inference using JIT/IPEX/JIT + IPEX, we need to import `InferenceOptimizer` first:"
       ]
     },
     {

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_onnx.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_onnx.ipynb
@@ -77,7 +77,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To enable ONNXRuntime acceleration for your PyTorch inference pipeline, **the major change you need to made is to import BigDL-Nano** `InferenceOptimizer`**, and trace your PyTorch model to convert it into an ONNXRuntime accelerated module for inference**:"
+    "To enable ONNXRuntime acceleration for your PyTorch inference pipeline, **the major change you need to make is to import BigDL-Nano** `InferenceOptimizer`**, and trace your PyTorch model to convert it into an ONNXRuntime accelerated model for inference**:"
    ]
   },
   {

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_onnx.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_onnx.ipynb
@@ -134,7 +134,7 @@
    "source": [
     "> 📝 **Note**\n",
     "> \n",
-    "> For all Nano optimized models by `InferenceOptimizer.trace`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.htm) for more detailed usage of the context manager."
+    "> For all Nano optimized models by `InferenceOptimizer.trace`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.html) for more detailed usage of the context manager."
    ]
   },
   {

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_onnx.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_onnx.ipynb
@@ -22,12 +22,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "nbsphinx": "hidden"
    },
    "source": [
-    "To apply ONNXRuntime acceleration, the following dependencies need to be installed first:"
+    "To apply ONNXRuntime acceleration, you need to install BigDL-Nano for PyTorch inference first:"
    ]
   },
   {
@@ -72,26 +73,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we set it in evaluation mode:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model_ft.eval()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To enable ONNXRuntime acceleration for your PyTorch inference pipeline, **the only change you need to made is to import BigDL-Nano** `InferenceOptimizer`**, and trace your PyTorch model to convert it into an ONNXRuntime accelerated module for inference**:"
+    "To enable ONNXRuntime acceleration for your PyTorch inference pipeline, **the major change you need to made is to import BigDL-Nano** `InferenceOptimizer`**, and trace your PyTorch model to convert it into an ONNXRuntime accelerated module for inference**:"
    ]
   },
   {
@@ -120,10 +106,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You could then do the normal inference steps with the model optimized by ONNXRuntime:"
+    "You could then do the normal inference steps **under the context manager provided by Nano**, with the model optimized by ONNXRuntime:"
    ]
   },
   {
@@ -141,30 +128,42 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 📝 **Note**\n",
+    "> \n",
+    "> For all Nano optimized models by `InferenceOptimizer.trace`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.htm) for more detailed usage of the context manager."
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> 📚 **Related Readings**\n",
     "> \n",
     "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)\n",
-    "> - [How to install BigDL-Nano in Google Colab](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Install/install_in_colab.html)"
+    "> - [How to enable automatic context management for PyTorch inference on Nano optimized models](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.html)\n",
+    "> - [How to save and load optimized ONNXRuntime model](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_save_and_load_onnx.html)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.10 ('ruonan_nano')",
+   "display_name": "nano-pytorch",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "name": "python",
-   "version": "3.7.10"
+   "version": "3.7.15 (default, Nov 24 2022, 21:12:53) \n[GCC 11.2.0]"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
+    "hash": "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1"
    }
   }
  },

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_openvino.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_openvino.ipynb
@@ -22,12 +22,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "nbsphinx": "hidden"
    },
    "source": [
-    "To apply OpenVINO acceleration, the following dependencies need to be installed first："
+    "To apply OpenVINO acceleration, you need to install BigDL-Nano for inference first："
    ]
   },
   {
@@ -72,26 +73,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we set it in evaluation mode:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model_ft.eval()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To enable OpenVINO acceleration for your PyTorch inference pipeline, **the only change you need to made is to import BigDL-Nano** `InferenceOptimizer`**, and trace your PyTorch model to convert it into an OpenVINO accelerated module for inference**:"
+    "To enable OpenVINO acceleration for your PyTorch inference pipeline, **the major change you need to made is to import BigDL-Nano** `InferenceOptimizer`**, and trace your PyTorch model to convert it into an OpenVINO accelerated module for inference**:"
    ]
   },
   {
@@ -120,10 +106,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You could then do the normal inference steps with the model optimized by OpenVINO:"
+    "You could then do the normal inference steps **under the context manager provided by Nano**, with the model optimized by OpenVINO:"
    ]
   },
   {
@@ -141,30 +128,42 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 📝 **Note**\n",
+    "> \n",
+    "> For all Nano optimized models by `InferenceOptimizer.trace`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.htm) for more detailed usage of the context manager."
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> 📚 **Related Readings**\n",
     "> \n",
     "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)\n",
-    "> - [How to install BigDL-Nano in Google Colab](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Install/install_in_colab.html)"
+    "> - [How to enable automatic context management for PyTorch inference on Nano optimized models](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.html)\n",
+    "> - [How to save and load optimized OpenVINO model](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_save_and_load_openvino.html)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.10 ('ruonan_nano')",
+   "display_name": "nano-pytorch",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "name": "python",
-   "version": "3.7.10"
+   "version": "3.7.15 (default, Nov 24 2022, 21:12:53) \n[GCC 11.2.0]"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
+    "hash": "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1"
    }
   }
  },

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_openvino.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_openvino.ipynb
@@ -28,7 +28,7 @@
     "nbsphinx": "hidden"
    },
    "source": [
-    "To apply OpenVINO acceleration, you need to install BigDL-Nano for inference first："
+    "To apply OpenVINO acceleration, you need to install BigDL-Nano for PyTorch inference first："
    ]
   },
   {
@@ -77,7 +77,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To enable OpenVINO acceleration for your PyTorch inference pipeline, **the major change you need to made is to import BigDL-Nano** `InferenceOptimizer`**, and trace your PyTorch model to convert it into an OpenVINO accelerated module for inference**:"
+    "To enable OpenVINO acceleration for your PyTorch inference pipeline, **the major change you need to make is to import BigDL-Nano** `InferenceOptimizer`**, and trace your PyTorch model to convert it into an OpenVINO accelerated model for inference**:"
    ]
   },
   {

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_openvino.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_openvino.ipynb
@@ -134,7 +134,7 @@
    "source": [
     "> 📝 **Note**\n",
     "> \n",
-    "> For all Nano optimized models by `InferenceOptimizer.trace`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.htm) for more detailed usage of the context manager."
+    "> For all Nano optimized models by `InferenceOptimizer.trace`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.html) for more detailed usage of the context manager."
    ]
   },
   {

--- a/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
@@ -23,12 +23,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "nbsphinx": "hidden"
    },
    "source": [
-    "To inference using BigDL-Nano InferenceOptimizer, the following packages need to be installed first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment. \n",
+    "To inference using BigDL-Nano InferenceOptimizer, you need to install BigDL-Nano for PyTorch inference first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment. \n",
     "\n",
     "You can create a conda environment by executing:\n",
     "\n",

--- a/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
@@ -29,7 +29,7 @@
     "nbsphinx": "hidden"
    },
    "source": [
-    "To inference using BigDL-Nano InferenceOptimizer, you need to install BigDL-Nano for PyTorch inference first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment. \n",
+    "To do inference using BigDL-Nano InferenceOptimizer, you need to install BigDL-Nano for PyTorch inference first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment. \n",
     "\n",
     "You can create a conda environment by executing:\n",
     "\n",

--- a/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
@@ -24,7 +24,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
    "source": [
     "To inference using BigDL-Nano InferenceOptimizer, the following packages need to be installed first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment. \n",
     "\n",
@@ -40,7 +42,9 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "nbsphinx": "hidden"
+   },
    "source": [
     "Then initialize environment variables with script `bigdl-nano-init` installed with bigdl-nano.\n",
     "\n",
@@ -608,6 +612,16 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 📝 **Note**\n",
+    "> \n",
+    "> For all Nano optimized models by `InferenceOptimizer.optimize`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.htm) for more detailed usage of the context manager."
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -661,19 +675,24 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> 📚 **Related Readings**\n",
     "> \n",
     "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)\n",
-    "> - [How to install BigDL-Nano in Google Colab](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Install/install_in_colab.html)"
+    "> - [How to enable automatic context management for PyTorch inference on Nano optimized models](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.html)\n",
+    "> - [How to save and load optimized ONNXRuntime model](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_save_and_load_onnx.html)\n",
+    "> - [How to save and load optimized OpenVINO model](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_save_and_load_openvino.html)\n",
+    "> - [How to save and load optimized JIT model](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_save_and_load_jit.html)\n",
+    "> - [How to save and load optimized IPEX model](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_save_and_load_ipex.html)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "nano-pytorch",
    "language": "python",
    "name": "python3"
   },
@@ -687,11 +706,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10 (default, Jun  4 2021, 14:48:32) \n[GCC 7.5.0]"
+   "version": "3.7.15 (default, Nov 24 2022, 21:12:53) \n[GCC 11.2.0]"
   },
   "vscode": {
    "interpreter": {
-    "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
+    "hash": "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1"
    }
   }
  },

--- a/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/inference_optimizer_optimize.ipynb
@@ -619,7 +619,7 @@
    "source": [
     "> 📝 **Note**\n",
     "> \n",
-    "> For all Nano optimized models by `InferenceOptimizer.optimize`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.htm) for more detailed usage of the context manager."
+    "> For all Nano optimized models by `InferenceOptimizer.optimize`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.html) for more detailed usage of the context manager."
    ]
   },
   {

--- a/python/nano/tutorial/notebook/inference/pytorch/multi_instance_pytorch_inference.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/multi_instance_pytorch_inference.ipynb
@@ -8,10 +8,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Accelerate PyTorch Inference using multiple instances"
+    "# Accelerate PyTorch Inference using Multiple Instances"
    ]
   },
   {
@@ -22,12 +23,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "nbsphinx": "hidden"
    },
    "source": [
-    "To apply multi-instance acceleration, the following dependencies need to be installed first:"
+    "To apply multi-instance acceleration, you should install BigDL-Nano for PyTorch first:"
    ]
   },
   {
@@ -88,10 +90,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To enable multi-instance acceleration for your PyTorch inference pipeline, **you should import BigDL-Nano** `InferenceOptimizer`**, and convert your model to a multi-instance model** first:"
+    "To enable multi-instance acceleration for your PyTorch inference pipeline, **you should import BigDL-Nano** `InferenceOptimizer`**, and convert your model to a multi-instance model**:"
    ]
   },
   {
@@ -183,19 +186,19 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> 📚 **Related Readings**\n",
     "> \n",
-    "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)\n",
-    "> - [How to install BigDL-Nano in Google Colab](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Install/install_in_colab.html)"
+    "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.10 ('nano-torch')",
+   "display_name": "nano-pytorch",
    "language": "python",
    "name": "python3"
   },
@@ -209,12 +212,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.15 (default, Nov 24 2022, 21:12:53) \n[GCC 11.2.0]"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "bc64c6abdd4f97e070994ad40219fd32575aea61f9fa271f1288afdc551ed374"
+    "hash": "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1"
    }
   }
  },

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_context_manager.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_context_manager.ipynb
@@ -15,16 +15,19 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You can use ``InferenceOptimizer.get_context(model=...)`` API to enable automatic context management for PyTorch inference. With only one line of code change, BigDL-Nano will automatically provide suitable context management for each accelerated model, it usually contains part of or all of following three types of context manager:\n",
+    "You can use ``InferenceOptimizer.get_context(model=...)`` API to enable automatic context management for PyTorch inference. With only one line of code change, BigDL-Nano will automatically provide suitable context management for each accelerated model optimized by ``InferenceOptimizer.trace``/``quantize``/``optimize``, it usually contains part of or all of following four types of context manager:\n",
     "\n",
-    "1. ``torch.no_grad()`` to disable gradients, which will be used for all model\n",
+    "1. ``torch.inference_mode(True)`` to disable gradients, which will be used for all models\n",
     "   \n",
     "2. ``torch.cpu.amp.autocast(dtype=torch.bfloat16)`` to run in mixed precision, which will be provided for bf16 related model\n",
     "   \n",
-    "3. ``torch.set_num_threads()`` to control thread number, which will be used only if you specify ``thread_num`` when applying ``InferenceOptimizer.trace``/``quantize``/``optimize``"
+    "3. ``torch.set_num_threads()`` to control thread number, which will be used only if you specify ``thread_num`` when applying ``InferenceOptimizer.trace``/``quantize``/``optimize``\n",
+    "\n",
+    "4. ``torch.jit.enable_onednn_fusion(True)`` to support ONEDNN fusion for jit when using jit as accelerator"
    ]
   },
   {
@@ -294,13 +297,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> 📚 **Related Readings**\n",
     "> \n",
-    "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)\n",
-    "> - [How to install BigDL-Nano in Google Colab](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Install/install_in_colab.html)"
+    "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)"
    ]
   }
  ],

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_context_manager.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_context_manager.ipynb
@@ -8,10 +8,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Automatic inference context management by `get_context`"
+    "# Automatic Inference Context Management by `get_context`"
    ]
   },
   {

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_context_manager.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_context_manager.ipynb
@@ -22,7 +22,7 @@
    "source": [
     "You can use ``InferenceOptimizer.get_context(model=...)`` API to enable automatic context management for PyTorch inference. With only one line of code change, BigDL-Nano will automatically provide suitable context management for each accelerated model optimized by ``InferenceOptimizer.trace``/``quantize``/``optimize``, it usually contains part of or all of following four types of context manager:\n",
     "\n",
-    "1. ``torch.inference_mode(True)`` to disable gradients, which will be used for all models\n",
+    "1. ``torch.inference_mode(True)`` to disable gradients, which will be used for all models. For the case when ``torch <= 1.12``, ``torch.no_grad()`` will be used for PyTorch mixed precision inference as a replacement of ``torch.inference_mode(True)``\n",
     "   \n",
     "2. ``torch.cpu.amp.autocast(dtype=torch.bfloat16)`` to run in mixed precision, which will be provided for bf16 related model\n",
     "   \n",

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_context_manager.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_context_manager.ipynb
@@ -31,12 +31,13 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "nbsphinx": "hidden"
    },
    "source": [
-    "To do inference using Bigdl-nano InferenceOptimizer, the following packages need to be installed first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment.\n",
+    "To do inference using Bigdl-nano InferenceOptimizer, you need to install BigDL-Nano for PyTorch inference first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment.\n",
     "\n",
     "You can create a conda environment by executing:\n",
     "\n",
@@ -309,7 +310,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.10 ('ruonan_nano')",
+   "display_name": "nano-pytorch",
    "language": "python",
    "name": "python3"
   },
@@ -323,12 +324,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.15 (default, Nov 24 2022, 21:12:53) \n[GCC 11.2.0]"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
+    "hash": "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1"
    }
   }
  },

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_ipex.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_ipex.ipynb
@@ -18,10 +18,13 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "nbsphinx": "hidden"
+      },
       "source": [
-        "To inference using Bigdl-nano InferenceOptimizer, the following packages need to be installed first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment.\n",
+        "To conduct IPEX optimization through BigDL-Nano InferenceOptimizer, you need to install BigDL-Nano for PyTorch first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment.\n",
         "\n",
         "You can create a conda environment by executing:\n",
         "\n",
@@ -38,7 +41,9 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "nbsphinx": "hidden"
+      },
       "outputs": [],
       "source": [
         "# Necessary packages for inference accelaration\n",
@@ -46,10 +51,11 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "First, prepare model. We need load the pretrained ResNet18 model."
+        "First, prepare model. We need to load the pretrained ResNet18 model:"
       ]
     },
     {
@@ -61,15 +67,15 @@
         "import torch\n",
         "from torchvision.models import resnet18\n",
         "\n",
-        "model_ft = resnet18(pretrained=True)\n",
-        "model_ft.eval()"
+        "model_ft = resnet18(pretrained=True)"
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Accelerate Inference Using IPEX"
+        "## Accelerate Inference Using IPEX"
       ]
     },
     {
@@ -84,10 +90,12 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Save Optimized IPEX Model\n",
+        "## Save Optimized IPEX Model\n",
+        "\n",
         "The saved model files will be saved at \"./optimized_model_ipex\" directory\n",
         "There are 2 files in optimized_model_ipex, users only need to take \"ckpt.pth\" file for further usage:\n",
         "\n",
@@ -105,10 +113,11 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Load the Optimized Model"
+        "## Load the Optimized Model"
       ]
     },
     {
@@ -131,10 +140,11 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Inference with the Loaded Model"
+        "## Inference with the Loaded Model"
       ]
     },
     {
@@ -151,19 +161,19 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
         "> 📚 **Related Readings**\n",
         ">\n",
-        "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)\n",
-        "> - [How to install BigDL-Nano in Google Colab](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Install/install_in_colab.html)"
+        "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)"
       ]
     }
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "Python 3.7.13 ('junwang-resnext-oob')",
+      "display_name": "nano-pytorch",
       "language": "python",
       "name": "python3"
     },
@@ -177,12 +187,12 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.7.13"
+      "version": "3.7.15 (default, Nov 24 2022, 21:12:53) \n[GCC 11.2.0]"
     },
     "orig_nbformat": 4,
     "vscode": {
       "interpreter": {
-        "hash": "2c2c667a59d63f4d9cf9e9a8f7eff73ad81424da777ad3c4a3346b0ce2b012b2"
+        "hash": "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1"
       }
     }
   },

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_ipex.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_ipex.ipynb
@@ -46,7 +46,7 @@
       },
       "outputs": [],
       "source": [
-        "# Necessary packages for inference accelaration\n",
+        "# Necessary packages for inference accelaration using IPEX\n",
         "!pip install --pre --upgrade bigdl-nano[pytorch]"
       ]
     },

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_ipex.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_ipex.ipynb
@@ -16,7 +16,7 @@
         "\n",
         "This example illustrates how to save and load a model accelerated by IPEX.\n",
         "\n",
-        "In this example, we use a pretrained ResNet18 model. Then, by calling `InferenceOptimizer.trace(..., use_ipex=True)`, we can obtain a model accelerated by IPEX method. By calling `InferenceOptimizer.save(model_name, path)` , we could save the model to a folder. By calling `InferenceOptimizer.load(path)`, we could load the model from a folder."
+        "In this example, we use a pretrained ResNet18 model. Then, by calling `InferenceOptimizer.trace(..., use_ipex=True)`, we can obtain a model accelerated by IPEX method. By calling `InferenceOptimizer.save(model=..., path=...)` , we could save the Nano optimized model to a folder. By calling `InferenceOptimizer.load(path=..., model=original_model)`, we could load the IPEX optimized model from a folder."
       ]
     },
     {
@@ -124,22 +124,24 @@
       ]
     },
     {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
-        "> 📝 **Note**\n",
-        ">\n",
-        "> * For a model accelerated by JIT, OpenVINO or ONNXRuntime, we saved the structure of its network, so we don't need its unaccelerated model when we load the optimized model.\n",
-        "> * For a model accelerated by IPEX, we only store the `state_dict` which is simply a python dictionary object that maps each layer to its parameter tensor when saving the model, so when we load the optimized model, we need to pass in the orginal model."
-      ]
-    },
-    {
       "cell_type": "code",
       "execution_count": null,
       "metadata": {},
       "outputs": [],
       "source": [
         "loaded_model = InferenceOptimizer.load(\"./optimized_model_ipex\", model=model_ft)"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> 📝 **Note**\n",
+        ">\n",
+        "> The original model is required when we load the IPEX optimized model. As we only store the `state_dict`, which is simply a python dictionary object that maps each layer to its parameter tensor, when saving the IPEX optimized model.\n",
+        ">\n",
+        "> Note that when the model is optimized by IPEX as well as the JIT accelerator, the original model is not required when loading the optimized model."
       ]
     },
     {

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_ipex.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_ipex.ipynb
@@ -8,13 +8,15 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
         "# Save and Load Optimized IPEX Model\n",
         "\n",
         "This example illustrates how to save and load a model accelerated by IPEX.\n",
-        "In this example, we use a ResNet18 model pretrained. Then, by calling `InferenceOptimizer.trace(..., use_ipex=True)`, we can obtain a model accelerated by IPEX method. By calling `InferenceOptimizer.save(model_name, path)` , we could save the model to a folder. By calling `InferenceOptimizer.load(path)`, we could load the model from a folder."
+        "\n",
+        "In this example, we use a pretrained ResNet18 model. Then, by calling `InferenceOptimizer.trace(..., use_ipex=True)`, we can obtain a model accelerated by IPEX method. By calling `InferenceOptimizer.save(model_name, path)` , we could save the model to a folder. By calling `InferenceOptimizer.load(path)`, we could load the model from a folder."
       ]
     },
     {
@@ -96,7 +98,8 @@
       "source": [
         "## Save Optimized IPEX Model\n",
         "\n",
-        "The saved model files will be saved at \"./optimized_model_ipex\" directory\n",
+        "The saved model files will be saved at \"./optimized_model_ipex\" directory.\n",
+        "\n",
         "There are 2 files in optimized_model_ipex, users only need to take \"ckpt.pth\" file for further usage:\n",
         "\n",
         "* nano_model_meta.yml: meta information of the saved model checkpoint\n",

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_jit.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_jit.ipynb
@@ -16,7 +16,7 @@
         "\n",
         "This example illustrates how to save and load a model accelerated by JIT.\n",
         "\n",
-        "In this example, we use a pretrained ResNet18 model. Then, by calling `InferenceOptimizer.trace(model, accelerator=\"jit\"...)`, we can obtain a model accelarated by JIT method. By calling `InferenceOptimizer.save(model_name, path)` , we could save the model to a folder. By calling `InferenceOptimizer.load(path)`, we could load the model from a folder."
+        "In this example, we use a pretrained ResNet18 model. Then, by calling `InferenceOptimizer.trace(..., accelerator=\"jit\")`, we can obtain a model accelarated by JIT method. By calling `InferenceOptimizer.save(model=..., path=...)` , we could save the Nano optimized model to a folder. By calling `InferenceOptimizer.load(path=...)`, we could load the JIT optimized model from a folder."
       ]
     },
     {
@@ -131,6 +131,16 @@
       "outputs": [],
       "source": [
         "loaded_model = InferenceOptimizer.load(\"./optimized_model_jit\")"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> 📝 **Note**\n",
+        ">\n",
+        "> For a model accelerated by JIT, we save the structure of its network. So, the original model is not needed when we load the optimized model."
       ]
     },
     {

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_jit.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_jit.ipynb
@@ -8,13 +8,15 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
         "# Save and Load Optimized JIT Model\n",
         "\n",
         "This example illustrates how to save and load a model accelerated by JIT.\n",
-        "In this example, we use a ResNet18 model pretrained. Then, by calling `InferenceOptimizer.trace(model, accelerator=\"jit\"...)`, we can obtain a model accelarated by JIT method. By calling `InferenceOptimizer.save(model_name, path)` , we could save the model to a folder. By calling `InferenceOptimizer.load(path)`, we could load the model from a folder."
+        "\n",
+        "In this example, we use a pretrained ResNet18 model. Then, by calling `InferenceOptimizer.trace(model, accelerator=\"jit\"...)`, we can obtain a model accelarated by JIT method. By calling `InferenceOptimizer.save(model_name, path)` , we could save the model to a folder. By calling `InferenceOptimizer.load(path)`, we could load the model from a folder."
       ]
     },
     {
@@ -51,10 +53,11 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "First, prepare model. We need load the pretrained ResNet18 model."
+        "First, prepare model. We need to load the pretrained ResNet18 model:"
       ]
     },
     {
@@ -96,7 +99,8 @@
       "source": [
         "## Save Optimized JIT Model\n",
         "\n",
-        "The saved model files will be saved at \"./optimized_model_jit\" directory\n",
+        "The saved model files will be saved at \"./optimized_model_jit\" directory.\n",
+        "\n",
         "There are 2 files in optimized_model_jit, users only need to take \"ckpt.pth\" file for further usage:\n",
         "\n",
         "* nano_model_meta.yml: meta information of the saved model checkpoint\n",

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_jit.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_jit.ipynb
@@ -18,10 +18,13 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "nbsphinx": "hidden"
+      },
       "source": [
-        "To inference using Bigdl-nano InferenceOptimizer, the following packages need to be installed first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment.\n",
+        "To conduct JIT optimization through BigDL-Nano InferenceOptimizer, you need to install BigDL-Nano for PyTorch first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment.\n",
         "\n",
         "You can create a conda environment by executing:\n",
         "\n",
@@ -38,10 +41,12 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "nbsphinx": "hidden"
+      },
       "outputs": [],
       "source": [
-        "# Necessary packages for inference accelaration\n",
+        "# Necessary packages for inference accelaration using JIT\n",
         "!pip install --pre --upgrade bigdl-nano[pytorch]"
       ]
     },
@@ -65,10 +70,11 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Accelerate Inference Using JIT"
+        "## Accelerate Inference Using JIT"
       ]
     },
     {
@@ -84,10 +90,12 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Save Optimized JIT Model\n",
+        "## Save Optimized JIT Model\n",
+        "\n",
         "The saved model files will be saved at \"./optimized_model_jit\" directory\n",
         "There are 2 files in optimized_model_jit, users only need to take \"ckpt.pth\" file for further usage:\n",
         "\n",
@@ -105,10 +113,11 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Load the Optimized Model"
+        "## Load the Optimized Model"
       ]
     },
     {
@@ -121,10 +130,11 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Inference with the Loaded Model"
+        "## Inference with the Loaded Model"
       ]
     },
     {
@@ -141,20 +151,20 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
         "\n",
         "> 📚 **Related Readings**\n",
         ">\n",
-        "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)\n",
-        "> - [How to install BigDL-Nano in Google Colab](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Install/install_in_colab.html)"
+        "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)"
       ]
     }
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "Python 3.7.10 ('ruonan_nano')",
+      "display_name": "nano-pytorch",
       "language": "python",
       "name": "python3"
     },
@@ -168,12 +178,12 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.7.10"
+      "version": "3.7.15 (default, Nov 24 2022, 21:12:53) \n[GCC 11.2.0]"
     },
     "orig_nbformat": 4,
     "vscode": {
       "interpreter": {
-        "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
+        "hash": "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1"
       }
     }
   },

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_onnx.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_onnx.ipynb
@@ -15,18 +15,23 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
         "This example illustrates how to save and load a model accelerated by onnxruntime.\n",
-        "In this example, we use a ResNet18 model pretrained. Then, by calling `trace(model, accelerator=\"onnxruntime\"...)`, we can obtain a model accelarated by onnxruntime method provided by BigDL-Nano for inference. By calling `save(model_name, path)` , we could save the model to a folder. By calling `load(path)`, we could load the model from a folder."
+        "\n",
+        "In this example, we use a pretrained ResNet18 model. Then, by calling `trace(model, accelerator=\"onnxruntime\"...)`, we can obtain a model accelarated by onnxruntime method provided by BigDL-Nano for inference. By calling `save(model_name, path)` , we could save the model to a folder. By calling `load(path)`, we could load the model from a folder."
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "nbsphinx": "hidden"
+      },
       "source": [
-        "To inference using Bigdl-nano InferenceOptimizer, the following packages need to be installed first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment.\n",
+        "To conduct ONNXRuntime optimization through BigDL-Nano InferenceOptimizer, you need to install BigDL-Nano for PyTorch Inference first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment.\n",
         "\n",
         "You can create a conda environment by executing:\n",
         "\n",
@@ -44,18 +49,21 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "nbsphinx": "hidden"
+      },
       "outputs": [],
       "source": [
-        "# Necessary packages for inference accelaration\n",
+        "# Necessary packages for inference accelaration using ONNXRuntime\n",
         "!pip install --pre --upgrade bigdl-nano[pytorch,inference]"
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "First, prepare model. We use a pretrained ResNet18 model(`model_ft` in following code) in this example."
+        "First, prepare model. We need to load the pretrained ResNet18 model:"
       ]
     },
     {
@@ -67,15 +75,15 @@
         "import torch\n",
         "from torchvision.models import resnet18\n",
         "\n",
-        "model_ft = resnet18(pretrained=True)\n",
-        "model_ft.eval()"
+        "model_ft = resnet18(pretrained=True)"
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Accelerate Inference Using ONNX Runtime"
+        "## Accelerate Inference Using ONNXRuntime"
       ]
     },
     {
@@ -88,21 +96,18 @@
         "\n",
         "ort_model = InferenceOptimizer.trace(model_ft,\n",
         "                                     accelerator=\"onnxruntime\",\n",
-        "                                     input_sample=torch.rand(1, 3, 224, 224))\n",
-        "\n",
-        "with InferenceOptimizer.get_context(ort_model):\n",
-        "    x = torch.rand(2, 3, 224, 224)\n",
-        "    y_hat = ort_model(x)\n",
-        "    predictions = y_hat.argmax(dim=1)\n",
-        "    print(predictions)"
+        "                                     input_sample=torch.rand(1, 3, 224, 224))"
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Save Optimized Model\n",
-        "The saved model files will be saved at \"./optimized_model_ort\" directory\n",
+        "## Save Optimized Model\n",
+        "\n",
+        "The saved model files will be saved at \"./optimized_model_ort\" directory.\n",
+        "\n",
         "There are 2 files in optimized_model_ort, users only need to take \".onnx\" file for further usage:\n",
         "\n",
         "* nano_model_meta.yml: meta information of the saved model checkpoint\n",
@@ -119,10 +124,11 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Load the Optimized Model"
+        "## Load the Optimized Model"
       ]
     },
     {
@@ -135,10 +141,11 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Inference with the Loaded Model"
+        "## Inference with the Loaded Model"
       ]
     },
     {
@@ -148,25 +155,26 @@
       "outputs": [],
       "source": [
         "with InferenceOptimizer.get_context(loaded_model):\n",
+        "    x = torch.rand(2, 3, 224, 224)\n",
         "    y_hat = loaded_model(x)\n",
         "    predictions = y_hat.argmax(dim=1)\n",
-        "    print(predictions)\n"
+        "    print(predictions)"
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
         "> 📚 **Related Readings**\n",
         ">\n",
-        "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)\n",
-        "> - [How to install BigDL-Nano in Google Colab](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Install/install_in_colab.html)"
+        "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)"
       ]
     }
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "Python 3.7.10 ('ruonan_nano')",
+      "display_name": "nano-pytorch",
       "language": "python",
       "name": "python3"
     },
@@ -180,12 +188,12 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.7.10"
+      "version": "3.7.15 (default, Nov 24 2022, 21:12:53) \n[GCC 11.2.0]"
     },
     "orig_nbformat": 4,
     "vscode": {
       "interpreter": {
-        "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
+        "hash": "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1"
       }
     }
   },

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_onnx.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_onnx.ipynb
@@ -19,9 +19,9 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "This example illustrates how to save and load a model accelerated by onnxruntime.\n",
+        "This example illustrates how to save and load a model accelerated by ONNXRuntime.\n",
         "\n",
-        "In this example, we use a pretrained ResNet18 model. Then, by calling `trace(model, accelerator=\"onnxruntime\"...)`, we can obtain a model accelarated by onnxruntime method provided by BigDL-Nano for inference. By calling `save(model_name, path)` , we could save the model to a folder. By calling `load(path)`, we could load the model from a folder."
+        "In this example, we use a pretrained ResNet18 model. Then, by calling `trace(..., accelerator=\"onnxruntime\")`, we can obtain a model accelarated by onnxruntime method provided by BigDL-Nano for inference. By calling `save(model=..., path=...)` , we could save the Nano optimized model to a folder. By calling `load(path=...)`, we could load the ONNXRuntime optimized model from a folder."
       ]
     },
     {
@@ -138,6 +138,16 @@
       "outputs": [],
       "source": [
         "loaded_model = InferenceOptimizer.load(\"./optimized_model_ort\")"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> 📝 **Note**\n",
+        ">\n",
+        "> For a model accelerated by ONNXRuntime, we save the structure of its network. So, the original model is not needed when we load the optimized model."
       ]
     },
     {

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_openvino.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_openvino.ipynb
@@ -8,20 +8,25 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
         "# Save and Load OpenVINO Model\n",
         "\n",
         "This example illustrates how to save and load a model accelerated by openVINO.\n",
-        "In this example, we use a ResNet18 model pretrained. Then, by calling `trace(model, accelerator=\"openvino\"...)`, we can obtain a model accelarated by openVINO method provided by BigDL-Nano for inference. By calling `save(model_name, path)` , we could save the model to a folder. By calling `load(path)`, we could load the model from a folder."
+        "\n",
+        "In this example, we use a pretrained ResNet18 model. Then, by calling `trace(model, accelerator=\"openvino\"...)`, we can obtain a model accelarated by openVINO method provided by BigDL-Nano for inference. By calling `save(model_name, path)` , we could save the model to a folder. By calling `load(path)`, we could load the model from a folder."
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
-      "metadata": {},
+      "metadata": {
+        "nbsphinx": "hidden"
+      },
       "source": [
-        "To inference using Bigdl-nano InferenceOptimizer, the following packages need to be installed first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment.\n",
+        "To conduct OpenVINO optimization through BigDL-Nano InferenceOptimizer, you need to install BigDL-Nano for PyTorch inference first. We recommend you to use [Miniconda](https://docs.conda.io/en/latest/miniconda.html) to prepare the environment and install the following packages in a conda environment.\n",
         "\n",
         "You can create a conda environment by executing:\n",
         "\n",
@@ -39,18 +44,21 @@
     {
       "cell_type": "code",
       "execution_count": null,
-      "metadata": {},
+      "metadata": {
+        "nbsphinx": "hidden"
+      },
       "outputs": [],
       "source": [
-        "# Necessary packages for inference accelaration\n",
+        "# Necessary packages for inference accelaration using OpenVINO\n",
         "!pip install --pre --upgrade bigdl-nano[pytorch,inference]"
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "First, prepare model. We use a pretrained ResNet18 model(`model_ft` in following code) in this example."
+        "First, prepare model. We need to load the pretrained ResNet18 model:"
       ]
     },
     {
@@ -62,15 +70,15 @@
         "import torch\n",
         "from torchvision.models import resnet18\n",
         "\n",
-        "model_ft = resnet18(pretrained=True)\n",
-        "model_ft.eval()\n"
+        "model_ft = resnet18(pretrained=True)"
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Accelerate Inference Using OpenVINO"
+        "## Accelerate Inference Using OpenVINO"
       ]
     },
     {
@@ -83,21 +91,17 @@
         "\n",
         "ov_model = InferenceOptimizer.trace(model_ft,\n",
         "                                    accelerator=\"openvino\",\n",
-        "                                    input_sample=torch.rand(1, 3, 224, 224))\n",
-        "\n",
-        "with InferenceOptimizer.get_context(ov_model):\n",
-        "    x = torch.rand(2, 3, 224, 224)\n",
-        "    y_hat = ov_model(x)\n",
-        "    predictions = y_hat.argmax(dim=1)\n",
-        "    print(predictions)\n"
+        "                                    input_sample=torch.rand(1, 3, 224, 224))"
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Save Optimized Model\n",
-        "The saved model files will be saved at \"./optimized_model_ov\" directory\n",
+        "## Save Optimized Model\n",
+        "The saved model files will be saved at \"./optimized_model_ov\" directory.\n",
+        "\n",
         "There are 3 files in optimized_model_ov, users only need to take \".bin\" and \".xml\" file for further usage:\n",
         "\n",
         "* nano_model_meta.yml: meta information of the saved model checkpoint\n",
@@ -115,10 +119,11 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Load the Optimized Model"
+        "## Load the Optimized Model"
       ]
     },
     {
@@ -131,10 +136,11 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Inference with the Loaded Model"
+        "## Inference with the Loaded Model"
       ]
     },
     {
@@ -144,19 +150,20 @@
       "outputs": [],
       "source": [
         "with InferenceOptimizer.get_context(loaded_model):\n",
+        "    x = torch.rand(2, 3, 224, 224)\n",
         "    y_hat = loaded_model(x)\n",
         "    predictions = y_hat.argmax(dim=1)\n",
         "    print(predictions)"
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
         "> 📚 **Related Readings**\n",
         ">\n",
-        "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)\n",
-        "> - [How to install BigDL-Nano in Google Colab](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Install/install_in_colab.html)"
+        "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)"
       ]
     }
   ],

--- a/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_openvino.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/pytorch_save_and_load_openvino.ipynb
@@ -16,7 +16,7 @@
         "\n",
         "This example illustrates how to save and load a model accelerated by openVINO.\n",
         "\n",
-        "In this example, we use a pretrained ResNet18 model. Then, by calling `trace(model, accelerator=\"openvino\"...)`, we can obtain a model accelarated by openVINO method provided by BigDL-Nano for inference. By calling `save(model_name, path)` , we could save the model to a folder. By calling `load(path)`, we could load the model from a folder."
+        "In this example, we use a pretrained ResNet18 model. Then, by calling `trace(..., accelerator=\"openvino\")`, we can obtain a model accelarated by openVINO method provided by BigDL-Nano for inference. By calling `save(model=..., path=...)` , we could save the Nano optimized model to a folder. By calling `load(path=...)`, we could load the OpenVINO optimized model from a folder."
       ]
     },
     {
@@ -140,6 +140,16 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
+        "> 📝 **Note**\n",
+        ">\n",
+        "> For a model accelerated by OpenVINO, we save the structure of its network. So, the original model is not needed when we load the optimized model."
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
         "## Inference with the Loaded Model"
       ]
     },
@@ -169,7 +179,7 @@
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "Python 3.7.10 ('ruonan_nano')",
+      "display_name": "nano-pytorch",
       "language": "python",
       "name": "python3"
     },
@@ -183,12 +193,12 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.7.10"
+      "version": "3.7.15 (default, Nov 24 2022, 21:12:53) \n[GCC 11.2.0]"
     },
     "orig_nbformat": 4,
     "vscode": {
       "interpreter": {
-        "hash": "d347a5dca25745bedb029e46e41f7d6c8c9b5181ecb97033e2e81a7538459254"
+        "hash": "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1"
       }
     }
   },

--- a/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_inc.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_inc.ipynb
@@ -8,26 +8,29 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Quantize PyTorch Model for Inference using Intel Neural Compressor"
+    "# Quantize PyTorch Model in INT8 for Inference using Intel Neural Compressor"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "With Intel Neural Compressor (INC) as quantization engine, you can apply `InferenceOptimizer.quantize` API to realize post-training quantization on your PyTorch `nn.Module`. `InferenceOptimizer.quantize` also supports ONNXRuntime acceleration at the meantime through specifying `accelerator='onnxruntime'`. All acceleration takes only a few lines."
+    "With Intel Neural Compressor (INC) as quantization engine, you can apply `InferenceOptimizer.quantize` API to realize INT8 post-training quantization on your PyTorch `nn.Module`. `InferenceOptimizer.quantize` also supports ONNXRuntime acceleration at the meantime through specifying `accelerator='onnxruntime'`. All acceleration takes only a few lines."
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "nbsphinx": "hidden"
    },
    "source": [
-    "To quantize your model with INC, the following dependencies need to be installed first:"
+    "To quantize your model with INC, you need to install BigDL-Nano for PyTorch inference first:"
    ]
   },
   {
@@ -145,26 +148,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we set the model in evaluation mode:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model.eval()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To enable quantization using INC for inference, you could simply **import BigDL-Nano** `InferenceOptimizer`**, and use** `InferenceOptimizer` **to quantize your PyTorch model**:"
+    "To enable INT8 quantization using INC for inference, you could simply **import BigDL-Nano** `InferenceOptimizer`**, and use** `InferenceOptimizer` **to quantize your PyTorch model**:"
    ]
   },
   {
@@ -200,12 +188,15 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> 📝 **Note**\n",
     "> \n",
-    "> `InferenceOptimizer` will by default quantize your PyTorch `nn.Module` through **static** post-training quantization. For this case, `calib_data` (for calibration data) is required. Batch size is not important to ``calib_data``, as it intends to read 100 samples. And there could be no label in calibration data.\n",
+    "> The `InferenceOptimizer.quantize` function has a `precision` parameter to specify the precision for quantization. It is default to be `'int8'`. So, we omit the `precision` parameter here for INT8 quantization.\n",
+    ">\n",
+    "> During INT8 quantization, `InferenceOptimizer` will by default quantize your PyTorch `nn.Module` through **static** post-training quantization. For this case, `calib_data` (for calibration data) is required. Batch size is not important to ``calib_data``, as it intends to read 100 samples. And there could be no label in calibration data.\n",
     "> \n",
     "> If you would like to implement dynamic post-training quantization, you could set parameter `approach='dynamic'`. In this case, `calib_dataloader` should be `None`. Compared to dynamic quantization, static quantization could lead to faster inference as it eliminates the data conversion costs between layers.\n",
     "> \n",
@@ -213,10 +204,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You could then do the normal inference steps with the quantized model:"
+    "You could then do the normal inference steps **under the context manager provided by Nano**, with the quantized model:"
    ]
   },
   {

--- a/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_inc.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_inc.ipynb
@@ -196,7 +196,7 @@
     "> \n",
     "> The `InferenceOptimizer.quantize` function has a `precision` parameter to specify the precision for quantization. It is default to be `'int8'`. So, we omit the `precision` parameter here for INT8 quantization.\n",
     ">\n",
-    "> During INT8 quantization, `InferenceOptimizer` will by default quantize your PyTorch `nn.Module` through **static** post-training quantization. For this case, `calib_data` (for calibration data) is required. Batch size is not important to ``calib_data``, as it intends to read 100 samples. And there could be no label in calibration data.\n",
+    "> During INT8 quantization using INC, `InferenceOptimizer` will by default quantize your PyTorch `nn.Module` through **static** post-training quantization. For this case, `calib_data` (for calibration data) is required. Batch size is not important to ``calib_data``, as it intends to read 100 samples. And there could be no label in calibration data.\n",
     "> \n",
     "> If you would like to implement dynamic post-training quantization, you could set parameter `approach='dynamic'`. In this case, `calib_dataloader` should be `None`. Compared to dynamic quantization, static quantization could lead to faster inference as it eliminates the data conversion costs between layers.\n",
     "> \n",
@@ -226,13 +226,24 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 📝 **Note**\n",
+    "> \n",
+    "> For all Nano optimized models by `InferenceOptimizer.quantize`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.htm) for more detailed usage of the context manager."
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> 📚 **Related Readings**\n",
     "> \n",
     "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)\n",
-    "> - [How to install BigDL-Nano in Google Colab](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Install/install_in_colab.html)"
+    "> - [How to enable automatic context management for PyTorch inference on Nano optimized models](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.html)"
    ]
   }
  ],

--- a/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_inc.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_inc.ipynb
@@ -232,7 +232,7 @@
    "source": [
     "> 📝 **Note**\n",
     "> \n",
-    "> For all Nano optimized models by `InferenceOptimizer.quantize`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.htm) for more detailed usage of the context manager."
+    "> For all Nano optimized models by `InferenceOptimizer.quantize`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.html) for more detailed usage of the context manager."
    ]
   },
   {

--- a/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_pot.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_pot.ipynb
@@ -213,7 +213,7 @@
    "source": [
     "> 📝 **Note**\n",
     "> \n",
-    "> For all Nano optimized models by `InferenceOptimizer.quantize`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.htm) for more detailed usage of the context manager."
+    "> For all Nano optimized models by `InferenceOptimizer.quantize`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.html) for more detailed usage of the context manager."
    ]
   },
   {

--- a/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_pot.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/quantize_pytorch_inference_pot.ipynb
@@ -8,26 +8,29 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Quantize PyTorch Model for Inference using OpenVINO Post-training Optimization Tools"
+    "# Quantize PyTorch Model in INT8 for Inference using OpenVINO Post-training Optimization Tools"
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As Post-training Optimization Tools (POT) is provided by OpenVINO toolkit, OpenVINO acceleration will be enabled in the meantime when using POT for quantization. You can call `InferenceOptimizer.quantize` API with `accelerator='openvino'` to use POT for your PyTorch `nn.Module`. It only takes a few lines."
+    "As Post-training Optimization Tools (POT) is provided by OpenVINO toolkit, OpenVINO acceleration will be enabled in the meantime when using POT for INT8 quantization. You can call `InferenceOptimizer.quantize` API with `accelerator='openvino'` (and `precision='int8'`) to use POT for your PyTorch `nn.Module`. It only takes a few lines."
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {
     "nbsphinx": "hidden"
    },
    "source": [
-    "To quantize your model with POT, the following dependencies need to be installed first:"
+    "To quantize your model with POT, you need to install BigDL-Nano for PyTorch inference first:"
    ]
   },
   {
@@ -51,17 +54,6 @@
     "> 📝 **Note**\n",
     "> \n",
     "> We recommend to run the commands above, especially `source bigdl-nano-init` before jupyter kernel is started, or some of the optimizations may not take effect."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "nbsphinx": "hidden"
-   },
-   "source": [
-    "> ⚠️ **Warning**\n",
-    ">\n",
-    "> Errors may occur when using `InferenceOptimizer.quantize(..., accelerator='openvino')` API in CentOS, becuase the latest version of `openvino-dev` is not supported in CentOS."
    ]
   },
   {
@@ -156,26 +148,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Then we set it in evaluation mode:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "model.eval()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "To enable quantization using POT for inference, you could simply **import BigDL-Nano** `InferenceOptimizer`**, and use** `InferenceOptimizer` **to quantize your PyTorch model**:"
+    "To enable INT8 quantization using POT for inference, you could simply **import BigDL-Nano** `InferenceOptimizer`**, and use** `InferenceOptimizer` **to quantize your PyTorch model** with `accelerator='openvino'`:"
    ]
   },
   {
@@ -192,12 +169,15 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> 📝 **Note**\n",
+    ">\n",
+    "> The `InferenceOptimizer.quantize` function has a `precision` parameter to specify the precision for quantization. It is default to be `'int8'`. So, we omit the `precision` parameter here for INT8 quantization.\n",
     "> \n",
-    "> For POT, only **static** post-training quantization is supported. So `calib_data` (for calibration data) is always required when `accelerator='openvino'`. \n",
+    "> For IN8 quantization using POT, only **static** post-training quantization is supported. So `calib_data` (for calibration data) is always required when `accelerator='openvino'`. \n",
     "> \n",
     "> For `calib_data`, batch size is not important as it intends to read 100 samples. And there could be no label in calibration data.\n",
     "> \n",
@@ -205,10 +185,11 @@
    ]
   },
   {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "You could then do the normal inference steps with the quantized model:"
+    "You could then do the normal inference steps **under the context manager provided by Nano**, with the quantized model:"
    ]
   },
   {
@@ -226,30 +207,41 @@
    ]
   },
   {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "> 📝 **Note**\n",
+    "> \n",
+    "> For all Nano optimized models by `InferenceOptimizer.quantize`, you need to wrap the inference steps with an automatic context manager `InferenceOptimizer.get_context(model=...)` provided by Nano. You could refer to [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.htm) for more detailed usage of the context manager."
+   ]
+  },
+  {
+   "attachments": {},
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "> 📚 **Related Readings**\n",
     "> \n",
     "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)\n",
-    "> - [How to install BigDL-Nano in Google Colab](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Install/install_in_colab.html)"
+    "> - [How to enable automatic context management for PyTorch inference on Nano optimized models](https://bigdl.readthedocs.io/en/latest/doc/Nano/Howto/Inference/PyTorch/pytorch_context_manager.html)"
    ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.7.12 ('nano')",
+   "display_name": "nano-pytorch",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "name": "python",
-   "version": "3.7.12"
+   "version": "3.7.15 (default, Nov 24 2022, 21:12:53) \n[GCC 11.2.0]"
   },
   "orig_nbformat": 4,
   "vscode": {
    "interpreter": {
-    "hash": "75c4387adfc215da0f2d9d02c27ad9a4df553a9f0187eec0365fe565a2e50216"
+    "hash": "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1"
    }
   }
  },


### PR DESCRIPTION
## Description

Revise out-of-date info in PyTorch Inference how-to guides

### 1. Summary of the change 

- Revise 12 PyTorch Inference how-to guides regarding:
  - usage of context manager
  - installation related clarification
  - removal of model.eval()
  - removal of "How to install BigDL-Nano in Google Colab" in the related readings as it is totally out of date
  - related readings
  - clarification of INT8 quantization in existed quantization how-to guides
- Change the index order of this 12 how-to guides

### 2. How to test?
- [x] Document test: https://yuwentestdocs.readthedocs.io/en/nano-pytorch-inference-howto-revision/doc/Nano/Howto/Inference/PyTorch/index.html