### PR TITLE
Chronos: reduce overhead during inference

### DIFF
--- a/python/chronos/src/bigdl/chronos/pytorch/utils.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/utils.py
@@ -26,14 +26,17 @@ def _inference(model, input_sample_list, batch_size):
     else:
         yhat_list = []
         sample_num = input_sample_list[0].shape[0]  # the first dim should be sample_num
-        batch_num = math.ceil(sample_num / batch_size)
-        for batch_id in range(batch_num):
-            yhat_list.append(model(
-                *tuple(map(lambda x: x[batch_id * batch_size: (batch_id + 1) * batch_size],
-                           input_sample_list))).numpy())
-        # this operation may cause performance degradation
-        yhat = np.concatenate(yhat_list, axis=0)
-        return yhat
+        if sample_num <= batch_size:
+            return model(*input_sample_list).numpy()
+        else:
+            batch_num = math.ceil(sample_num / batch_size)
+            for batch_id in range(batch_num):
+                yhat_list.append(model(
+                    *tuple(map(lambda x: x[batch_id * batch_size: (batch_id + 1) * batch_size],
+                            input_sample_list))).numpy())
+            # this operation may cause performance degradation
+            yhat = np.concatenate(yhat_list, axis=0)
+            return yhat
 
 
 def _pytorch_fashion_inference(model, input_data, batch_size=None):

--- a/python/chronos/src/bigdl/chronos/pytorch/utils.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/utils.py
@@ -33,7 +33,7 @@ def _inference(model, input_sample_list, batch_size):
             for batch_id in range(batch_num):
                 yhat_list.append(model(
                     *tuple(map(lambda x: x[batch_id * batch_size: (batch_id + 1) * batch_size],
-                            input_sample_list))).numpy())
+                               input_sample_list))).numpy())
             # this operation may cause performance degradation
             yhat = np.concatenate(yhat_list, axis=0)
             return yhat


### PR DESCRIPTION
## Description

If the input data is smaller than one batch, we don't need to use loop to divide input data and call `np.concatenate`.
This simplification can help reduce overhead during inference.

### 2. User API changes

None

### 4. How to test?
- [x] Unit test
