### PR TITLE
Nano: use subprocess to calculate throughput for inc quantizated model

### DIFF
--- a/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
@@ -19,6 +19,8 @@ import sys
 import numpy as np
 import pickle
 import tensorflow as tf
+import os
+from bigdl.nano.tf.keras import InferenceOptimizer
 
 
 def throughput_calculate_helper(iterrun, func, model, input_sample):
@@ -45,5 +47,10 @@ if __name__ == "__main__":
         tf.config.threading.set_inter_op_parallelism_threads(0)
         tf.config.threading.set_intra_op_parallelism_threads(thread_num)
     params = pickle.load(open(param_file, "rb"))
+    if params["method"] != "original":
+        model_dir = os.path.dirname(param_file)
+        qmodel = InferenceOptimizer.load(model_dir, params["model"])
+        params["model"] = qmodel
+    del params["method"]
     latency = throughput_calculate_helper(**params)
     print(latency)

--- a/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/_worker.py
@@ -17,7 +17,7 @@
 import time
 import sys
 import numpy as np
-import pickle
+import cloudpickle
 import tensorflow as tf
 import os
 from bigdl.nano.tf.keras import InferenceOptimizer
@@ -46,7 +46,7 @@ if __name__ == "__main__":
         thread_num = int(thread_num)  # type: ignore
         tf.config.threading.set_inter_op_parallelism_threads(0)
         tf.config.threading.set_intra_op_parallelism_threads(thread_num)
-    params = pickle.load(open(param_file, "rb"))
+    params = cloudpickle.load(open(param_file, "rb"))
     if params["method"] != "original":
         model_dir = os.path.dirname(param_file)
         qmodel = InferenceOptimizer.load(model_dir, params["model"])

--- a/python/nano/test/tf/inference/test_inf_optimizer.py
+++ b/python/nano/test/tf/inference/test_inf_optimizer.py
@@ -37,6 +37,7 @@ class TestInferencePipeline(TestCase):
                      thread_num=8)
         model = opt.get_best_model()
         assert isinstance(opt.optimized_model_dict["original"]["latency"], float)
+        assert isinstance(opt.optimized_model_dict["static_int8"]["latency"], float)
 
     def test_optimize_model_without_accuracy(self):
         model = MobileNetV2(weights=None, input_shape=[40, 40, 3], classes=10)


### PR DESCRIPTION
## Description

In https://github.com/intel-analytics/BigDL/pull/7263, I use subprocess to calculate throughput for original model to achieve thread control.
Now use subprocess to calculate throughput for inc quantizated model, so that all model's throughput could be calculated rightly in keras `InferenceOptimizer.optimize`.

### How to test?
- [x] Unit test
