### PR TITLE
Nano: support jit int8 quantization for pytorch

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -132,6 +132,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             "jit_bf16_ipex_channels_last": TorchAccelerationOption(jit=True, bf16=True,
                                                                    ipex=True,
                                                                    channels_last=True),
+            "jit_int8": TorchAccelerationOption(fx=True, jit=True),
+            "jit_int8_channels_last": TorchAccelerationOption(fx=True, jit=True,
+                                                              channels_last=True),
             "openvino_fp32": TorchAccelerationOption(openvino=True),
             "openvino_bf16": TorchAccelerationOption(openvino=True, bf16=True),
             "openvino_fp16": TorchAccelerationOption(openvino=True, fp16=True),
@@ -177,9 +180,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
 
         The available methods are "original", "fp32_channels_last", "fp32_ipex",
         "fp32_ipex_channels_last", "bf16", "bf16_channels_last", "bf16_ipex",
-        "bf16_ipex_channels_last", "static_int8", "static_int8_ipex", "jit_fp32", "jit_bf16",
+        "bf16_ipex_channels_last", "static_int8", "static_int8_ipex", "jit_fp32",
+        "jit_fp32_channels_last", "jit_bf16", "jit_bf16_channels_last",
         "jit_fp32_ipex", "jit_fp32_ipex_channels_last", "jit_bf16_ipex",
-        "jit_bf16_ipex_channels_last", "openvino_fp32", "openvino_int8", "onnxruntime_fp32",
+        "jit_bf16_ipex_channels_last", "jit_int8", "jit_int8_channels_last",
+        "openvino_fp32", "openvino_int8", "onnxruntime_fp32",
         "onnxruntime_int8_qlinear" and "onnxruntime_int8_integer".
 
         :param model: A torch.nn.Module to be optimized
@@ -224,7 +229,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
 
         :param input_sample: (optional) A set of inputs for trace, defaults to None.
                In most cases, you don't need specify this parameter, it will be obtained from
-               training_data. You have to specidy this parameter only if the forward function
+               training_data. You have to specify this parameter only if the forward function
                of your model contains some kwargs like `def forward(self, x1, x2, x3=1)`.
         :param metric: (optional) A callable object which is used for calculating accuracy.
                It supports two kinds of callable object:
@@ -237,7 +242,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                | 2. A callable object that takes model and validation_data (if
                | validation_data is not None) as input, and returns an accuracy value in
                | this calling method metric(model, data_loader) (or metric(model) if
-               | validation_data is None).
+               | validation_data is None). Note that there is no need to call `with
+               | torch.no_grad()` etc. in this object.
 
         :param direction: (optional) A string that indicates the higher/lower
                better for the metric, "min" for the lower the better and "max" for the
@@ -248,14 +254,14 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                accelerated model. In other words, the process of model conversion and optional
                accuracy calculation won't be restricted by this parameter. Defaults to None,
                represents that all cores will be used.
-        :param accelerator: (optional) A string tuple that specifys the accelerators to search.
+        :param accelerator: (optional) A string tuple that specifies the accelerators to search.
                The optional accelerators are: None, 'openvino', 'onnxruntime', 'jit'.
                Defaults to None which represents there is no restriction on accelerators.
-               If not None, then will only travese corresponding methods whose accelerator falls
+               If not None, then will only traverse corresponding methods whose accelerator falls
                within the specified accelerator tuple.
-        :param precision: (optional) A string tuple that specifys the precision to search.
+        :param precision: (optional) A string tuple that specifies the precision to search.
                The optional precision are: 'int8', 'bf16', and 'fp32'. Defaults to None which
-               represents no precision limit. If not None, then will only travese corresponding
+               represents no precision limit. If not None, then will only traverse corresponding
                methods whose precision falls within the specified precision tuple.
         :param use_ipex: (optional) if not None, then will only try methods with/without
                this specific ipex setting.
@@ -661,7 +667,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                            passed to ``torch.jit.trace``. if ``accelerator != 'jit'`` or
                            ``jit_method='script'``, it will be ignored. Default to True.
         :param jit_method: Whether to use ``jit.trace`` or ``jit.script`` to convert a model
-                           to TorchScript. Accepected values are ``'trace'``, ``'script'``,
+                           to TorchScript. Accepted values are ``'trace'``, ``'script'``,
                            and ``None``. Default to be ``None`` meaning the try-except logic
                            to use ``jit.trace`` or ``jit.script``. If ``accelerator != 'jit'``,
                            this parameter will be ignored.
@@ -708,13 +714,13 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                          preparation function will instantiate observers multiple times for each
                          of the layers.
                          This parameter only works for native ipex and jit quantization with int8
