### PR TITLE
Nano: fix multi-instance on Windows

### DIFF
--- a/docs/readthedocs/source/doc/Nano/Overview/support.md
+++ b/docs/readthedocs/source/doc/Nano/Overview/support.md
@@ -35,7 +35,7 @@
 | **Channel last**   | ✅                    | ✅       | ✅                  | ?                     | ✅       |
 | **BF16**           | ✅                    | ✅       | ⭕                  | ⭕                     | ✅       |
 | **IPEX**           | ✅                    | ✅       | ❌                  | ❌                     | ❌       |
-| **Multi-instance** | ✅                    | ✅       | ②                  | ②                     | ✅       |
+| **Multi-instance** | ✅                    | ✅       | ②                  | ②                     | ②       |
 
 ## TensorFlow Feature Support
 

--- a/python/nano/src/bigdl/nano/tf/model.py
+++ b/python/nano/src/bigdl/nano/tf/model.py
@@ -21,7 +21,8 @@ from bigdl.nano.utils.common import AcceleratedModel
 try:
     import torch
     is_torch_available = True
-except ImportError:
+except Exception as _e:
+    # import torch after import tensorflow may cause `OSError` exception on Windows
     is_torch_available = False
 
 

--- a/python/nano/src/bigdl/nano/utils/common/schedule.py
+++ b/python/nano/src/bigdl/nano/utils/common/schedule.py
@@ -41,8 +41,10 @@ def get_cpu_info():
         logical_cores = int(subprocess.check_output(
             get_logical_core_args, universal_newlines=True).splitlines()[4].split("=")[1])
         for i in range(logical_cores):
-            for j in range(physical_cores):
-                get_physical_core[i] = j
+            # We don't know how to query which cores are physical cores on Windows,
+            # so we use all logical cores
+            get_physical_core[i] = i
+            get_socket[i] = 0
         for i in range(logical_cores):
             get_socket[i] = 0
     elif platform.system() == "Darwin":

--- a/python/nano/src/bigdl/nano/utils/common/schedule.py
+++ b/python/nano/src/bigdl/nano/utils/common/schedule.py
@@ -45,8 +45,6 @@ def get_cpu_info():
             # so we use all logical cores
             get_physical_core[i] = i
             get_socket[i] = 0
-        for i in range(logical_cores):
-            get_socket[i] = 0
     elif platform.system() == "Darwin":
         # We cannot query which cores are physical cores on MacOS,
         # so we use all logical cores


### PR DESCRIPTION
## Description

Fix multi-instance bugs on Windows:
- all logical cores will be mapped to the same physical core
- specifying cores used by each process will cause error
- catch the `OSError` exception caused by `import torch` after `import tensorflow`

### 4. How to test?
- [x] Manually test


