### PR TITLE
Nano: update save & load and related ut

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -1160,9 +1160,14 @@ class InferenceOptimizer(BaseInferenceOptimizer):
 
         :param path: Path to model to be loaded. Path should be a directory.
         :param model: Required FP32 model to load pytorch model, it is needed if:
-               1. you accelerated the model with accelerator=None by
-               InferenceOptimizer.trace/InferenceOptimizer.quantize.
-               2. you want to the loaded model contains the attributes of original model.
+               1. you accelerate the model with accelerator=None by
+               InferenceOptimizer.trace()/InferenceOptimizer.quantize().
+               2. you accelerate the model with InferenceOptimizer.optimize() and
+               get_model()/get_best_model(), and the best method or the method you
+               specify don't contain accelerator 'onnxruntime'/'openvino'/'jit'.
+               If you are not sure what optimization method is used, we recommend that
+               you always pass in the original model for this case.
+               3. you want to the loaded model contains the attributes of original model.
         :param input_sample: Input sample for your model, could be a Tensor or a tuple.
                Only valid for inc ipex quantization model, otherwise will be ignored.
         :param inplace: whether to perform inplace optimization. Default: ``False``.

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -1159,10 +1159,10 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         Load a model from local.
 
         :param path: Path to model to be loaded. Path should be a directory.
-        :param model: Required FP32 model to load pytorch model, it is needed if you accelerated
-               the model with accelerator=None by InferenceOptimizer.trace/
-               InferenceOptimizer.quantize. model should be set to None if you choose
-               accelerator="onnxruntime"/"openvino"/"jit".
+        :param model: Required FP32 model to load pytorch model, it is needed if:
+               1. you accelerated the model with accelerator=None by
+               InferenceOptimizer.trace/InferenceOptimizer.quantize.
+               2. you want to the loaded model contains the attributes of original model.
         :param input_sample: Input sample for your model, could be a Tensor or a tuple.
                Only valid for inc ipex quantization model, otherwise will be ignored.
         :param inplace: whether to perform inplace optimization. Default: ``False``.

--- a/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
+++ b/python/nano/src/bigdl/nano/pytorch/trainer/Trainer.py
@@ -413,7 +413,7 @@ class Trainer(pl.Trainer):
                                            **export_kwargs)
 
     @staticmethod
-    def save(model: pl.LightningModule, path):
+    def save(model: nn.Module, path):
         """
         Save the model to local file.
 
@@ -424,15 +424,28 @@ class Trainer(pl.Trainer):
         save_model(model, path)
 
     @staticmethod
-    def load(path, model: pl.LightningModule = None):
+    def load(path, model: Optional[nn.Module] = None, input_sample=None,
+             inplace=False, device=None):
         """
         Load a model from local.
 
         :param path: Path to model to be loaded. Path should be a directory.
-        :param model: Required FP32 model to load pytorch model, it is needed if you accelerated
-               the model with accelerator=None by Trainer.trace/Trainer.quantize. model
-               should be set to None if you choose accelerator="onnxruntime"/"openvino"/"jit".
+        :param model: Required FP32 model to load pytorch model, it is needed if:
+               1. you accelerate the model with accelerator=None by
+               InferenceOptimizer.trace()/InferenceOptimizer.quantize().
+               2. you accelerate the model with InferenceOptimizer.optimize() and
+               get_model()/get_best_model(), and the best method or the method you
+               specify don't contain accelerator 'onnxruntime'/'openvino'/'jit'.
+               If you are not sure what optimization method is used, we recommend that
+               you always pass in the original model for this case.
+               3. you want to the loaded model contains the attributes of original model.
+        :param input_sample: Input sample for your model, could be a Tensor or a tuple.
+               Only valid for inc ipex quantization model, otherwise will be ignored.
+        :param inplace: whether to perform inplace optimization. Default: ``False``.
+        :param device: A string represents the device of the inference. Default to None.
+               Only valid for openvino model, otherwise will be ignored.
         :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                  precision(FP32/FP16/BF16/INT8).
         """
-        return load_model(path, model)
+        return load_model(path, model, input_sample=input_sample,
+                          inplace=inplace, device=device)

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -773,10 +773,15 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         Load a model from local.
 
         :param path: Path to model to be loaded. Path should be a directory.
-        :param model: Required FP32 model to load tensorflow model, it is needed if:
-               1. you accelerated the model with accelerator=None by
-               InferenceOptimizer.trace/InferenceOptimizer.quantize.
-               2. you want to the loaded model contains the attributes of original model.
+        :param model: Required FP32 model to load pytorch model, it is needed if:
+               1. you accelerate the model with accelerator=None by
+               InferenceOptimizer.trace()/InferenceOptimizer.quantize().
+               2. you accelerate the model with InferenceOptimizer.optimize() and
+               get_model()/get_best_model(), and the best method or the method you
+               specify don't contain accelerator 'onnxruntime'/'openvino'/'jit'.
+               If you are not sure what optimization method is used, we recommend that
+               you always pass in the original model for this case.
+               3. you want to the loaded model contains the attributes of original model.
         :param device: A string represents the device of the inference. Default to None.
                Only valid for openvino model, otherwise will be ignored.
         :return: Model with different acceleration(None/OpenVINO/ONNX Runtime) or

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -768,12 +768,15 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             model.save(checkpoint_path)
 
     @staticmethod
-    def load(path, model: Model, device=None):
+    def load(path, model: Optional[Model] = None, device=None):
         """
         Load a model from local.
 
         :param path: Path to model to be loaded. Path should be a directory.
