### PR TITLE
Orca: Support tqdm progress bar in evaluation and predict

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/base.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/base.py
@@ -41,10 +41,16 @@ class Callback(object):
     def before_val_epoch(self, runner):
         self.before_epoch(runner)
 
+    def before_pred_epoch(self, runner):
+        self.before_epoch(runner)
+
     def after_train_epoch(self, runner):
         self.after_epoch(runner)
 
     def after_val_epoch(self, runner):
+        self.after_epoch(runner)
+
+    def after_pred_epoch(self, runner):
         self.after_epoch(runner)
 
     def before_train_iter(self, runner):
@@ -53,8 +59,14 @@ class Callback(object):
     def before_val_iter(self, runner):
         self.before_iter(runner)
 
+    def before_pred_iter(self, runner):
+        self.before_iter(runner)
+
     def after_train_iter(self, runner):
         self.after_iter(runner)
 
     def after_val_iter(self, runner):
+        self.after_iter(runner)
+
+    def after_pred_iter(self, runner):
         self.after_iter(runner)

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tqdm.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tqdm.py
@@ -44,7 +44,7 @@ class TqdmCallback(Callback):
     def before_train_epoch(self, runner):
         if self._is_rank_zero(runner):
             desc = "{}/{}e".format(runner.epochs + 1,
-                                runner.num_epochs)
+                                   runner.num_epochs)
 
             invalidInputError(tqdm is not None,
                               "tqdm is not installed, please install with 'pip install tqdm'")
@@ -57,8 +57,7 @@ class TqdmCallback(Callback):
         if self._is_rank_zero(runner):
             runner._progress_bar.n = runner.batch_idx
             postfix = {}
-            if "val_loss" in runner.validation_stats:
-                postfix.update(loss=runner.validation_stats["val_loss"])
+            postfix.update(loss=runner.loss.item())
             runner._progress_bar.set_postfix(postfix)
 
     def before_val_epoch(self, runner):
@@ -74,7 +73,7 @@ class TqdmCallback(Callback):
 
     def after_pred_iter(self, runner):
         if self._is_rank_zero(runner):
-            print("\r rank0 predict batch_idx: {%d}" % runner.batch_idx, end="")
+            print("\r Predict batch_idx: {%d}" % runner.batch_idx, end="")
 
     def _is_rank_zero(self, runner):
         invalidInputError(runner, "Sanity check failed. Runner must not be None!")

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tqdm.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/tqdm.py
@@ -44,7 +44,7 @@ class TqdmCallback(Callback):
     def before_train_epoch(self, runner):
         if self._is_rank_zero(runner):
             desc = "{}/{}e".format(runner.epochs + 1,
-                                   runner.num_epochs)
+                                runner.num_epochs)
 
             invalidInputError(tqdm is not None,
                               "tqdm is not installed, please install with 'pip install tqdm'")
@@ -52,6 +52,29 @@ class TqdmCallback(Callback):
                                         desc=desc,
                                         unit="batch",
                                         leave=False)
+
+    def after_val_iter(self, runner):
+        if self._is_rank_zero(runner):
+            runner._progress_bar.n = runner.batch_idx
+            postfix = {}
+            if "val_loss" in runner.validation_stats:
+                postfix.update(loss=runner.validation_stats["val_loss"])
+            runner._progress_bar.set_postfix(postfix)
+
+    def before_val_epoch(self, runner):
+        if self._is_rank_zero(runner):
+            desc = "1/1e"
+
+            invalidInputError(tqdm is not None,
+                              "tqdm is not installed, please install with 'pip install tqdm'")
+            runner._progress_bar = tqdm(total=len(runner.val_loader),
+                                        desc=desc,
+                                        unit="batch",
+                                        leave=False)
+
+    def after_pred_iter(self, runner):
+        if self._is_rank_zero(runner):
+            print("\r rank0 predict batch_idx: {%d}" % runner.batch_idx, end="")
 
     def _is_rank_zero(self, runner):
         invalidInputError(runner, "Sanity check failed. Runner must not be None!")

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -410,7 +410,9 @@ class PyTorchPySparkEstimator(BaseEstimator):
                 data: Union['SparkXShards', 'SparkDataFrame'],
                 batch_size: int=32,
                 feature_cols: Optional[List[str]]=None,
