### PR TITLE
[ORCA] Enhance Continuous Training with TF2 PySpark Backend

### DIFF
--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -167,7 +167,7 @@ class SparkTFEstimator():
             weights = sc.broadcast(self.model_weights)
         else:
             weights = None
-        
+
         if self.optimizer_weights:
             opt_weights = sc.broadcast(self.optimizer_weights)
         else:

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -644,14 +644,14 @@ class SparkTFEstimator():
             model = load_model(**self.load_params)
 
         if set_weights:
-            if self.model_weights is not None:
-                model.set_weights(self.model_weights)
             if self.optimizer_weights is not None:
                 import tensorflow as tf
                 grad_vars = model.trainable_weights
                 zero_grads = [tf.zeros_like(w) for w in grad_vars]
                 model.optimizer.apply_gradients(zip(zero_grads, grad_vars))
                 model.optimizer.set_weights(self.optimizer_weights)
+            if self.model_weights is not None:
+                model.set_weights(self.model_weights)
         return model
 
     @property

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -266,8 +266,10 @@ class SparkRunner:
                                     def load_opt_weights():
                                         grad_vars = self.model.trainable_weights
                                         zero_grads = [tf.zeros_like(w) for w in grad_vars]
-                                        self.model.optimizer.apply_gradients(zip(zero_grads, grad_vars))
-                                        self.model.optimizer.set_weights(self.optimizer_weights.value)
+                                        self.model.optimizer.apply_gradients(
+                                            zip(zero_grads, grad_vars))
+                                        self.model.optimizer.set_weights(
+                                            self.optimizer_weights.value)
                                     self.strategy.run(load_opt_weights)
                             else:
                                 self.model = tf.keras.models.load_model(self.model_load)

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -260,8 +260,6 @@ class SparkRunner:
                         else:
                             if self.model_creator is not None:
                                 self.model = self.model_creator(self.config)
-                                if self.model_weights:
-                                    self.model.set_weights(self.model_weights.value)
                                 if self.optimizer_weights:
                                     def load_opt_weights():
                                         grad_vars = self.model.trainable_weights
@@ -271,6 +269,8 @@ class SparkRunner:
                                         self.model.optimizer.set_weights(
                                             self.optimizer_weights.value)
                                     self.strategy.run(load_opt_weights)
+                                if self.model_weights:
+                                    self.model.set_weights(self.model_weights.value)
                             else:
                                 self.model = tf.keras.models.load_model(self.model_load)
 

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
@@ -660,7 +660,7 @@ class TestTFEstimator(TestCase):
             after_res = est.predict(df, feature_cols=["feature"]).collect()
             pred_res = np.concatenate([part["prediction"] for part in after_res])
             assert np.array_equal(expect_res, pred_res)
-            assert np.array_equal(pre_opt_weights, after_model_weights)
+            assert np.array_equal(pre_opt_weights, after_opt_weights)
 
             # test continuous training
             est.fit(df, epochs=5, batch_size=4, steps_per_epoch=25,
@@ -671,7 +671,7 @@ class TestTFEstimator(TestCase):
             # check optimizer weights
             new_model = est.get_model(set_weights=True)
             new_opt_weights = new_model.optimizer.get_weights()
-            assert not np.array_equal(after_model_weights, new_model_weights)
+            assert not np.array_equal(after_opt_weights, new_opt_weights)
             # test continuous evaluation
             res = est.evaluate(df, batch_size=4, num_steps=25, feature_cols=["feature"],
                                label_cols=["label"])

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf_spark_estimator.py
@@ -637,6 +637,9 @@ class TestTFEstimator(TestCase):
                         validation_data=df,
                         validation_steps=1)
 
+            # check optimizer weights
+            pre_model = trainer.get_model(set_weights=True)
+            pre_opt_weights = pre_model.optimizer.get_weights()
             # save model as h5 format
             trainer.save(os.path.join(temp_dir, "saved_model.h5"))
             before_res = trainer.predict(df, feature_cols=["feature"]).collect()
@@ -650,10 +653,14 @@ class TestTFEstimator(TestCase):
                 backend="spark")
 
             est.load(os.path.join(temp_dir, "saved_model.h5"))
+            # check optimizer weights
+            after_model = est.get_model(set_weights=True)
+            after_opt_weights = after_model.optimizer.get_weights()
             # test continous predicting
             after_res = est.predict(df, feature_cols=["feature"]).collect()
             pred_res = np.concatenate([part["prediction"] for part in after_res])
             assert np.array_equal(expect_res, pred_res)
+            assert np.array_equal(pre_opt_weights, after_model_weights)
 
             # test continuous training
             est.fit(df, epochs=5, batch_size=4, steps_per_epoch=25,
@@ -661,6 +668,10 @@ class TestTFEstimator(TestCase):
                     label_cols=["label"],
                     validation_data=df,
                     validation_steps=1)
+            # check optimizer weights
+            new_model = est.get_model(set_weights=True)
+            new_opt_weights = new_model.optimizer.get_weights()
+            assert not np.array_equal(after_model_weights, new_model_weights)
             # test continuous evaluation
             res = est.evaluate(df, batch_size=4, num_steps=25, feature_cols=["feature"],
                                label_cols=["label"])


### PR DESCRIPTION
## Description
Fix for https://github.com/intel-analytics/BigDL/issues/7268, which needs to enhance the continuous training pipeline when `model_dir` is None.

This PR only supports TensorFlow 2.10.0 and previous versions, for 2.11.0 version, we will complete the support in PR https://github.com/intel-analytics/BigDL/pull/7423 later.

### 1. Why the change?
For the previous implement, the optimizer weight is not supported to save, which could cause a gap when training with loading a saved model.

### 2. User API changes
N/A

### 3. Summary of the change 
Support return `optimizer_weights` after the training step, and re-create the model by loading `optimizer_weights` when calling `get_model` (same as `model_weights` does).

### 4. How to test?
- [x] Unit test

