### PR TITLE
Nano: check affinity core number and omp thread number for both PT and TF

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/__init__.py
@@ -23,6 +23,7 @@ import torch
 import platform
 import warnings
 from bigdl.nano.utils.common import register_suggestion
+from bigdl.nano.utils.common import get_affinity_core_num
 
 
 if 'KMP_INIT_AT_FORK' in os.environ:
@@ -32,34 +33,11 @@ if 'KMP_INIT_AT_FORK' in os.environ:
 if platform.system() == "Linux":
     # only UNIX-like system applied
     preset_thread_nums = torch.get_num_threads()
-
-    # When using proclist to bind cores,
-    # `os.sched_getaffinity(0)` will return only the first bound core,
-    # so we need to parse KMP_AFFINITY manually in this case
-    KMP_AFFINITY = os.environ.get("KMP_AFFINITY", "")
-    if "proclist" not in KMP_AFFINITY:
-        affinity_core_num = len(os.sched_getaffinity(0))
-    else:
-        try:
-            start_pos = KMP_AFFINITY.find('[', KMP_AFFINITY.find("proclist")) + 1
-            end_pos = KMP_AFFINITY.find(']', start_pos)
-            proclist_str = KMP_AFFINITY[start_pos:end_pos].replace(" ", "")
-            core_list = []
-            for n in proclist_str.split(','):
-                if '-' not in n:
-                    core_list.append(int(n))
-                else:
-                    start, end = n.split('-')
-                    core_list.extend(range(int(start), int(end) + 1))
-            affinity_core_num = len(core_list)
-        except Exception as _e:
-            warnings.warn(f"Failed to parse KMP_AFFINITY: '{KMP_AFFINITY}'."
-                          f" Will use default thread number: {preset_thread_nums}")
-            affinity_core_num = preset_thread_nums
+    affinity_core_num = get_affinity_core_num()
 
     if preset_thread_nums > affinity_core_num:
         register_suggestion(f"CPU Affinity is set to this program and {affinity_core_num} "
-                            f"cores are binded. While OpenMP code block will use "
+                            f"cores are binded. While PyTorch OpenMP code block will use "
                             f"{preset_thread_nums} cores, which may cause severe performance "
                             f"downgrade. Please set `OMP_NUM_THREADS` to {affinity_core_num}.")
 

--- a/python/nano/src/bigdl/nano/tf/__init__.py
+++ b/python/nano/src/bigdl/nano/tf/__init__.py
@@ -16,6 +16,21 @@
 import platform
 import os
 import warnings
+from bigdl.nano.utils.common import register_suggestion
+from bigdl.nano.utils.common import get_affinity_core_num
+
+
+# reset the num of threads
+if platform.system() == "Linux":
+    # only UNIX-like system applied
+    preset_thread_nums = int(os.environ.get("OMP_NUM_THREADS", "0"))
+    affinity_core_num = get_affinity_core_num()
+
+    if preset_thread_nums > affinity_core_num:
+        register_suggestion(f"CPU Affinity is set to this program and {affinity_core_num} "
+                            f"cores are binded. While Tensorflow OpenMP code block will use "
+                            f"{preset_thread_nums} cores, which may cause severe performance "
+                            f"downgrade. Please set `OMP_NUM_THREADS` to {affinity_core_num}.")
 
 
 if platform.system() != "Darwin":

--- a/python/nano/src/bigdl/nano/utils/common/__init__.py
+++ b/python/nano/src/bigdl/nano/utils/common/__init__.py
@@ -43,6 +43,8 @@ from .inspect import get_default_args
 
 from .decorator import deprecated
 
+from .affinity_core import get_affinity_core_num
+
 from .env import _env_variable_is_set
 from .env import _find_library
 

--- a/python/nano/src/bigdl/nano/utils/common/affinity_core.py
+++ b/python/nano/src/bigdl/nano/utils/common/affinity_core.py
@@ -1,0 +1,44 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+
+
+def get_affinity_core_num():
+    # When using proclist to bind cores,
+    # `os.sched_getaffinity(0)` will return only the first bound core,
+    # so we need to parse KMP_AFFINITY manually in this case
+    KMP_AFFINITY = os.environ.get("KMP_AFFINITY", "")
+    if "proclist" not in KMP_AFFINITY:
+        affinity_core_num = len(os.sched_getaffinity(0))
+    else:
+        try:
+            start_pos = KMP_AFFINITY.find('[', KMP_AFFINITY.find("proclist")) + 1
+            end_pos = KMP_AFFINITY.find(']', start_pos)
+            proclist_str = KMP_AFFINITY[start_pos:end_pos].replace(" ", "")
+            core_list = []
+            for n in proclist_str.split(','):
+                if '-' not in n:
+                    core_list.append(int(n))
+                else:
+                    start, end = n.split('-')
+                    core_list.extend(range(int(start), int(end) + 1))
+            affinity_core_num = len(core_list)
+        except Exception as _e:
+            warnings.warn(f"Failed to parse KMP_AFFINITY: '{KMP_AFFINITY}'."
+                          f" Will use default thread number: {preset_thread_nums}")
+            affinity_core_num = preset_thread_nums
+    return affinity_core_num


### PR DESCRIPTION
## Description

### 1. Why the change?
Users will use nano's system variable setting, but use `taskset`, `numactl`, `KMP_AFFINITY` as well, a typical usage is
```bash
source bigdl-nano-init  # this will set OMP_NUM_THREADS to physical core number, e.g., 16
taskset -c 0-3 python test.py  # this will only use 4 cores
```
If openmp thread number is set larger than affinity core number, the program will be run really slow.

### 2. User API changes
nothing. A warning will be raised to users like below if openmp thread number is set larger than affinity core number
```bash
*****************Nano performance Suggestions*****************
CPU Affinity is set to this program and 2 cores are binded. While PyTorch OpenMP code block will use 3 cores, which may cause severe performance downgrade. Please set `OMP_NUM_THREADS` to 2.
CPU Affinity is set to this program and 2 cores are binded. While Tensorflow OpenMP code block will use 3 cores, which may cause severe performance downgrade. Please set `OMP_NUM_THREADS` to 2.

*****************Nano performance Suggestions*****************
```

### 3. Summary of the change 
Add the check to `__init__.py` of `bigdl.nano.tf` and `bigdl.nano.pytorch`.

### 4. How to test?
- [ ] Unit test
