### PR TITLE
[Nano] Make tf bf16 quantization not inplace

### DIFF
--- a/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
@@ -19,16 +19,16 @@ import tensorflow as tf
 
 
 def BF16Model(model):
-    model_policys = []
+    original_model_policies = []
     policy_bf16 = mixed_precision.Policy('mixed_bfloat16')
     for layer in model.layers:
-        model_policys.append(layer._dtype_policy)
+        original_model_policies.append(layer._dtype_policy)
         layer._dtype_policy = policy_bf16
     with TemporaryDirectory() as temp_dir:
         model.save(temp_dir)
         bf16_model = tf.keras.models.load_model(temp_dir)
     for idx, layer in enumerate(model.layers):
-        layer._dtype_policy = model_policys[idx]
+        layer._dtype_policy = original_model_policies[idx]
     return bf16_model
 
 

--- a/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
@@ -19,12 +19,16 @@ import tensorflow as tf
 
 
 def BF16Model(model):
+    model_policys = []
     policy_bf16 = mixed_precision.Policy('mixed_bfloat16')
     for layer in model.layers:
+        model_policys.append(layer._dtype_policy)
         layer._dtype_policy = policy_bf16
     with TemporaryDirectory() as temp_dir:
         model.save(temp_dir)
         bf16_model = tf.keras.models.load_model(temp_dir)
+    for idx, layer in enumerate(model.layers):
+        layer._dtype_policy = model_policys[idx]
     return bf16_model
 
 

--- a/python/nano/test/tf/inference/test_trace_and_quantize.py
+++ b/python/nano/test/tf/inference/test_trace_and_quantize.py
@@ -207,12 +207,15 @@ class TestTraceAndQuantize(TestCase):
         # change the original's model dtype policy 
         model = MyModel(100)
         model.compile(loss='mse', metrics=MeanSquaredError())
-        ori_model_config = model.get_config()
+        model_policys = []
+        for layer in model.layers:
+            model_policys.append(layer._dtype_policy)
         x = np.random.random((100, 4))
         model(x)
 
         bf16_model = InferenceOptimizer.quantize(model, precision="bf16")
-        assert ori_model_config == model.get_config()
+        for idx, layer in enumerate(model.layers):
+            assert layer._dtype_policy == model_policys[idx]
 
         from bigdl.nano.utils.common import _avx512_checker
         if _avx512_checker():

--- a/python/nano/test/tf/inference/test_trace_and_quantize.py
+++ b/python/nano/test/tf/inference/test_trace_and_quantize.py
@@ -203,12 +203,16 @@ class TestTraceAndQuantize(TestCase):
 
     def test_quantize_bf16(self):
         # for custom model, quantized model still return fp32 output
+        # test at the same time that the quantization does not 
+        # change the original's model dtype policy 
         model = MyModel(100)
         model.compile(loss='mse', metrics=MeanSquaredError())
+        ori_model_config = model.get_config()
         x = np.random.random((100, 4))
         model(x)
 
         bf16_model = InferenceOptimizer.quantize(model, precision="bf16")
+        assert ori_model_config = model.get_config()
 
         from bigdl.nano.utils.common import _avx512_checker
         if _avx512_checker():
@@ -223,12 +227,16 @@ class TestTraceAndQuantize(TestCase):
             output = load_model(x)
             assert output.dtype == tf.float32
 
-        # test standard model, quantized model still return bf16 output
+        # test standard model, quantized model return bf16 output
+        # test at the same time that the quantization does not 
+        # change the original's model dtype policy 
         model = MobileNetV2(weights="imagenet")
+        ori_model_config = model.get_config()
         x = np.random.rand(32, 224, 224, 3)
         model(x)
 
         bf16_model = InferenceOptimizer.quantize(model, precision="bf16")
+        assert ori_model_config = model.get_config()
 
         from bigdl.nano.utils.common import _avx512_checker
         if _avx512_checker():