-                profile: bool=False) -> Union['SparkXShards', 'SparkDataFrame']:
+                profile: bool=False,
+                callbacks: Optional[List['Callback']]=None) -> Union['SparkXShards',
+                                                                     'SparkDataFrame']:
         """
         Using this PyTorch model to make predictions on the data.
 
@@ -443,9 +445,15 @@ class PyTorchPySparkEstimator(BaseEstimator):
             cluster_info=cluster_info)
         init_params.update(self.worker_init_params)
 
+        callbacks = callbacks or []
+        make_only_mainCallback(callbacks)
+        if self.use_tqdm:
+            callbacks.append(TqdmCallback())
+
         params = dict(
             batch_size=batch_size,
-            profile=profile
+            profile=profile,
+            callbacks=callbacks
         )
 
         if isinstance(data, DataFrame):  # Computation would be triggered by the user

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -162,14 +162,15 @@ class PytorchPysparkWorker(TorchRunner):
             LogMonitor.stop_log_monitor(self.log_path, self.logger_thread, self.thread_stop)
         return [validation_stats]
 
-    def predict(self, data_creator, batch_size=32, profile=False):
+    def predict(self, data_creator, batch_size=32, profile=False, callbacks=None):
         """Evaluates the model on the validation data set."""
         config = copy.copy(self.config)
         self._toggle_profiling(profile=profile)
 
         partition = data_creator(config, batch_size)
         self.load_state_dict(self.state_dict.value)
-        result = super().predict(partition=partition, batch_size=batch_size, profile=profile)
+        result = super().predict(partition=partition, batch_size=batch_size,
+                                 profile=profile, callbacks=callbacks)
         if self.log_to_driver:
             LogMonitor.stop_log_monitor(self.log_path, self.logger_thread, self.thread_stop)
         return result

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -321,7 +321,9 @@ class PyTorchRayEstimator(BaseRayEstimator):
                 data: Union['SparkXShards', 'SparkDataFrame'],
                 batch_size: int=32,
                 feature_cols: Optional[List[str]]=None,
-                profile: bool=False) -> Union['SparkXShards', 'SparkDataFrame']:
+                profile: bool=False,
+                callbacks: Optional[List['Callback']]=None) -> Union['SparkXShards',
+                                                                     'SparkDataFrame']:
         """
         Using this PyTorch model to make predictions on the data.
 
@@ -340,10 +342,18 @@ class PyTorchRayEstimator(BaseRayEstimator):
         if batch_size <= 0:
             batch_size = 1
         from bigdl.orca.data import SparkXShards
+
+        callbacks = callbacks or []
+        make_only_mainCallback(callbacks)
+        if self.use_tqdm:
+            callbacks.append(TqdmCallback())
+
         param = dict(
             batch_size=batch_size,
-            profile=profile
+            profile=profile,
+            callbacks=callbacks
         )
+
         from pyspark.sql import DataFrame
         if isinstance(data, DataFrame):
             xshards, _ = dataframe_to_xshards(data,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_worker.py
@@ -120,7 +120,7 @@ class PytorchRayWorker(TorchRunner):
         self._create_schedulers_if_available()
         self._create_loss()
 
-    def predict(self, data_creator, batch_size=32, profile=False):
+    def predict(self, data_creator, batch_size=32, profile=False, callbacks=None):
         """Evaluates the model on the validation data set."""
         config = copy.copy(self.config)
         self._toggle_profiling(profile=profile)
@@ -128,7 +128,7 @@ class PytorchRayWorker(TorchRunner):
         shards_ref = data_creator(config, batch_size)
         if isinstance(shards_ref, IterableDataset):
             pred_stats = super().predict(partition=shards_ref, batch_size=batch_size,
-                                         profile=profile)
+                                         profile=profile, callbacks=callbacks)
             for pred_stat in pred_stats:
                 pred_stat.update(pred_stat)
             worker_stats = pred_stat["prediction"]
@@ -138,5 +138,5 @@ class PytorchRayWorker(TorchRunner):
                                   "Only xshards and Ray Dataset is supported for predict")
             partition = ray.get(shards_ref)
             worker_stats = super().predict(partition=partition, batch_size=batch_size,
-                                           profile=profile)
+                                           profile=profile, callbacks=callbacks)
         return worker_stats

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -529,9 +529,7 @@ class TorchRunner(BaseRunner):
 
         result["num_samples"] = total_samples
 
-        self.validation_stats = result
         self.call_hook(callbacks=callbacks, fn_name="after_val_epoch")
-        del self.validation_stats
         return result
 
     def forward_batch(self, batch, callbacks=None):
