### PR TITLE
Nano: upgrade to ipex 1.13.100

### DIFF
--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -115,7 +115,7 @@ def setup_package():
     # ipex is only avaliable for linux now
     pytorch_113_requires = ["torch==1.13.0",
                             "torchvision==0.14.0",
-                            "intel_extension_for_pytorch==1.13.0;platform_system=='Linux'"]
+                            "intel_extension_for_pytorch==1.13.100;platform_system=='Linux'"]
 
     pytorch_112_requires = ["torch==1.12.1",
                             "torchvision==0.13.1",

--- a/python/nano/src/bigdl/nano/pytorch/strategies/ipex_strategy.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/ipex_strategy.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import operator
 from contextlib import contextmanager
 from functools import partial
 from logging import warning
@@ -28,6 +29,7 @@ from pytorch_lightning.strategies import SingleDeviceStrategy
 from pytorch_lightning.accelerators.accelerator import Accelerator
 from pytorch_lightning.plugins.precision import PrecisionPlugin
 
+from bigdl.nano.utils.common import compare_version
 from bigdl.nano.utils.common import invalidInputError
 from bigdl.nano.deps.ipex.ipex_api import ipex_optimize
 
@@ -86,7 +88,12 @@ class IPEXBF16Precision(PrecisionPlugin):
                        closure: Callable[[], Any],
                        **kwargs: Any) -> Any:
         """Bf16 optimizer step."""
-        from intel_extension_for_pytorch.optim._optimizer_utils import IPEX_FUSED_OPTIMIZER_LIST
+        if compare_version("intel_extension_for_pytorch", operator.lt, "1.13.100"):
+            from intel_extension_for_pytorch.optim._optimizer_utils import \
+                IPEX_FUSED_OPTIMIZER_LIST
+        else:
+            from intel_extension_for_pytorch.optim._optimizer_utils import \
+                IPEX_FUSED_OPTIMIZER_LIST_CPU as IPEX_FUSED_OPTIMIZER_LIST
         """Hook to run the optimizer step."""
         if type(optimizer) in IPEX_FUSED_OPTIMIZER_LIST:
             return super().optimizer_step(model, optimizer, optimizer_idx, closure, **kwargs)

--- a/python/nano/test/pytorch/utils/_train_ipex_callback.py
+++ b/python/nano/test/pytorch/utils/_train_ipex_callback.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 
+import operator
 import torch
 import warnings
 from typing import Dict
@@ -24,6 +25,7 @@ from pytorch_lightning.accelerators.cpu import CPUAccelerator
 
 from bigdl.nano.pytorch.utils import TORCH_VERSION_LESS_1_10
 from bigdl.nano.utils.common import _avx512_checker
+from bigdl.nano.utils.common import compare_version
 
 
 class CheckIPEXCallback(Callback):
@@ -82,7 +84,12 @@ class CheckIPEXFusedStepCallback(Callback):
             # IPEX BF16 weight prepack needs the cpu support avx512bw, avx512vl and avx512dq
             return
         if not TORCH_VERSION_LESS_1_10:
-            from intel_extension_for_pytorch.optim._optimizer_utils import IPEX_FUSED_OPTIMIZER_LIST
+            if compare_version("intel_extension_for_pytorch", operator.lt, "1.13.100"):
+                from intel_extension_for_pytorch.optim._optimizer_utils import \
+                    IPEX_FUSED_OPTIMIZER_LIST
+            else:
+                from intel_extension_for_pytorch.optim._optimizer_utils import \
+                    IPEX_FUSED_OPTIMIZER_LIST_CPU as IPEX_FUSED_OPTIMIZER_LIST
             # IPEX only support one optimizer
             opt = trainer.optimizers[0]
             if type(opt) in IPEX_FUSED_OPTIMIZER_LIST:


### PR DESCRIPTION
## Description

IPEX model and optimizer doesn't support `load_state_dict()` before, so we use some workaround.
This issue should be fixed in version 1.13.100, so we upgrade to this version and won't use workaround with pytorch 1.13