--- a/python/nano/test/tf/inference/test_trace_and_quantize.py
+++ b/python/nano/test/tf/inference/test_trace_and_quantize.py
@@ -207,15 +207,15 @@ class TestTraceAndQuantize(TestCase):
         # change the original's model dtype policy 
         model = MyModel(100)
         model.compile(loss='mse', metrics=MeanSquaredError())
-        model_policys = []
+        ori_model_policies = []
         for layer in model.layers:
-            model_policys.append(layer._dtype_policy)
+            ori_model_policies.append(layer._dtype_policy)
         x = np.random.random((100, 4))
         model(x)
 
         bf16_model = InferenceOptimizer.quantize(model, precision="bf16")
         for idx, layer in enumerate(model.layers):
-            assert layer._dtype_policy == model_policys[idx]
+            assert layer._dtype_policy == ori_model_policies[idx]
 
         from bigdl.nano.utils.common import _avx512_checker
         if _avx512_checker():

--- a/python/nano/test/tf/inference/test_trace_and_quantize.py
+++ b/python/nano/test/tf/inference/test_trace_and_quantize.py
@@ -212,7 +212,7 @@ class TestTraceAndQuantize(TestCase):
         model(x)
 
         bf16_model = InferenceOptimizer.quantize(model, precision="bf16")
-        assert ori_model_config = model.get_config()
+        assert ori_model_config == model.get_config()
 
         from bigdl.nano.utils.common import _avx512_checker
         if _avx512_checker():
@@ -236,7 +236,7 @@ class TestTraceAndQuantize(TestCase):
         model(x)
 
         bf16_model = InferenceOptimizer.quantize(model, precision="bf16")
-        assert ori_model_config = model.get_config()
+        assert ori_model_config == model.get_config()
 
         from bigdl.nano.utils.common import _avx512_checker
         if _avx512_checker():

--- a/python/nano/tutorial/notebook/inference/tensorflow/tensorflow_inference_bf16.ipynb
+++ b/python/nano/tutorial/notebook/inference/tensorflow/tensorflow_inference_bf16.ipynb
@@ -132,15 +132,6 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-       "> 📝 Note\n",
-       ">\n",
-       "> Please note that, during the `'bf16'` quantization without extra accelerator, there are also changes conducted on the `fp32_model`. If you still need the original model after the optimization, please load the original model again, or make a copy of it before the optimization, etc."
-      ]
-     },
-     {
-      "cell_type": "markdown",
-      "metadata": {},
-      "source": [
        "## With Extra Accelerator"
       ]
      },
@@ -174,9 +165,7 @@
       "source": [
        "> 📝 Note\n",
        ">\n",
-       "> Different from the `'bf16'` quantization without accelerator, the optimization here is not in place.\n",
-       ">\n",
-       "> Please also note that, when you have a custom model to quantize (e.g. inherated from `tf.keras.Model`), you need to specify the `input_spec` parameter to let OpenVINO accelerator know the shape of the model input.\n",
+       "> Please note that, when you have a custom model to quantize (e.g. inherated from `tf.keras.Model`), you need to specify the `input_spec` parameter to let OpenVINO accelerator know the shape of the model input.\n",
        ">\n",
        "> Please refer to [API documentation](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/tensorflow.html#bigdl.nano.tf.keras.InferenceOptimizer.quantize) for more information on `InferenceOptimizer.quantize`."
       ]


### PR DESCRIPTION
## Description

Make sure that no changes are made to the original model during `bigdl.nano.tf.keras.InferenceOptimizer.quantize(model, precision="bf16")`

### 1. Why the change?

Current implementation of TensorFlow bf16 quantization makes change to the original model, which is not intuitive to use for users.

### 2. User API changes

N/A

### 3. Summary of the change 

- Make sure that no changes are made to the original model during `bigdl.nano.tf.keras.InferenceOptimizer.quantize(model, precision="bf16")`
- Update related uts
- Update relate how-to guides

### 4. How to test?
- [x] Unit test
- [x] Document test: https://yuwentestdocs.readthedocs.io/en/fix-nano-tf-bf16-inplace/doc/Nano/Howto/Inference/TensorFlow/tensorflow_inference_bf16.html