### PR TITLE
Orca: rm redundant test `test_xshards_partition`

### DIFF
--- a/python/orca/dev/test/run-pytests-ray
+++ b/python/orca/dev/test/run-pytests-ray
@@ -67,6 +67,7 @@ if [ $python_version == 3.7.10 ];then
 
     echo "Running orca data tests"
     python -m pytest -v test/bigdl/orca/data \
+          # test_xshards_partition.py is tested in run-pytests-basic-env.sh
           --ignore=test/bigdl/orca/data/test_xshards_partition.py \
           --ignore=test/bigdl/orca/data/test_read_parquet_images.py
     exit_status_4=$?
@@ -94,6 +95,7 @@ else
 
     echo "Running orca data tests"
     python -m pytest -v test/bigdl/orca/data \
+          # test_xshards_partition.py is tested in run-pytests-basic-env.sh
           --ignore=test/bigdl/orca/data/test_xshards_partition.py \
           --ignore=test/bigdl/orca/data/test_read_parquet_images.py \
           --ignore=test/bigdl/orca/data/test_write_parquet.py \

--- a/python/orca/dev/test/run-pytests-ray
+++ b/python/orca/dev/test/run-pytests-ray
@@ -67,6 +67,7 @@ if [ $python_version == 3.7.10 ];then
 
     echo "Running orca data tests"
     python -m pytest -v test/bigdl/orca/data \
+          --ignore=test/bigdl/orca/data/test_xshards_partition.py \
           --ignore=test/bigdl/orca/data/test_read_parquet_images.py
     exit_status_4=$?
     if [ $exit_status_4 -ne 0 ];
@@ -93,6 +94,7 @@ else
 
     echo "Running orca data tests"
     python -m pytest -v test/bigdl/orca/data \
+          --ignore=test/bigdl/orca/data/test_xshards_partition.py \
           --ignore=test/bigdl/orca/data/test_read_parquet_images.py \
           --ignore=test/bigdl/orca/data/test_write_parquet.py \
           --ignore=test/bigdl/orca/data/test_spark_backend.py


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

Since the pytest sciprt `orca/data/test_xshards_partition.py` is already tested in the `Orca-Python-Py37-Basic`, PR: https://github.com/intel-analytics/BigDL/pull/7463, it can be removed from the old test.

### 2. How to test?

The following Orca Unit Test should be completed ✅ 
- [x] [Orca-Python-Ray-Py37-Spark3](https://github.com/intel-analytics/BigDL/actions/runs/4140170348/jobs/7158675399)
- [x] [Orca-Python-Ray-Py38-Spark3](https://github.com/intel-analytics/BigDL/actions/runs/4140170348/jobs/7158675086)

