### PR TITLE
Nano: support CPU fp16 when accelerator is openvino

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -875,8 +875,6 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 invalidInputError(False,
                                   "Accelerator {} is invalid.".format(accelerator))
         if precision == 'fp16':
-            invalidInputError('GPU' in device or device == 'VPUX',
-                              "fp16 is not supported on {} device.".format(device))
             invalidInputError(accelerator == 'openvino',
                               "fp16 is not supported on {} accelerator.".format(accelerator))
             if device == 'VPUX':

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -555,8 +555,6 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             original_model = model
 
         if precision == 'fp16':
-            invalidInputError('GPU' in device or device == 'VPUX',
-                              "fp16 is not supported on {} device.".format(device))
             invalidInputError(accelerator == 'openvino',
                               "fp16 is not supported on {} accelerator.".format(accelerator))
             if device == 'VPUX':

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -25,6 +25,7 @@ from torch.utils.data.dataset import TensorDataset
 from torch.utils.data.dataloader import DataLoader
 import tempfile
 import pytest
+import numpy as np
 
 
 class TestOpenVINO(TestCase):
@@ -346,7 +347,7 @@ class TestOpenVINO(TestCase):
                                                     precision='fp16')
 
         with InferenceOptimizer.get_context(ov_fp16_model):
-            pred1 = ov_fp16_model(x).numpy()
+            preds1 = ov_fp16_model(x).numpy()
             ov_fp16_model(x2).numpy()  # test dinamic shape
         
         with tempfile.TemporaryDirectory() as tmp_dir_name:
@@ -354,6 +355,6 @@ class TestOpenVINO(TestCase):
             load_model = InferenceOptimizer.load(tmp_dir_name)
 
         with InferenceOptimizer.get_context(load_model):
-            pred2 = load_model(x).numpy()
+            preds2 = load_model(x).numpy()
 
         np.testing.assert_almost_equal(preds1, preds2, decimal=5)

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -241,23 +241,23 @@ class TestOpenVINO(TestCase):
         x2 = torch.rand((10, 3, 256, 256))
 
         # test GPU fp16
-        openvino_model = InferenceOptimizer.quanize(model,
-                                                    input_sample=x,
-                                                    accelerator='openvino',
-                                                    device='GPU',
-                                                    precision='fp16')
+        openvino_model = InferenceOptimizer.quantize(model,
+                                                     input_sample=x,
+                                                     accelerator='openvino',
+                                                     device='GPU',
+                                                     precision='fp16')
         result = openvino_model(x)
         # GPU don't support dynamic shape
         with pytest.raises(RuntimeError):
             openvino_model(x2)
 
         # test GPU int8
-        openvino_model = InferenceOptimizer.quanize(model,
-                                                    input_sample=x,
-                                                    accelerator='openvino',
-                                                    device='GPU',
-                                                    precision='int8',
-                                                    calib_data=x)
+        openvino_model = InferenceOptimizer.quantize(model,
+                                                     input_sample=x,
+                                                     accelerator='openvino',
+                                                     device='GPU',
+                                                     precision='int8',
+                                                     calib_data=x)
         result = openvino_model(x)
         # GPU don't support dynamic shape
         with pytest.raises(RuntimeError):
@@ -279,12 +279,12 @@ class TestOpenVINO(TestCase):
         x2 = torch.rand((10, 3, 256, 256))
 
         # test VPU int8
-        openvino_model = InferenceOptimizer.quanize(model,
-                                                    input_sample=x,
-                                                    accelerator='openvino',
-                                                    device='VPUX',
-                                                    precision='int8',
-                                                    calib_data=x)
+        openvino_model = InferenceOptimizer.quantize(model,
+                                                     input_sample=x,
+                                                     accelerator='openvino',
+                                                     device='VPUX',
+                                                     precision='int8',
+                                                     calib_data=x)
         result = openvino_model(x)
         # VPU don't support dynamic shape
         with pytest.raises(RuntimeError):