@@ -575,10 +573,12 @@ class TorchRunner(BaseRunner):
 
         # User should not see batch from last iteration
         output = self.output
+        loss = self.loss
         del self.batch
         del self.output
+        del self.loss
 
-        return output, target, self.loss
+        return output, target, loss
 
     def predict(self, partition, batch_size=32, profile=False, callbacks=None):
         """Evaluates the model on the validation data set."""

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -244,6 +244,7 @@ class TorchRunner(BaseRunner):
             val_loader = None
             val_steps = None
 
+        self.val_loader = val_loader
         self.call_hook(callbacks=callbacks, fn_name="before_run")
 
         stats_list = list()
@@ -468,6 +469,7 @@ class TorchRunner(BaseRunner):
                 loader = self.with_sampler(loader)
         elif wrap_dataloader is True:
             loader = self.with_sampler(loader)
+        self.val_loader = loader
         loader = iter(loader)
 
         with self.timers.record("validation"):
@@ -521,13 +523,15 @@ class TorchRunner(BaseRunner):
 
                 del self.batch_idx
 
-        self.call_hook(callbacks=callbacks, fn_name="after_val_epoch")
         result = {name: metric.compute() for name, metric in metrics.items()}
 
         result["val_loss"] = sum(losses) / total_samples
 
         result["num_samples"] = total_samples
 
+        self.validation_stats = result
+        self.call_hook(callbacks=callbacks, fn_name="after_val_epoch")
+        del self.validation_stats
         return result
 
     def forward_batch(self, batch, callbacks=None):
@@ -576,10 +580,11 @@ class TorchRunner(BaseRunner):
 
         return output, target, self.loss
 
-    def predict(self, partition, batch_size=32, profile=False):
+    def predict(self, partition, batch_size=32, profile=False, callbacks=None):
         """Evaluates the model on the validation data set."""
         config = copy.copy(self.config)
         self._toggle_profiling(profile=profile)
+        callbacks = callbacks or []
 
         params = {"batch_size": batch_size, "shuffle": False}
         for arg in ["shuffle", "sampler", "batch_sampler", "num_workers", "collate_fn",
@@ -590,7 +595,7 @@ class TorchRunner(BaseRunner):
 
         def predict_fn(shard):
             if isinstance(partition, IterableDataset):
-                y = self._predict(shard)
+                y = self._predict(shard, callbacks=callbacks)
             else:
                 if isinstance(shard["x"], tuple) or isinstance(shard["x"], list):
                     tensors = [torch.from_numpy(arr) for arr in shard["x"]]
@@ -598,24 +603,34 @@ class TorchRunner(BaseRunner):
                     tensors = [torch.from_numpy(shard["x"])]
                 dataset = torch.utils.data.TensorDataset(*tensors)
                 data_loader = DataLoader(dataset, **params)
-                y = self._predict(iter(data_loader))
+                y = self._predict(iter(data_loader), callbacks=callbacks)
             return {"prediction": y}
 
+        self.call_hook(callbacks, "before_pred_epoch")
         with self.timers.record("predict"):
             if isinstance(partition, IterableDataset):
                 new_part = [predict_fn(shard) for shard, shard_idx in partition]
             else:
                 new_part = [predict_fn(shard) for shard in partition]
+        self.call_hook(callbacks, "after_pred_epoch")
         return new_part
 
-    def _predict(self, pred_iterator):
+    def _predict(self, pred_iterator, callbacks=None):
         # switch to evaluate mode
         self._mode = 'predict'
         self.model.eval()
         result = []
         with torch.no_grad():
-            for batch in pred_iterator:
-                result.append(self.predict_batch(batch))
+            for batch_idx, batch in enumerate(pred_iterator):
+                self.batch = batch
+                self.batch_idx = batch_idx
+
+                self.call_hook(callbacks, "before_pred_iter")
+                result.append(self.predict_batch(self.batch))
+                self.call_hook(callbacks, "after_pred_iter")
+
+                del self.batch
+                del self.batch_idx
 
         return np.concatenate(result, axis=0)
 


### PR DESCRIPTION
## Description

In this PR we support tqdm progress bar in evaluaion like training does.
In predict mode it is hard to apply a progress bar on it for uncountable iterable dataset, so we may just notify users with some steady log output in one line:
```python
    def after_pred_iter(self, runner):
        if self._is_rank_zero(runner):
            print("\r rank0 predict batch_idx: {%d}" % runner.batch_idx, end="")
```