### PR TITLE
Nano: add setuptools version requirement

### DIFF
--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -164,7 +164,8 @@ def setup_package():
                         "protobuf==3.19.5",
                         "py-cpuinfo",
                         "pyyaml",
-                        "packaging"]
+                        "packaging",
+                        "setuptools<66"]
 
     package_data = [
         "libs/libjemalloc.so",


### PR DESCRIPTION
## Description

INC requires setuptools < 66, so we add this requirement in `setup.py`

