### PR TITLE
Nano: add Unet ut for PyTorch openvino & ipex+jit

### DIFF
--- a/.github/workflows/nano_unit_tests_pytorch.yml
+++ b/.github/workflows/nano_unit_tests_pytorch.yml
@@ -145,6 +145,7 @@ jobs:
           $CONDA/bin/conda info
           bash python/nano/dev/build_and_install.sh linux default false pytorch,inference
           pip install pytest
+          pip install diffusers==0.11.1
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
             bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]} -f https://software.intel.com/ipex-whl-stable
@@ -252,6 +253,7 @@ jobs:
           $CONDA/bin/conda info
           bash python/nano/dev/build_and_install.sh linux default false pytorch,inference
           pip install pytest
+          pip install diffusers==0.11.1
           if [ ! -z "${{matrix.pytorch-version}}" ]; then
             requirements=(${{matrix.pytorch-version}})
             bash python/nano/dev/build_and_install.sh linux default false ${requirements[0]} -f https://software.intel.com/ipex-whl-stable

--- a/python/nano/src/bigdl/nano/utils/pytorch/inspect.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/inspect.py
@@ -77,7 +77,9 @@ def get_forward_annotations(model):
     return forward_annotations
 
 
-def get_conditional_args(model, include=(torch.Tensor,), exclude=()):
+def get_conditional_args(model,
+                         include=(torch.Tensor, torch.FloatTensor, torch.LongTensor),
+                         exclude=()):
     '''
     This function will return all the parameters that (might) in `condition`
     It will return a list or tensor args name

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -306,13 +306,13 @@ class TestOpenVINO(TestCase):
 
     def test_openvino_trace_stable_diffusion_unet(self):
         from diffusers.models import UNet2DConditionModel
-        unet = UNet2DConditionModel(sample_size=512, cross_attention_dim=1024)
+        unet = UNet2DConditionModel(sample_size=128, cross_attention_dim=10)
         dynamic_axes= {"sample": [0],
                        "encoder_hidden_states": [0],
                        "unet_output": [0]}
-        latent_shape = (2, 4, 64, 64)
+        latent_shape = (2, 4, 16, 16)
         image_latents = torch.randn(latent_shape, device = "cpu", dtype=torch.float32)
-        encoder_hidden_states = torch.randn((2, 77, 1024))
+        encoder_hidden_states = torch.randn((2, 77, 10))
         input_sample = (image_latents, torch.Tensor([980]).long(), encoder_hidden_states, False)
         nano_unet = InferenceOptimizer.trace(unet, accelerator="openvino",
                                              input_sample=input_sample,

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -308,12 +308,10 @@ class TestOpenVINO(TestCase):
         from diffusers.models import UNet2DConditionModel
         unet = UNet2DConditionModel(sample_size=64,
                                     cross_attention_dim=10,
-                                    attention_head_dim=1,
-                                    down_block_types=("CrossAttnDownBlock2D", "DownBlock2D"),
-                                    up_block_types=("UpBlock2D", "CrossAttnUpBlock2D",))
+                                    attention_head_dim=1)
         latent_shape = (2, 4, 8, 8)
         image_latents = torch.randn(latent_shape, device = "cpu", dtype=torch.float32)
-        encoder_hidden_states = torch.randn((2, 12, 10), device = "cpu", dtype=torch.float32)
+        encoder_hidden_states = torch.randn((2, 6, 10), device = "cpu", dtype=torch.float32)
         input_sample = (image_latents, torch.Tensor([980]).long(), encoder_hidden_states, False)
         dynamic_axes= {"sample": [0],
                        "encoder_hidden_states": [0],
@@ -321,12 +319,12 @@ class TestOpenVINO(TestCase):
         nano_unet = InferenceOptimizer.trace(unet, accelerator="openvino",
                                              input_sample=input_sample,
                                              input_names=["sample", "timestep",
-                                                         "encoder_hidden_states", "return_dict"],
+                                                          "encoder_hidden_states", "return_dict"],
                                              output_names=["unet_output"],
                                              dynamic_axes=dynamic_axes,
                                              device='CPU')
         nano_unet(image_latents, torch.Tensor([980]).long(), encoder_hidden_states)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(nano_unet, tmp_dir_name)
-            new_model = InferenceOptimizer.load(tmp_dir_name, unet)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
         new_model(image_latents, torch.Tensor([980]).long(), encoder_hidden_states)

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -306,14 +306,18 @@ class TestOpenVINO(TestCase):
 
     def test_openvino_trace_stable_diffusion_unet(self):
         from diffusers.models import UNet2DConditionModel
-        unet = UNet2DConditionModel(sample_size=128, cross_attention_dim=10)
+        unet = UNet2DConditionModel(sample_size=64,
+                                    cross_attention_dim=10,
+                                    attention_head_dim=1,
+                                    down_block_types=("CrossAttnDownBlock2D", "DownBlock2D"),
+                                    up_block_types=("UpBlock2D", "CrossAttnUpBlock2D",))
+        latent_shape = (2, 4, 8, 8)
+        image_latents = torch.randn(latent_shape, device = "cpu", dtype=torch.float32)
+        encoder_hidden_states = torch.randn((2, 12, 10), device = "cpu", dtype=torch.float32)
+        input_sample = (image_latents, torch.Tensor([980]).long(), encoder_hidden_states, False)
         dynamic_axes= {"sample": [0],
                        "encoder_hidden_states": [0],
                        "unet_output": [0]}
-        latent_shape = (2, 4, 16, 16)
-        image_latents = torch.randn(latent_shape, device = "cpu", dtype=torch.float32)
-        encoder_hidden_states = torch.randn((2, 77, 10))
-        input_sample = (image_latents, torch.Tensor([980]).long(), encoder_hidden_states, False)
         nano_unet = InferenceOptimizer.trace(unet, accelerator="openvino",
                                              input_sample=input_sample,
                                              input_names=["sample", "timestep",

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -446,6 +446,7 @@ class IPEXJITInference_gt_1_10:
 
     def test_ipex_jit_inference_stable_diffusion_unet(self):
         from diffusers.models import UNet2DConditionModel
+        # reduce model size as action runner has limited memory
         unet = UNet2DConditionModel(sample_size=64,
                                     cross_attention_dim=10,
                                     attention_head_dim=1,

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -448,7 +448,11 @@ class IPEXJITInference_gt_1_10:
         from diffusers.models import UNet2DConditionModel
         unet = UNet2DConditionModel(sample_size=64,
                                     cross_attention_dim=10,
-                                    attention_head_dim=1)
+                                    attention_head_dim=1,
+                                    down_block_types=("CrossAttnDownBlock2D", "DownBlock2D"),
+                                    block_out_channels=(32, 64),
+                                    up_block_types=("UpBlock2D", "CrossAttnUpBlock2D"),
+                                    layers_per_block=1)
         latent_shape = (2, 4, 8, 8)
         image_latents = torch.randn(latent_shape, device = "cpu", dtype=torch.float32)
         encoder_hidden_states = torch.randn((2, 6, 10), device = "cpu", dtype=torch.float32)

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -444,6 +444,25 @@ class IPEXJITInference_gt_1_10:
             new_model(self.data_sample)
             assert new_model.enable_onednn is True
 
+    def test_ipex_jit_inference_stable_diffusion_unet(self):
+        from diffusers.models import UNet2DConditionModel
+        unet = UNet2DConditionModel(sample_size=512, cross_attention_dim=1024)
+        latent_shape = (2, 4, 64, 64)
+        image_latents = torch.randn(latent_shape, device = "cpu", dtype=torch.float32)
+        encoder_hidden_states = torch.randn((2, 77, 1024), device = "cpu", dtype=torch.float32)
+        input_sample = (image_latents, torch.Tensor([980]).long(), encoder_hidden_states, torch.tensor(False))
+        nano_unet = InferenceOptimizer.trace(unet, accelerator="jit",
+                                             use_ipex=True,
+                                             input_sample=input_sample,
+                                             jit_strict=False,
+                                             weights_prepack=False)
+        nano_unet(image_latents, torch.Tensor([980]).long(), encoder_hidden_states, torch.tensor(False))
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(nano_unet, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name, unet)
+        new_model(image_latents, torch.Tensor([980]).long(), encoder_hidden_states, torch.tensor(False))
+
+
 class IPEXJITInference_lt_1_10:
     def test_placeholder(self):
         pass

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -446,10 +446,14 @@ class IPEXJITInference_gt_1_10:
 
     def test_ipex_jit_inference_stable_diffusion_unet(self):
         from diffusers.models import UNet2DConditionModel
-        unet = UNet2DConditionModel(sample_size=128, cross_attention_dim=10)
-        latent_shape = (2, 4, 16, 16)
+        unet = UNet2DConditionModel(sample_size=64,
+                                    cross_attention_dim=10,
+                                    attention_head_dim=1,
+                                    down_block_types=("CrossAttnDownBlock2D", "DownBlock2D"),
+                                    up_block_types=("UpBlock2D", "CrossAttnUpBlock2D",))
+        latent_shape = (2, 4, 8, 8)
         image_latents = torch.randn(latent_shape, device = "cpu", dtype=torch.float32)
-        encoder_hidden_states = torch.randn((2, 77, 10), device = "cpu", dtype=torch.float32)
+        encoder_hidden_states = torch.randn((2, 12, 10), device = "cpu", dtype=torch.float32)
         input_sample = (image_latents, torch.Tensor([980]).long(), encoder_hidden_states, torch.tensor(False))
         nano_unet = InferenceOptimizer.trace(unet, accelerator="jit",
                                              use_ipex=True,

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -446,10 +446,10 @@ class IPEXJITInference_gt_1_10:
 
     def test_ipex_jit_inference_stable_diffusion_unet(self):
         from diffusers.models import UNet2DConditionModel
-        unet = UNet2DConditionModel(sample_size=512, cross_attention_dim=1024)
-        latent_shape = (2, 4, 64, 64)
+        unet = UNet2DConditionModel(sample_size=128, cross_attention_dim=10)
+        latent_shape = (2, 4, 16, 16)
         image_latents = torch.randn(latent_shape, device = "cpu", dtype=torch.float32)
-        encoder_hidden_states = torch.randn((2, 77, 1024), device = "cpu", dtype=torch.float32)
+        encoder_hidden_states = torch.randn((2, 77, 10), device = "cpu", dtype=torch.float32)
         input_sample = (image_latents, torch.Tensor([980]).long(), encoder_hidden_states, torch.tensor(False))
         nano_unet = InferenceOptimizer.trace(unet, accelerator="jit",
                                              use_ipex=True,

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -457,17 +457,27 @@ class IPEXJITInference_gt_1_10:
         latent_shape = (2, 4, 8, 8)
         image_latents = torch.randn(latent_shape, device = "cpu", dtype=torch.float32)
         encoder_hidden_states = torch.randn((2, 6, 10), device = "cpu", dtype=torch.float32)
-        input_sample = (image_latents, torch.Tensor([980]).long(), encoder_hidden_states, torch.tensor(False))
+        input_sample = (image_latents, torch.Tensor([980]).long(), encoder_hidden_states)
+
+        latent_shape2 = (1, 4, 8, 8) # different shape
+        image_latents2 = torch.randn(latent_shape2, device = "cpu", dtype=torch.float32)
+        encoder_hidden_states2 = torch.randn((1, 12, 10), device = "cpu", dtype=torch.float32)
+
+        unet(image_latents, torch.Tensor([980]).long(), encoder_hidden_states)
+        unet(image_latents2, torch.Tensor([980]).long(), encoder_hidden_states2)
+
         nano_unet = InferenceOptimizer.trace(unet, accelerator="jit",
                                              use_ipex=True,
                                              input_sample=input_sample,
                                              jit_strict=False,
                                              weights_prepack=False)
-        nano_unet(image_latents, torch.Tensor([980]).long(), encoder_hidden_states, torch.tensor(False))
+        nano_unet(image_latents, torch.Tensor([980]).long(), encoder_hidden_states)
+        nano_unet(image_latents2, torch.Tensor([980]).long(), encoder_hidden_states2)
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(nano_unet, tmp_dir_name)
             new_model = InferenceOptimizer.load(tmp_dir_name)
-        new_model(image_latents, torch.Tensor([980]).long(), encoder_hidden_states, torch.tensor(False))
+        new_model(image_latents, torch.Tensor([980]).long(), encoder_hidden_states)
+        new_model(image_latents2, torch.Tensor([980]).long(), encoder_hidden_states2)
 
 
 class IPEXJITInference_lt_1_10:

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -448,12 +448,10 @@ class IPEXJITInference_gt_1_10:
         from diffusers.models import UNet2DConditionModel
         unet = UNet2DConditionModel(sample_size=64,
                                     cross_attention_dim=10,
-                                    attention_head_dim=1,
-                                    down_block_types=("CrossAttnDownBlock2D", "DownBlock2D"),
-                                    up_block_types=("UpBlock2D", "CrossAttnUpBlock2D",))
+                                    attention_head_dim=1)
         latent_shape = (2, 4, 8, 8)
         image_latents = torch.randn(latent_shape, device = "cpu", dtype=torch.float32)
-        encoder_hidden_states = torch.randn((2, 12, 10), device = "cpu", dtype=torch.float32)
+        encoder_hidden_states = torch.randn((2, 6, 10), device = "cpu", dtype=torch.float32)
         input_sample = (image_latents, torch.Tensor([980]).long(), encoder_hidden_states, torch.tensor(False))
         nano_unet = InferenceOptimizer.trace(unet, accelerator="jit",
                                              use_ipex=True,
@@ -463,7 +461,7 @@ class IPEXJITInference_gt_1_10:
         nano_unet(image_latents, torch.Tensor([980]).long(), encoder_hidden_states, torch.tensor(False))
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(nano_unet, tmp_dir_name)
-            new_model = InferenceOptimizer.load(tmp_dir_name, unet)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
         new_model(image_latents, torch.Tensor([980]).long(), encoder_hidden_states, torch.tensor(False))
 
 


### PR DESCRIPTION
## Description

Add UNet related UT in PR action to prevent changes on Nano side from causing stable diffusion to fail.

### 1. Why the change?
https://github.com/intel-analytics/BigDL/pull/7500

### 2. User API changes
None, just add two unittests.

### 3. Summary of the change

- add twos UNet related UT
- extend Tensor conditional_args from `torch.Tensor` to `(torch.Tensor, torch.FloatTensor, torch.LongTensor)` to cope more Tensor types

### 4. How to test?
- [x] Unit test