-        :param model: Required FP32 model to load tensorflow model.
+        :param model: Required FP32 model to load tensorflow model, it is needed if:
+               1. you accelerated the model with accelerator=None by
+               InferenceOptimizer.trace/InferenceOptimizer.quantize.
+               2. you want to the loaded model contains the attributes of original model.
         :param device: A string represents the device of the inference. Default to None.
                Only valid for openvino model, otherwise will be ignored.
         :return: Model with different acceleration(None/OpenVINO/ONNX Runtime) or

--- a/python/nano/src/bigdl/nano/tf/utils.py
+++ b/python/nano/src/bigdl/nano/tf/utils.py
@@ -66,6 +66,8 @@ def patch_attrs(target_obj: object, source_obj: object) -> object:
     :param source_obj: source object
     :return: `target_obj`
     """
+    if source_obj is None:
+        return target_obj
     if inspect.ismethod(target_obj.__setattr__):
         # `target_obj` has custom `__setattr__`
         wrapper_obj = _ModuleWrapper(target_obj, source_obj)

--- a/python/nano/test/inc/pytorch/test_quantize.py
+++ b/python/nano/test/inc/pytorch/test_quantize.py
@@ -224,6 +224,13 @@ class TestTrainer(TestCase):
             out = qmodel(x)
         assert out.shape == torch.Size([256, 10])
 
+        # save & load with original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(qmodel, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model=pl_model)
+        assert load_model.channels == 3
+        load_model.hello()
+
     # This UT will fail with INC < 2.0
     @pytest.mark.skipif(compare_version("neural_compressor", operator.lt, "2.0"), reason="")
     def test_ipex_int8_quantize_with_model_cannot_deepcopy(self):

--- a/python/nano/test/onnx/pytorch/test_inc_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_inc_onnx.py
@@ -241,6 +241,22 @@ class TestOnnx(TestCase):
         with pytest.raises(AttributeError):
             onnx_model.width
 
+        # save & load without original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(onnx_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+        with pytest.raises(AttributeError):
+            load_model.channels == 3
+        with pytest.raises(AttributeError):
+            load_model.hello()
+
+        # save & load with original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(onnx_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model=pl_model)
+        assert load_model.channels == 3
+        load_model.hello()
+
     def test_onnx_quantize_dynamic_axes(self):
         class CustomModel(nn.Module):
             def __init__(self):

--- a/python/nano/test/onnx/pytorch/test_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_onnx.py
@@ -209,6 +209,22 @@ class TestOnnx(TestCase):
         with pytest.raises(AttributeError):
             onnx_model.width
 
+        # save & load without original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(onnx_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+        with pytest.raises(AttributeError):
+            load_model.channels == 3
+        with pytest.raises(AttributeError):
+            load_model.hello()
+
+        # save & load with original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(onnx_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model=pl_model)
+        assert load_model.channels == 3
+        load_model.hello()
+
     def test_onnx_default_values(self):
         # default bool values
         class Net(nn.Module):

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -166,6 +166,22 @@ class TestOpenVINO(TestCase):
             assert torch.get_num_threads() == 2
             y1 = openvino_model(x[0:1])
 
+        # save & load without original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(openvino_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, device='CPU')
+        with pytest.raises(AttributeError):
+            load_model.channels == 3
+        with pytest.raises(AttributeError):
+            load_model.hello()
+
+        # save & load with original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(openvino_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model=model, device='CPU')
+        assert load_model.channels == 3
+        load_model.hello()
+
     def test_openvino_quantize_dynamic_axes(self):
         class CustomModel(nn.Module):
             def __init__(self):

--- a/python/nano/test/pytorch/tests/inference/test_bf16.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16.py
@@ -181,6 +181,13 @@ class Pytorch1_12:
         with pytest.raises(AttributeError):
             bf16_model.width
 
+        # save & load with original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(bf16_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
+        assert load_model.channels == 3
+        load_model.hello()
+
     def test_bf16_channels_last_various_input_sample(self):
 
         class DummyModel(torch.nn.Module):

--- a/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
@@ -136,6 +136,8 @@ class Pytorch1_11:
             print("hello world!")
         # patch a function
         model.hello = hello
+
+        # test jit + ipex + bf16
         new_model = InferenceOptimizer.trace(model, precision='bf16',
                                              accelerator="jit", use_ipex=True,
                                              input_sample=x)
@@ -143,7 +145,14 @@ class Pytorch1_11:
             new_model(x)
         assert new_model.channels == 3
         new_model.hello()
+        # save & load with original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(new_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
+        assert load_model.channels == 3
+        load_model.hello()
 
+        # test jit + bf16
         new_model = InferenceOptimizer.trace(model, precision='bf16',
                                              accelerator="jit",
                                              input_sample=x)
@@ -151,7 +160,14 @@ class Pytorch1_11:
             new_model(x)
         assert new_model.channels == 3
         new_model.hello()
+        # save & load with original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(new_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
+        assert load_model.channels == 3
+        load_model.hello()
 
+        # test iepx + bf16
         new_model = InferenceOptimizer.trace(model, precision='bf16',
                                              use_ipex=True)
         with InferenceOptimizer.get_context(new_model):
@@ -160,6 +176,12 @@ class Pytorch1_11:
         new_model.hello()
         with pytest.raises(AttributeError):
             new_model.width
+        # save & load with original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(new_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
+        assert load_model.channels == 3
+        load_model.hello()
 
     def test_bf16_ipex_jit_method(self):
 

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -175,6 +175,13 @@ class IPEXJITInference_gt_1_10:
         assert new_model.channels == 3
         new_model.hello()
 
+        # save & load with original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(new_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
+        assert load_model.channels == 3
+        load_model.hello()
+
         # test jit + ipex + inplace
         new_model = InferenceOptimizer.trace(model, accelerator="jit",
                                              use_ipex=True,
@@ -201,6 +208,13 @@ class IPEXJITInference_gt_1_10:
         assert new_model.channels == 3
         new_model.hello()
 
+        # save & load with original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(new_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
+        assert load_model.channels == 3
+        load_model.hello()
+
         # test ipex
         new_model = InferenceOptimizer.trace(model, use_ipex=True)
         with InferenceOptimizer.get_context(new_model):
@@ -209,6 +223,13 @@ class IPEXJITInference_gt_1_10:
         new_model.hello()
         with pytest.raises(AttributeError):
             new_model.width
+
+        # save & load with original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(new_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
+        assert load_model.channels == 3
+        load_model.hello()
 
         # test ipex inplace
         new_model = InferenceOptimizer.trace(model, use_ipex=True, inplace=True)

--- a/python/nano/test/tf/inference/test_trace_and_quantize.py
+++ b/python/nano/test/tf/inference/test_trace_and_quantize.py
@@ -191,15 +191,6 @@ class TestTraceAndQuantize(TestCase):
         new_model.do_nothing()
         assert new_model.get_x() == quantized_model.x == x
 
-        # test save/load without original model
-        with tempfile.TemporaryDirectory() as tmp_dir_name:
-            InferenceOptimizer.save(quantized_model, tmp_dir_name)
-            new_model = InferenceOptimizer.load(tmp_dir_name)
-        with pytest.raises(AttributeError):
-            new_model.do_nothing()
-        with pytest.raises(AttributeError):
-            assert new_model.get_x()
-
     def test_evaluate(self):
         inputs = tf.keras.Input(shape=(28*28,), name='digits')
         x = layers.Dense(10, name='dense_logits')(inputs)

--- a/python/nano/test/tf/inference/test_trace_and_quantize.py
+++ b/python/nano/test/tf/inference/test_trace_and_quantize.py
@@ -18,6 +18,7 @@ import tempfile
 import operator
 import numpy as np
 import tensorflow as tf
+import pytest
 from tensorflow.keras.metrics import MeanSquaredError, CategoricalAccuracy
 from tensorflow.keras import layers, Model
 from tensorflow.keras.applications import MobileNetV2
@@ -67,13 +68,22 @@ class TestTraceAndQuantize(TestCase):
         traced_model(np.random.random((1, 4)).astype(np.float32))
         traced_model(inputs=np.random.random((1, 4)).astype(np.float32))
 
-        # test save/load
+        # test save/load with original model
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(traced_model, tmp_dir_name)
             new_model = InferenceOptimizer.load(tmp_dir_name, model)
         new_model.do_nothing()
         assert new_model.get_x() == traced_model.x == x
-        
+
+        # test save/load without original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(traced_model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
+        with pytest.raises(AttributeError):
+            new_model.do_nothing()
+        with pytest.raises(AttributeError):
+            assert new_model.get_x()
+
         # for openvino
         model = MyModel(x)
         traced_model = InferenceOptimizer.trace(model, accelerator="openvino",
@@ -83,12 +93,21 @@ class TestTraceAndQuantize(TestCase):
         assert traced_model.get_x() == traced_model.x == x
         traced_model(np.random.random((1, 4)).astype(np.float32))
 
-        # test save/load
+        # test save/load with original model
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(traced_model, tmp_dir_name)
             new_model = InferenceOptimizer.load(tmp_dir_name, model)
         new_model.do_nothing()
         assert new_model.get_x() == traced_model.x == x
+
+        # test save/load without original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(traced_model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
+        with pytest.raises(AttributeError):
+            new_model.do_nothing()
+        with pytest.raises(AttributeError):
+            assert new_model.get_x()
 
     def test_attribute_access_after_quantize(self):
         x = 100
@@ -105,12 +124,21 @@ class TestTraceAndQuantize(TestCase):
         quantized_model(np.random.random((1, 4)).astype(np.float32))
         quantized_model(inputs=np.random.random((1, 4)).astype(np.float32))
         
-        # test save/load
+        # test save/load with original model
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(quantized_model, tmp_dir_name)
             new_model = InferenceOptimizer.load(tmp_dir_name, model)
         new_model.do_nothing()
         assert new_model.get_x() == quantized_model.x == x
+
+        # test save/load without original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(quantized_model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
+        with pytest.raises(AttributeError):
+            new_model.do_nothing()
+        with pytest.raises(AttributeError):
+            assert new_model.get_x()
 
         # for openvino
         model = MyModel(x)
@@ -124,12 +152,21 @@ class TestTraceAndQuantize(TestCase):
         assert quantized_model.get_x() == quantized_model.x == x
         quantized_model(np.random.random((1, 4)).astype(np.float32))
 
-        # test save/load
+        # test save/load with original model
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(quantized_model, tmp_dir_name)
             new_model = InferenceOptimizer.load(tmp_dir_name, model)
         new_model.do_nothing()
         assert new_model.get_x() == quantized_model.x == x
+
+        # test save/load without original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(quantized_model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
+        with pytest.raises(AttributeError):
+            new_model.do_nothing()
+        with pytest.raises(AttributeError):
+            assert new_model.get_x()
         
         # for inc
         from bigdl.nano.utils.common import compare_version
@@ -147,12 +184,21 @@ class TestTraceAndQuantize(TestCase):
         assert quantized_model.get_x() == quantized_model.x == x
         quantized_model(np.random.random((1, 4)).astype(np.float32))
 
-        # test save/load
+        # test save/load with original model
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(quantized_model, tmp_dir_name)
             new_model = InferenceOptimizer.load(tmp_dir_name, model)
         new_model.do_nothing()
         assert new_model.get_x() == quantized_model.x == x
+
+        # test save/load without original model
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(quantized_model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
+        with pytest.raises(AttributeError):
+            new_model.do_nothing()
+        with pytest.raises(AttributeError):
+            assert new_model.get_x()
 
     def test_evaluate(self):
         inputs = tf.keras.Input(shape=(28*28,), name='digits')


### PR DESCRIPTION
## Description

Update loading logic for PyTorch and Keras, now original model is not necessary for accelerator=None, only when you want to contain original attributes, you can pass it.

### 1. Why the change?

In the past, for keras, user must pass in original model when loading model, however, in PyTorch, we can't pass in original model to obtain some original attributes.
Now we want to unify the two behaviors: original model is not necessary for accelerator=None, only when you want to contain original attributes, you can pass it.

### 2. User API changes
Update `InferenceOptimizer.load` for PyTorch and keras.
```python
# save & load without original model, for accelerator != None
InferenceOptimizer.save(openvino_model, dir_name)
load_model = InferenceOptimizer.load(dir_name) 

# save & load with original model, for accelerator == None or you wan to contain original attributes
InferenceOptimizer.save(openvino_model, tmp_dir_name)
load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
```

### 3. Summary of the change 

- Update loading behavior for PyTorch and Keras
- Update related ut

### 4. How to test?
- [x] Unit test
