### PR TITLE
Orca: Fix conflicts about use_tqdm and TqdmCallback

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tqdm.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tqdm.py
@@ -33,6 +33,7 @@ def is_tqdm_exited(callbacks):
             return True
     return False
 
+
 class TqdmCallback(Callback):
 
     def __init__(self):

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tqdm.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tqdm.py
@@ -27,7 +27,7 @@ except ImportError:
     pass
 
 
-def is_tqdm_exited(callbacks):
+def is_tqdm_exists(callbacks):
     for callback in callbacks:
         if isinstance(callback, TqdmCallback):
             return True

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tqdm.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tqdm.py
@@ -26,6 +26,12 @@ try:
 except ImportError:
     pass
 
+def is_tqdm_exited(callbacks):
+    for callback in callbacks:
+        if isinstance(callback, TqdmCallback):
+            return True
+    return False
+
 
 class TqdmCallback(Callback):
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tqdm.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tqdm.py
@@ -26,12 +26,12 @@ try:
 except ImportError:
     pass
 
+
 def is_tqdm_exited(callbacks):
     for callback in callbacks:
         if isinstance(callback, TqdmCallback):
             return True
     return False
-
 
 class TqdmCallback(Callback):
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -37,7 +37,7 @@ from bigdl.orca.data.file import get_remote_file_to_local, put_local_file_to_rem
 from bigdl.dllib.utils.common import get_node_and_core_number
 from bigdl.orca.learn.log_monitor import start_log_server, stop_log_server
 from bigdl.orca.learn.pytorch.callbacks.maincallback import make_only_mainCallback
-from bigdl.orca.learn.pytorch.callbacks.tqdm import TqdmCallback
+from bigdl.orca.learn.pytorch.callbacks.tqdm import TqdmCallback, is_tqdm_exited
 from bigdl.orca.learn.utils import find_free_port, find_ip_and_free_port
 from bigdl.dllib.utils.utils import get_node_ip
 from bigdl.dllib.utils.log4Error import invalidInputError
@@ -289,7 +289,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
         # Check uniqueness of the MainCallback
         callbacks = callbacks or []
         make_only_mainCallback(callbacks)
-        if self.use_tqdm:
+        if self.use_tqdm and not is_tqdm_exited(callbacks):
             callbacks.append(TqdmCallback())
 
         params = dict(
@@ -541,7 +541,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
         # Check uniqueness of the MainCallback
         callbacks = callbacks or []
         make_only_mainCallback(callbacks)
-        if self.use_tqdm:
+        if self.use_tqdm and not is_tqdm_exited(callbacks):
             callbacks.append(TqdmCallback())
 
         params = dict(

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -37,7 +37,7 @@ from bigdl.orca.data.file import get_remote_file_to_local, put_local_file_to_rem
 from bigdl.dllib.utils.common import get_node_and_core_number
 from bigdl.orca.learn.log_monitor import start_log_server, stop_log_server
 from bigdl.orca.learn.pytorch.callbacks.maincallback import make_only_mainCallback
-from bigdl.orca.learn.pytorch.callbacks.tqdm import TqdmCallback, is_tqdm_exited
+from bigdl.orca.learn.pytorch.callbacks.tqdm import TqdmCallback, is_tqdm_exists
 from bigdl.orca.learn.utils import find_free_port, find_ip_and_free_port
 from bigdl.dllib.utils.utils import get_node_ip
 from bigdl.dllib.utils.log4Error import invalidInputError
@@ -289,7 +289,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
         # Check uniqueness of the MainCallback
         callbacks = callbacks or []
         make_only_mainCallback(callbacks)
-        if self.use_tqdm and not is_tqdm_exited(callbacks):
+        if self.use_tqdm and not is_tqdm_exists(callbacks):
             callbacks.append(TqdmCallback())
 
         params = dict(
@@ -541,7 +541,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
         # Check uniqueness of the MainCallback
         callbacks = callbacks or []
         make_only_mainCallback(callbacks)
-        if self.use_tqdm and not is_tqdm_exited(callbacks):
+        if self.use_tqdm and not is_tqdm_exists(callbacks):
             callbacks.append(TqdmCallback())
 
         params = dict(

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -28,7 +28,7 @@ from bigdl.orca.ray import OrcaRayContext
 from bigdl.orca.learn.pytorch.core.base_ray_estimator import BaseRayEstimator
 from bigdl.orca.learn.pytorch.utils import process_stats, check_for_failure
 from bigdl.orca.learn.pytorch.callbacks.maincallback import make_only_mainCallback
-from bigdl.orca.learn.pytorch.callbacks.tqdm import TqdmCallback, is_tqdm_exited
+from bigdl.orca.learn.pytorch.callbacks.tqdm import TqdmCallback, is_tqdm_exists
 
 import ray
 from bigdl.dllib.utils.log4Error import invalidInputError
@@ -193,7 +193,7 @@ class PyTorchRayEstimator(BaseRayEstimator):
         # Check uniqueness of the MainCallback
         callbacks = callbacks or []
         make_only_mainCallback(callbacks)
-        if self.use_tqdm and not is_tqdm_exited(callbacks):
+        if self.use_tqdm and not is_tqdm_exists(callbacks):
             callbacks.append(TqdmCallback())
 
         params = dict(
@@ -440,7 +440,7 @@ class PyTorchRayEstimator(BaseRayEstimator):
         # Check uniqueness of the MainCallback
         callbacks = callbacks or []
         make_only_mainCallback(callbacks)
-        if self.use_tqdm and not is_tqdm_exited(callbacks):
+        if self.use_tqdm and not is_tqdm_exists(callbacks):
             callbacks.append(TqdmCallback())
 
         params = dict(batch_size=batch_size,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -28,7 +28,7 @@ from bigdl.orca.ray import OrcaRayContext
 from bigdl.orca.learn.pytorch.core.base_ray_estimator import BaseRayEstimator
 from bigdl.orca.learn.pytorch.utils import process_stats, check_for_failure
 from bigdl.orca.learn.pytorch.callbacks.maincallback import make_only_mainCallback
-from bigdl.orca.learn.pytorch.callbacks.tqdm import TqdmCallback
+from bigdl.orca.learn.pytorch.callbacks.tqdm import TqdmCallback, is_tqdm_exited
 
 import ray
 from bigdl.dllib.utils.log4Error import invalidInputError
@@ -193,7 +193,7 @@ class PyTorchRayEstimator(BaseRayEstimator):
         # Check uniqueness of the MainCallback
         callbacks = callbacks or []
         make_only_mainCallback(callbacks)
-        if self.use_tqdm:
+        if self.use_tqdm and not is_tqdm_exited(callbacks):
             callbacks.append(TqdmCallback())
 
         params = dict(
@@ -440,7 +440,7 @@ class PyTorchRayEstimator(BaseRayEstimator):
         # Check uniqueness of the MainCallback
         callbacks = callbacks or []
         make_only_mainCallback(callbacks)
-        if self.use_tqdm:
+        if self.use_tqdm and not is_tqdm_exited(callbacks):
             callbacks.append(TqdmCallback())
 
         params = dict(batch_size=batch_size,


### PR DESCRIPTION
## Description

If users wrongly input two identical tqdmcallbacks(users pass use_tqdm=true and tqdmcallback as the same time), we need to correctly handle this (Just ignore one)