### PR TITLE
Nano: add some exclude test method for inferenceoptimizer ut

### DIFF
--- a/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
@@ -29,6 +29,7 @@ import torch.nn.functional as F
 from test.pytorch.utils._train_torch_lightning import create_data_loader
 from torch.utils.data import TensorDataset, DataLoader
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10, TORCH_VERSION_LESS_1_12
+from bigdl.nano.utils.common import _avx512_checker
 from bigdl.nano.utils.common import invalidOperationError
 
 
@@ -320,8 +321,14 @@ class TestInferencePipeline(TestCase):
                                latency_sample_num=10)
         if TORCH_VERSION_LESS_1_12:
             return
+        exclude_test_method = []
+        if not _avx512_checker():
+            # Applying IPEX BF16 optimization needs the cpu support avx512
+            exclude_test_method = ["jit_bf16_ipex", "jit_bf16_ipex_channels_last"]
         optim_dict = inference_opt.optimized_model_dict
         for method, result in optim_dict.items():
+            if method in exclude_test_method:
+                continue
             assert result["status"] in ("successful", "early stopped"), \
                 "optimization failed with dict: {optim_dict}"
 
@@ -334,8 +341,14 @@ class TestInferencePipeline(TestCase):
                                latency_sample_num=10)
         if TORCH_VERSION_LESS_1_12:
             return
+        exclude_test_method = []
+        if not _avx512_checker():
+            # Applying IPEX BF16 optimization needs the cpu support avx512
+            exclude_test_method = ["jit_bf16_ipex", "jit_bf16_ipex_channels_last"]
         optim_dict = inference_opt.optimized_model_dict
         for method, result in optim_dict.items():
+            if method in exclude_test_method:
+                continue
             # TODO: nested tensor currently not work for openvino and onnx
             if "openvino" not in method and "onnxruntime_int8_qlinear" != method:
                 assert result["status"] in ("successful", "early stopped"), \
@@ -351,7 +364,13 @@ class TestInferencePipeline(TestCase):
         optim_dict = inference_opt.optimized_model_dict
         if TORCH_VERSION_LESS_1_12:
             return
+        exclude_test_method = []
+        if not _avx512_checker():
+            # Applying IPEX BF16 optimization needs the cpu support avx512
+            exclude_test_method = ["jit_bf16_ipex", "jit_bf16_ipex_channels_last"]
         for method, result in optim_dict.items():
+            if method in exclude_test_method:
+                continue
             # TODO: nested tensor currently not work for openvino and onnx and inc
             if "openvino" not in method and "onnxruntime_int8_qlinear" != method:
                 assert result["status"] in ("successful", "early stopped"), \
@@ -369,7 +388,13 @@ class TestInferencePipeline(TestCase):
         optim_dict = inference_opt.optimized_model_dict
         if TORCH_VERSION_LESS_1_12:
             return
+        exclude_test_method = []
+        if not _avx512_checker():
+            # Applying IPEX BF16 optimization needs the cpu support avx512
+            exclude_test_method = ["jit_bf16_ipex", "jit_bf16_ipex_channels_last"]
         for method, result in optim_dict.items():
+            if method in exclude_test_method:
+                continue
             assert result["status"] in ("successful", "early stopped"), \
                 f"optimization failed with dict: {optim_dict}"
 
@@ -424,7 +449,13 @@ class TestInferencePipeline(TestCase):
         optim_dict = inference_opt.optimized_model_dict
         if TORCH_VERSION_LESS_1_12:
             return
+        exclude_test_method = []
+        if not _avx512_checker():
+            # Applying IPEX BF16 optimization needs the cpu support avx512
+            exclude_test_method = ["jit_bf16_ipex", "jit_bf16_ipex_channels_last"]
         for method, result in optim_dict.items():
+            if method in exclude_test_method:
+                continue
             assert result["status"] in ("successful", "early stopped"), \
                 f"optimization failed with dict: {optim_dict}"
 


### PR DESCRIPTION
## Description
Some white box testing is involved in https://github.com/intel-analytics/BigDL/pull/7458 while they might be broken when the test is run on a server without avx512.