@@ -293,26 +293,26 @@ class TestOpenVINO(TestCase):
         # test VPU fp16
         model = resnet50()
         with pytest.raises(RuntimeError):
-            openvino_model = InferenceOptimizer.quanize(model,
-                                                        input_sample=x,
-                                                        accelerator='openvino',
-                                                        device='VPUX',
-                                                        precision='fp16')
+            openvino_model = InferenceOptimizer.quantize(model,
+                                                         input_sample=x,
+                                                         accelerator='openvino',
+                                                         device='VPUX',
+                                                         precision='fp16')
 
-        openvino_model = InferenceOptimizer.quanize(model,
-                                                    input_sample=x,
-                                                    accelerator='openvino',
-                                                    device='VPUX',
-                                                    precision='fp16',
-                                                    mean_value=[123.68,116.78,103.94])  # first type of mean value
+        openvino_model = InferenceOptimizer.quantize(model,
+                                                     input_sample=x,
+                                                     accelerator='openvino',
+                                                     device='VPUX',
+                                                     precision='fp16',
+                                                     mean_value=[123.68,116.78,103.94])  # first type of mean value
         result = openvino_model(x)
 
-        openvino_model = InferenceOptimizer.quanize(model,
-                                                    input_sample=x,
-                                                    accelerator='openvino',
-                                                    device='VPUX',
-                                                    precision='fp16',
-                                                    mean_value="x[123.68,116.78,103.94]") # the second type of mean value
+        openvino_model = InferenceOptimizer.quantize(model,
+                                                     input_sample=x,
+                                                     accelerator='openvino',
+                                                     device='VPUX',
+                                                     precision='fp16',
+                                                     mean_value="x[123.68,116.78,103.94]") # the second type of mean value
         result = openvino_model(x)
 
         # VPU don't support dynamic shape
@@ -333,3 +333,27 @@ class TestOpenVINO(TestCase):
                                                )
         with InferenceOptimizer.get_context(ov_model):
             result = ov_model(x)
+
+    def test_quantize_openvino_fp16(self):
+        model = mobilenet_v3_small(num_classes=10)
+
+        x = torch.rand((10, 3, 256, 256))
+        x2 = torch.rand((1, 3, 256, 256))
+
+        ov_fp16_model = InferenceOptimizer.quantize(model,
+                                                    accelerator='openvino',
+                                                    input_sample=x,
+                                                    precision='fp16')
+
+        with InferenceOptimizer.get_context(ov_fp16_model):
+            pred1 = ov_fp16_model(x).numpy()
+            ov_fp16_model(x2).numpy()  # test dinamic shape
+        
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(ov_fp16_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+
+        with InferenceOptimizer.get_context(load_model):
+            pred2 = load_model(x).numpy()
+
+        np.testing.assert_almost_equal(preds1, preds2, decimal=5)

--- a/python/nano/test/openvino/tf/test_openvino_quantize.py
+++ b/python/nano/test/openvino/tf/test_openvino_quantize.py
@@ -240,7 +240,7 @@ class TestOpenVINO(TestCase):
         # test original save / load
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(openvino_quantized_model, tmp_dir_name)
-            new_ov_model = InferenceOptimizer.load(tmp_dir_name)
+            new_ov_model = InferenceOptimizer.load(tmp_dir_name, model)
 
         preds1 = openvino_quantized_model(train_examples).numpy()
         preds2 = new_ov_model(train_examples).numpy()


### PR DESCRIPTION
## Description

support CPU fp16 when accelerator is openvino for PyTorch and Keras.

### 1. Why the change?

To support CPU fp16 when accelerator is openvino.

### 2. User API changes
Now precision `fp16` can be used when device is CPU.
```python
ov_fp16_model = InferenceOptimizer.quantize(model,
                                            accelerator='openvino',
                                            input_sample=x,
                                            precision='fp16')
```

### 3. Summary of the change 

- support CPU fp16
- add ut for this
- fix some wrong ut

### 4. How to test?
- [x] Unit test