-                         precision. When accelerator is 'jit', we support and recommend
-                         to directly pass a QConfigMapping (https://pytorch.org/docs/
-                         stable/generated/torch.ao.quantization.qconfig_mapping.
-                         QConfigMapping.html#qconfigmapping). QConfigMapping is a collection of
-                         quantization configurations, user can set the qconfig for each operator
-                         (torch op calls, functional calls, module calls) in the model through
-                         qconfig_mapping.
+                         precision. When accelerator='jit', we support and recommend to pass a
+                         QConfigMapping instead of single Qconfig for customized quantization.
+                         QConfigMapping (https://pytorch.org/docs/stable/generated/torch.ao.
+                         quantization.qconfig_mapping.QConfigMapping.html#qconfigmapping) is a
+                         collection of quantization configurations, user can set the qconfig for
+                         each operator (torch op calls, functional calls, module calls) in the
+                         model through qconfig_mapping.
         :param output_tensors: boolean, default to True and output of the model will be Tensors,
                                only valid when accelerator='onnxruntime' or accelerator='openvino',
                                otherwise will be ignored. If output_tensors=False, output of the
@@ -738,7 +744,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                          Can be defined for desired input of the model, for example:
                          "--mean_values data[255,255,255],info[255,255,255]". The exact meaning
                          and order of channels depend on how the original model was trained.
-        :return:            A accelerated torch.nn.Module if quantization is sucessful.
+        :return:            A accelerated torch.nn.Module if quantization is successful.
         """
         invalidInputError(precision in ['int8', 'fp16', 'bf16'],
                           "Only support 'int8', 'bf16', 'fp16' now, "

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -744,6 +744,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             invalidInputError(False,
                               "Now we only support {} device when accelerator"
                               "is openvino.".format(device))
+        model.eval()  # change model to eval mode
         if precision == 'bf16':
             if accelerator is None or accelerator == "jit":
                 if use_ipex or accelerator == "jit":
@@ -1089,6 +1090,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             invalidInputError(False,
                               "Now we only support {} device when accelerator "
                               "is openvino.".format(device))
+        model.eval()  # change model to eval mode
         if accelerator == 'openvino':  # openvino backend will not care about ipex usage
             final_openvino_option = {"INFERENCE_PRECISION_HINT": "f32"}
             if openvino_config is not None:

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -576,9 +576,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                 torch.nn.Module.
         :param precision:       Global precision of quantized model,
                                 supported type: 'int8', 'bf16', 'fp16', defaults to 'int8'.
-        :param accelerator:     Use accelerator 'None', 'onnxruntime', 'openvino', defaults to None.
-                                None means staying in pytorch.
-        :param use_ipex:        Whether we use ipex as accelerator for inferencing.
+        :param accelerator:     Use accelerator 'None', 'onnxruntime', 'openvino', 'jit', defaults
+                                to None. None means staying in pytorch.
+        :param use_ipex:        Whether we use ipex as accelerator for inference.
                                 If precision != bf16, it will be ignored. Default: ``False``.
         :param calib_data:      Calibration data is required for static quantization.
                                 It's also used as validation dataloader.
@@ -586,8 +586,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
 
                                 | 1. a torch.utils.data.dataloader.DataLoader object for training.
                                 |
-                                | 2. a single torch.Tensor which used for training, this case is
-                                | used to accept single sample input x.
+                                | 2. a single torch.Tensor used for training, this case is used
+                                | to accept single sample input x.
                                 |
                                 | 3. a tuple of torch.Tensor which used for training, this case is
                                 | used to accept single sample input (x, y) or (x1, x2) et al.
@@ -699,16 +699,22 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                               be ignored. For more details, please refer https://github.com/
                               pytorch/pytorch/tree/master/torch/csrc/jit/codegen/
                               onednn#pytorch---onednn-graph-api-bridge.
-        :param q_config: describes how to quantize a layer or a part of the network
-                         by providing settings (observer classes) for activations and weights
-                         respectively. Note that QConfig needs to contain observer classes
-                         (like MinMaxObserver) or a callable that returns instances on
-                         invocation, not the concrete observer instances themselves.
-                         Quantization preparation function will instantiate observers multiple
-                         times for each of the layers. For more details, please refer
-                         https://pytorch.org/docs/1.13/generated/torch.quantization.qconfig.
-                         QConfig.html#torch.quantization.qconfig.QConfig .
-                         This parameter only works for native ipex quantization.
+        :param q_config: Qconfig (https://pytorch.org/docs/stable/generated/torch.quantization.
+                         qconfig.QConfig.html#qconfig) describes how to quantize a layer or a part
+                         of the network by providing settings (observer classes) for activations
+                         and weights respectively. Note that QConfig needs to contain observer
+                         classes (like MinMaxObserver) or a callable that returns instances on
+                         invocation, not the concrete observer instances themselves. Quantization
+                         preparation function will instantiate observers multiple times for each
+                         of the layers.
+                         This parameter only works for native ipex and jit quantization with int8
+                         precision. When accelerator is 'jit', we support and recommend
+                         to directly pass a QConfigMapping (https://pytorch.org/docs/
+                         stable/generated/torch.ao.quantization.qconfig_mapping.
+                         QConfigMapping.html#qconfigmapping). QConfigMapping is a collection of
+                         quantization configurations, user can set the qconfig for each operator
+                         (torch op calls, functional calls, module calls) in the model through
+                         qconfig_mapping.
         :param output_tensors: boolean, default to True and output of the model will be Tensors,
                                only valid when accelerator='onnxruntime' or accelerator='openvino',
                                otherwise will be ignored. If output_tensors=False, output of the

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -939,7 +939,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                            channels_last=channels_last,
                                            thread_num=thread_num,
                                            jit_strict=jit_strict,
-                                           jit_method=jit_method)
+                                           jit_method=jit_method,
+                                           enable_onednn=enable_onednn)
             else:
                 invalidInputError(False,
                                   "Accelerator {} is invalid.".format(accelerator))

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -243,7 +243,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                | validation_data is not None) as input, and returns an accuracy value in
                | this calling method metric(model, data_loader) (or metric(model) if
                | validation_data is None). Note that there is no need to call `with
-               | torch.no_grad()` etc. in this object.
+               | InferenceOptimizer.get_context()` in this object.
 
         :param direction: (optional) A string that indicates the higher/lower
                better for the metric, "min" for the lower the better and "max" for the
@@ -714,8 +714,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                          preparation function will instantiate observers multiple times for each
                          of the layers.
                          This parameter only works for native ipex and jit quantization with int8
-                         precision. When accelerator='jit', we support and recommend to pass a
-                         QConfigMapping instead of single Qconfig for customized quantization.
+                         precision. When accelerator='jit', we also support and recommend to pass
+                         a QConfigMapping instead of single Qconfig for customized quantization.
                          QConfigMapping (https://pytorch.org/docs/stable/generated/torch.ao.
                          quantization.qconfig_mapping.QConfigMapping.html#qconfigmapping) is a
                          collection of quantization configurations, user can set the qconfig for

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -26,6 +26,7 @@ from bigdl.nano.utils.common import AccelerationOption, available_acceleration_c
     latency_calculate_helper, format_optimize_result, BaseInferenceOptimizer
 from bigdl.nano.utils.common import invalidInputError
 from bigdl.nano.pytorch.amp import BF16Model
+from bigdl.nano.pytorch.low_precision.jit_int8_api import PytorchJITINT8Model
 from bigdl.nano.deps.openvino.openvino_api import PytorchOpenVINOModel
 from bigdl.nano.deps.ipex.ipex_api import PytorchIPEXJITModel, PytorchIPEXJITBF16Model,\
     PytorchIPEXQuantizationModel
@@ -928,6 +929,17 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 }
                 return model.pot(calib_dataloader, thread_num=thread_num,
                                  config=openvino_config, **kwargs)
+            elif accelerator == 'jit':
+                invalidInputError(jit_method in [None, 'trace', 'script'],
+                                  "jit_method {} is invalid.".format(jit_method))
+                return PytorchJITINT8Model(model,
+                                           calib_dataloader,
+                                           q_config=q_config,
+                                           input_sample=input_sample,
+                                           channels_last=channels_last,
+                                           thread_num=thread_num,
+                                           jit_strict=jit_strict,
+                                           jit_method=jit_method)
             else:
                 invalidInputError(False,
                                   "Accelerator {} is invalid.".format(accelerator))

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_api.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_api.py
@@ -16,9 +16,9 @@
 
 
 def PytorchJITINT8Model(model, calib_data, q_config=None,
-                        input_sample=None, channels_last=None,
+                        input_sample=None, channels_last=False,
                         thread_num=None, jit_strict=True,
-                        jit_method=None, enable_onednn=True):
+                        jit_method=None, enable_onednn=False):
     from .jit_int8_model import PytorchJITINT8Model
     return PytorchJITINT8Model(model, calib_data, q_config=q_config,
                                input_sample=input_sample, channels_last=channels_last,

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_api.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_api.py
@@ -19,6 +19,32 @@ def PytorchJITINT8Model(model, calib_data, q_config=None,
                         input_sample=None, channels_last=False,
                         thread_num=None, jit_strict=True,
                         jit_method=None, enable_onednn=False):
+    '''
+    :param model: the model(nn.module) to be transform if from_load is False
+           the accelerated model if from_load is True.
+    :param calib_data: calibration data is required for static quantization.
+    :param q_config: We support 2 types of input here:
+           Qconfig (https://pytorch.org/docs/stable/generated/torch.quantization.
+           qconfig.QConfig.html#qconfig) is the configuration for how we insert
+           observers for a particular operator. Quantization preparation function
+           will instantiate observers multiple times for each of the layers.
+           QConfigMapping (https://pytorch.org/docs/stable/generated/torch.ao.
+           quantization.qconfig_mapping.QConfigMapping.html#qconfigmapping)
+           (recommended) is a collection of quantization configurations, user
+           can set the qconfig for each operator (torch op calls, functional
+           calls, module calls) in the model through qconfig_mapping.
+    :param input_sample: torch tensor indicate the data sample to be used
+           for tracing.
+    :param channels_last: if set model and data to be channels-last mode.
+    :param thread_num: the thread num allocated for this model.
+    :param from_load: this will only be set by _load method.
+    :param jit_strict: Whether recording your mutable container types.
+    :param jit_method: use ``jit.trace`` or ``jit.script`` to convert a model
+           to TorchScript.
+    :param enable_onednn: Whether to use PyTorch JIT graph fuser based on
+           oneDNN Graph API, which provides a flexible API for aggressive
+           fusion. Default to ``False``.
+    '''
     from .jit_int8_model import PytorchJITINT8Model
     return PytorchJITINT8Model(model, calib_data, q_config=q_config,
                                input_sample=input_sample, channels_last=channels_last,

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_api.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_api.py
@@ -25,6 +25,6 @@ def PytorchJITINT8Model(model, calib_data, q_config=None,
                                thread_num=thread_num, jit_strict=jit_strict,
                                jit_method=jit_method)
 
-def load_pytorchjitint8_model(path, model):
+def load_pytorchjitint8_model(path):
     from .jit_int8_model import PytorchJITINT8Model
-    return PytorchJITINT8Model._load(path, model)
+    return PytorchJITINT8Model._load(path)

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_api.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_api.py
@@ -24,15 +24,18 @@ def PytorchJITINT8Model(model, calib_data, q_config=None,
            the accelerated model if from_load is True.
     :param calib_data: calibration data is required for static quantization.
     :param q_config: We support 2 types of input here:
-           Qconfig (https://pytorch.org/docs/stable/generated/torch.quantization.
-           qconfig.QConfig.html#qconfig) is the configuration for how we insert
-           observers for a particular operator. Quantization preparation function
-           will instantiate observers multiple times for each of the layers.
-           QConfigMapping (https://pytorch.org/docs/stable/generated/torch.ao.
-           quantization.qconfig_mapping.QConfigMapping.html#qconfigmapping)
-           (recommended) is a collection of quantization configurations, user
-           can set the qconfig for each operator (torch op calls, functional
-           calls, module calls) in the model through qconfig_mapping.
+
+           | 1. Qconfig (https://pytorch.org/docs/stable/generated/torch.quantization.
+           | qconfig.QConfig.html#qconfig) is the configuration for how we insert
+           | observers for a particular operator. Quantization preparation function
+           | will instantiate observers multiple times for each of the layers.
+           |
+           | 2. QConfigMapping (https://pytorch.org/docs/stable/generated/torch.ao.
+           | quantization.qconfig_mapping.QConfigMapping.html#qconfigmapping)
+           | (recommended) is a collection of quantization configurations, user
+           | can set the qconfig for each operator (torch op calls, functional
+           | calls, module calls) in the model through qconfig_mapping.
+
     :param input_sample: torch tensor indicate the data sample to be used
            for tracing.
     :param channels_last: if set model and data to be channels-last mode.

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_api.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_api.py
@@ -18,12 +18,12 @@
 def PytorchJITINT8Model(model, calib_data, q_config=None,
                         input_sample=None, channels_last=None,
                         thread_num=None, jit_strict=True,
-                        jit_method=None):
+                        jit_method=None, enable_onednn=True):
     from .jit_int8_model import PytorchJITINT8Model
     return PytorchJITINT8Model(model, calib_data, q_config=q_config,
                                input_sample=input_sample, channels_last=channels_last,
                                thread_num=thread_num, jit_strict=jit_strict,
-                               jit_method=jit_method)
+                               jit_method=jit_method, enable_onednn=enable_onednn)
 
 def load_pytorchjitint8_model(path):
     from .jit_int8_model import PytorchJITINT8Model

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_api.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_api.py
@@ -1,0 +1,30 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+def PytorchJITINT8Model(model, calib_data, q_config=None,
+                        input_sample=None, channels_last=None,
+                        thread_num=None, jit_strict=True,
+                        jit_method=None):
+    from .jit_int8_model import PytorchJITINT8Model
+    return PytorchJITINT8Model(model, calib_data, q_config=q_config,
+                               input_sample=input_sample, channels_last=channels_last,
+                               thread_num=thread_num, jit_strict=jit_strict,
+                               jit_method=jit_method)
+
+def load_pytorchjitint8_model(path, model):
+    from .jit_int8_model import PytorchJITINT8Model
+    return PytorchJITINT8Model._load(path, model)

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_api.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_api.py
@@ -54,6 +54,7 @@ def PytorchJITINT8Model(model, calib_data, q_config=None,
                                thread_num=thread_num, jit_strict=jit_strict,
                                jit_method=jit_method, enable_onednn=enable_onednn)
 
+
 def load_pytorchjitint8_model(path):
     from .jit_int8_model import PytorchJITINT8Model
     return PytorchJITINT8Model._load(path)

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
@@ -1,0 +1,140 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from bigdl.nano.utils.inference.pytorch.model import AcceleratedLightningModule
+from bigdl.nano.pytorch.context_manager import generate_context_manager
+
+import torch
+import torch.ao.quantization
+from torch.quantization.quantize_fx import prepare_fx, convert_fx
+
+from collections.abc import Sequence
+
+
+class PytorchJITINT8Model(AcceleratedLightningModule):
+    def __init__(self, model: torch.nn.Module, calib_data, q_config=None,
+                 input_sample=None, channels_last=None, thread_num=None,
+                 from_load=False, jit_strict=True, jit_method=None):
+        super().__init__(model)
+        if from_load:
+            self.jit_strict = jit_strict
+            self.jit_method = jit_method
+            self._nano_context_manager = generate_context_manager(accelerator="jit",
+                                                                  precision="int8",
+                                                                  thread_num=thread_num)
+            return
+        
+        self.original_state_dict = model.state_dict()
+        self.jit_strict = jit_strict
+        self.jit_method = jit_method
+        self._nano_context_manager = generate_context_manager(accelerator="jit",
+                                                              precision="int8",
+                                                              thread_num=thread_num)
+        self.thread_num = thread_num
+        self.original_model = model
+
+        if q_config is None:
+            self.q_config = torch.ao.quantization.default_qconfig
+        else:
+            self.q_config = q_config
+        
+        if input_sample is None:
+            input_sample = next(iter(calib_data))
+            if isinstance(input_sample, (tuple, list)) and len(input_sample) > 1:
+                input_sample = input_sample[0]
+
+        self.model = prepare_fx(self.model, {'' : self.q_config},
+                                example_inputs=input_sample)
+
+        for x in calib_data:
+            if isinstance(x, (tuple, list)) and len(x) > 1:
+                x = x[0]
+            if isinstance(x, Sequence):
+                self.model(*x)
+            else:
+                self.model(x)
+
+        self.model = convert_fx(self.model)
+
+        with torch.no_grad():
+            if self.jit_method == 'trace':
+                self.model = torch.jit.trace(self.model, input_sample,
+                                             strict=jit_strict)
+            elif self.jit_method == 'script':
+                self.model = torch.jit.script(self.model)
+            else:
+                try:
+                    self.model = torch.jit.trace(self.model, input_sample,
+                                                 strict=jit_strict)
+                except Exception:
+                    self.model = torch.jit.script(self.model)
+            self.model = torch.jit.freeze(self.model)
+            
+    @property
+    def forward_args(self):
+        return [input_value.debugName() for input_value in self.model.graph.inputs()
+                if not input_value.debugName().startswith('self')]
+
+    def on_forward_start(self, inputs):
+        return inputs
+
+    def forward_step(self, *inputs):
+        return self.model(*inputs)
+
+    def on_forward_end(self, outputs):
+        return outputs
+
+    def __getattr__(self, name: str):
+        # the search order is:
+        # 1. current instance, like channels_last will be found at this place
+        # 2. super class, like model will be found at this place
+        # 3. original model, like additional attributes of original model
+        #    will be found at this place
+        try:
+            return super().__getattr__(name)
+        except AttributeError:
+            return getattr(self.original_model, name)
+
+    @property
+    def status(self):
+        status = super().status
+        status.update({"checkpoint": "ckpt.pth",
+                       "thread_num": self.thread_num,
+                       "jit_strict": self.jit_strict,
+                       'jit_method': self.jit_method})
+        return status
+
+    @staticmethod
+    def _load(path, model):
+        status = PytorchJITINT8Model._load_status(path)
+        checkpoint_path = path / status['checkpoint']
+        model = torch.jit.load(checkpoint_path)
+        model.eval()
+        model = torch.jit.freeze(model)
+        from_load = True
+        thread_num = None
+        if status["thread_num"] is not None and status['thread_num'] != {}:
+            thread_num = int(status['thread_num'])
+        return PytorchJITINT8Model(model,
+                              calib_data=None,
+                              from_load=from_load,
+                              thread_num=thread_num,
+                              jit_strict=status["jit_strict"],
+                              jit_method=status["jit_method"])
+
+    def _save_model(self, path):
+        self.model.save(path / "ckpt.pth")

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
@@ -38,16 +38,19 @@ class PytorchJITINT8Model(AcceleratedLightningModule):
         :param model: the model(nn.module) to be transform if from_load is False
                the accelerated model if from_load is True.
         :param calib_data: calibration data is required for static quantization.
-        :param q_config: We support 2 types of input here:
-               Qconfig (https://pytorch.org/docs/stable/generated/torch.quantization.
-               qconfig.QConfig.html#qconfig) is the configuration for how we insert
-               observers for a particular operator. Quantization preparation function
-               will instantiate observers multiple times for each of the layers.
-               QConfigMapping (https://pytorch.org/docs/stable/generated/torch.ao.
-               quantization.qconfig_mapping.QConfigMapping.html#qconfigmapping)
-               (recommended) is a collection of quantization configurations, user
-               can set the qconfig for each operator (torch op calls, functional
-               calls, module calls) in the model through qconfig_mapping.
+        :param q_config: We support 2 types of customized quantization config:
+
+               | 1. Qconfig (https://pytorch.org/docs/stable/generated/torch.quantization.
+               | qconfig.QConfig.html#qconfig) is the configuration for how we insert
+               | observers for a particular operator. Quantization preparation function
+               | will instantiate observers multiple times for each of the layers.
+               |
+               | 2. QConfigMapping (https://pytorch.org/docs/stable/generated/torch.ao.
+               | quantization.qconfig_mapping.QConfigMapping.html#qconfigmapping)
+               | (recommended) is a collection of quantization configurations, user
+               | can set the qconfig for each operator (torch op calls, functional
+               | calls, module calls) in the model through qconfig_mapping.
+               
         :param input_sample: torch tensor indicate the data sample to be used
                for tracing.
         :param channels_last: if set model and data to be channels-last mode.

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
@@ -66,7 +66,7 @@ class PytorchJITINT8Model(AcceleratedLightningModule):
         super().__init__(model)
         
         enable_onednn=False
-        # todo: since onednn cooperates well with other nano methods, it is set to True
+        # TODO: since onednn cooperates well with other nano methods, it is set to True
         # by default in InferenceOptimizer.quantize(). However, it will lead to strange
         # error in fx quantization during inference. Therefore, we disable it by hand.
 

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
@@ -50,7 +50,7 @@ class PytorchJITINT8Model(AcceleratedLightningModule):
                | (recommended) is a collection of quantization configurations, user
                | can set the qconfig for each operator (torch op calls, functional
                | calls, module calls) in the model through qconfig_mapping.
-               
+
         :param input_sample: torch tensor indicate the data sample to be used
                for tracing.
         :param channels_last: if set model and data to be channels-last mode.
@@ -64,8 +64,8 @@ class PytorchJITINT8Model(AcceleratedLightningModule):
                fusion. Default to ``False``.
         '''
         super().__init__(model)
-        
-        enable_onednn=False
+
+        enable_onednn = False
         # TODO: since onednn cooperates well with other nano methods, it is set to True
         # by default in InferenceOptimizer.quantize(). However, it will lead to strange
         # error in fx quantization during inference. Therefore, we disable it by hand.
@@ -89,7 +89,7 @@ class PytorchJITINT8Model(AcceleratedLightningModule):
                                                                   thread_num=thread_num,
                                                                   enable_onednn=enable_onednn)
             return
-        
+
         self.original_state_dict = model.state_dict()
         self.channels_last = channels_last
         self.jit_strict = jit_strict
@@ -108,10 +108,10 @@ class PytorchJITINT8Model(AcceleratedLightningModule):
             self.q_config = get_default_qconfig_mapping("fbgemm")
         else:
             if isinstance(q_config, QConfig):
-                self.q_config = {'' : q_config}
+                self.q_config = {'': q_config}
             else:
                 self.q_config = q_config
-        
+
         if input_sample is None:
             input_sample = next(iter(calib_data))
             if isinstance(input_sample, (tuple, list)) and len(input_sample) > 1:

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
@@ -71,9 +71,13 @@ class PytorchJITINT8Model(AcceleratedLightningModule):
         # error in fx quantization during inference. Therefore, we disable it by hand.
         # Actually, prepare_fx supports the onednn backend, related design is in here:
         # https://github.com/pytorch/pytorch/pull/69820
+        #
         # To use it, we can use below statement to replace the fbgemm(default) backend
         # in line 104.
         # qconfig_mapping = get_default_qconfig_mapping("onednn")
+        #
+        # A simple test of performance is shown in
+        # https://github.com/intel-analytics/BigDL/pull/7483
 
         if from_load:
             self.channels_last = channels_last

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
@@ -151,11 +151,6 @@ class PytorchJITINT8Model(AcceleratedLightningModule):
                 except Exception:
                     self.model = torch.jit.script(self.model)
             self.model = torch.jit.freeze(self.model)
-            
-    @property
-    def forward_args(self):
-        return [input_value.debugName() for input_value in self.model.graph.inputs()
-                if not input_value.debugName().startswith('self')]
 
     def on_forward_start(self, inputs):
         return inputs

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
@@ -69,6 +69,11 @@ class PytorchJITINT8Model(AcceleratedLightningModule):
         # TODO: since onednn cooperates well with other nano methods, it is set to True
         # by default in InferenceOptimizer.quantize(). However, it will lead to strange
         # error in fx quantization during inference. Therefore, we disable it by hand.
+        # Actually, prepare_fx supports the onednn backend, related design is in here:
+        # https://github.com/pytorch/pytorch/pull/69820
+        # To use it, we can use below statement to replace the fbgemm(default) backend
+        # in line 104.
+        # qconfig_mapping = get_default_qconfig_mapping("onednn")
 
         if from_load:
             self.channels_last = channels_last
@@ -117,6 +122,8 @@ class PytorchJITINT8Model(AcceleratedLightningModule):
         self.model = prepare_fx(self.model, self.q_config,
                                 example_inputs=(input_sample,))
 
+        # TODO: multiple input data not supported during calibration
+        # the same as ipex_quantization model
         for x in calib_data:
             if isinstance(x, (tuple, list)) and len(x) > 1:
                 x = x[0]

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
@@ -127,7 +127,7 @@ class PytorchJITINT8Model(AcceleratedLightningModule):
                                 example_inputs=(input_sample,))
 
         # TODO: multiple input data not supported during calibration
-        # the same as ipex_quantization model
+        # the same problem as ipex_quantization model
         for x in calib_data:
             if isinstance(x, (tuple, list)) and len(x) > 1:
                 x = x[0]

--- a/python/nano/src/bigdl/nano/utils/common/optimizer/acceleration_option.py
+++ b/python/nano/src/bigdl/nano/utils/common/optimizer/acceleration_option.py
@@ -23,7 +23,7 @@ from bigdl.nano.utils.common import _inc_checker, _ipex_checker,\
 
 
 _whole_acceleration_options = ["inc", "ipex", "onnxruntime", "openvino", "pot",
-                               "bf16", "fp16", "jit", "channels_last"]
+                               "bf16", "fp16", "jit", "fx", "channels_last"]
 
 
 class AccelerationOption(object):
@@ -38,7 +38,7 @@ class AccelerationOption(object):
         self.method = kwargs.get("method", None)
 
     def get_precision(self):
-        if self.inc or self.pot:
+        if self.inc or self.pot or self.fx:
             return "int8"
         if self.bf16:
             return "bf16"
@@ -65,7 +65,7 @@ def available_acceleration_combination(excludes: Optional[List[str]],
                                        full_methods: Dict[str, AccelerationOption],
                                        all_methods: Dict[str, AccelerationOption] = None):
     '''
-    :return: a dictionary states the availablity (if meet depdencies)
+    :return: a dictionary states the availability (if meet dependencies)
     '''
     dependency_checker = {"inc": _inc_checker,
                           "ipex": _ipex_checker,

--- a/python/nano/src/bigdl/nano/utils/common/optimizer/format.py
+++ b/python/nano/src/bigdl/nano/utils/common/optimizer/format.py
@@ -31,7 +31,7 @@ def format_acceleration_option(method_name: str,
     repr_str = ""
     for key, value in option.__dict__.items():
         if value is True:
-            if key == "pot":
+            if key == "pot" or key == "fx":
                 repr_str = repr_str + "int8" + " + "
             else:
                 repr_str = repr_str + key + " + "

--- a/python/nano/src/bigdl/nano/utils/common/optimizer/format.py
+++ b/python/nano/src/bigdl/nano/utils/common/optimizer/format.py
@@ -25,7 +25,7 @@ from .acceleration_option import AccelerationOption
 def format_acceleration_option(method_name: str,
                                full_methods: Dict[str, AccelerationOption]) -> str:
     '''
-    Get a string represation for current method's acceleration option
+    Get a string representation for current method's acceleration option
     '''
     option = full_methods[method_name]
     repr_str = ""
@@ -49,7 +49,7 @@ def format_acceleration_option(method_name: str,
 def format_optimize_result(optimize_result_dict: dict,
                            calculate_accuracy: bool) -> str:
     '''
-    Get a format string represation for optimization result
+    Get a format string representation for optimization result
     '''
     if calculate_accuracy is True:
         horizontal_line = " {0} {1} {2} {3}\n" \

--- a/python/nano/src/bigdl/nano/utils/common/optimizer/optimizer.py
+++ b/python/nano/src/bigdl/nano/utils/common/optimizer/optimizer.py
@@ -56,10 +56,14 @@ class BaseInferenceOptimizer:
         """
         According to results of `optimize`, obtain the model with method_name.
 
-        The available methods are "original", "fp32_ipex", "bf16", "bf16_ipex","int8",
-        "jit_fp32", "jit_fp32_ipex", "jit_fp32_ipex_channels_last", "openvino_fp32",
-        "openvino_int8", "onnxruntime_fp32", "onnxruntime_int8_qlinear"
-        and "onnxruntime_int8_integer".
+        The available methods are "original", "fp32_channels_last", "fp32_ipex",
+        "fp32_ipex_channels_last", "bf16", "bf16_channels_last", "bf16_ipex",
+        "bf16_ipex_channels_last", "static_int8", "static_int8_ipex", "jit_fp32",
+        "jit_fp32_channels_last", "jit_bf16", "jit_bf16_channels_last",
+        "jit_fp32_ipex", "jit_fp32_ipex_channels_last", "jit_bf16_ipex",
+        "jit_bf16_ipex_channels_last", "jit_int8", "jit_int8_channels_last",
+        "openvino_fp32", "openvino_int8", "onnxruntime_fp32",
+        "onnxruntime_int8_qlinear" and "onnxruntime_int8_integer".
 
         :param method_name: (optional) Obtain specific model according to method_name.
         :return: Model with different acceleration.

--- a/python/nano/src/bigdl/nano/utils/common/optimizer/optimizer.py
+++ b/python/nano/src/bigdl/nano/utils/common/optimizer/optimizer.py
@@ -127,7 +127,7 @@ class BaseInferenceOptimizer:
             if precision is not None:
                 if precision == 'bf16' and not option.bf16:
                     continue
-                if precision == 'int8' and not (option.inc or option.pot):
+                if precision == 'int8' and not (option.inc or option.pot or option.fx):
                     continue
                 if precision == 'fp32' and option.get_precision() != 'fp32':
                     continue

--- a/python/nano/src/bigdl/nano/utils/pytorch/load.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/load.py
@@ -49,6 +49,7 @@ def load_model(path, model: nn.Module = None, input_sample=None,
                 precision(FP32/FP16/BF16/INT8).
     """
     from bigdl.nano.pytorch.amp.amp_api import load_bf16_model
+    from bigdl.nano.pytorch.low_precision.jit_int8_api import load_pytorchjitint8_model
     from bigdl.nano.pytorch.context_manager import generate_context_manager
     from bigdl.nano.deps.openvino.openvino_api import load_openvino_model
     from bigdl.nano.deps.ipex.ipex_api import load_ipexjit_model, load_ipexjitbf16_model,\
@@ -82,6 +83,8 @@ def load_model(path, model: nn.Module = None, input_sample=None,
         result = load_ipex_quantization_model(path, model, inplace=inplace)
     if model_type == 'BF16Model':
         return load_bf16_model(path, model)
+    if model_type == 'PytorchJITINT8Model':
+        return load_pytorchjitint8_model(path)
     if result is not None:
         if isinstance(model, torch.nn.Module):
             # patch attributes to accelerated model

--- a/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
@@ -563,7 +563,7 @@ class TestInferencePipeline(TestCase):
                                thread_num=4,
                                precision=('bf16', 'int8'))
         optim_dict = inference_opt.optimized_model_dict
-        assert len(optim_dict) == 15
+        assert len(optim_dict) == 17
         with pytest.raises(RuntimeError):
             acc_model, option = inference_opt.get_best_model(precision="fp32")
 

--- a/python/nano/test/run-nano-codestyle-test.sh
+++ b/python/nano/test/run-nano-codestyle-test.sh
@@ -8,6 +8,6 @@ export NANO_TEST_DIR=${ANALYTICS_ZOO_ROOT}/python/nano/test
 
 pycodestyle ${NANO_HOME} --config=${NANO_TEST_DIR}/tox.ini
 pydocstyle --ignore D104,D100,D212,D203,D401,D402,D105 \
-           --match-dir '(?!common|deps|utils|runtime_binding|transforms|amp|inference|patching).*' \
+           --match-dir '(?!common|deps|utils|runtime_binding|transforms|amp|inference|patching|low_precision).*' \
            --match '(?!context_manager|model|_).*\.py' \
            ${NANO_HOME}/bigdl/nano/


### PR DESCRIPTION
## Description

Add `jit + int8` option to `InferenceOptimizer.quantize()`, which applies __FX Graph Mode Quantization__ and __JIT__ provided by pytorch.

### 1. Why the change?

Previously, Nano's int8 quantization supports accelerators like `onnxruntime` and `openvino`, or pure `ipex` / `inc` quantization. Since `TorchScript` is also a great accelerator to serialize and optimize pytorch models, we provide this approach to Nano users.

### 2. User API changes

New option in `InferenceOptimizer.quantize()` for pytorch:
```
int8_model = InferenceOptimizer.quantize(original_model, precision='int8', accelerator='jit',
                                         calib_data, q_config, input_sample, channels_last,
                                         thread_num, jit_strict, jit_method, enable_onednn)
```

### 3. Summary of the change 

original_model -> fx quantization (prepare, calibrate, convert) -> jit trace / script & freeze

### 4. How to test?

- [ ] Unit test

### Bug to be investigated
Note that enabling ONEDNN together with fx quantization leads to error on ResNet18 model, so we may disable it by default when using jit + int8.
