### PR TITLE
Nano: Add a multi-stage pipeline

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/__init__.py
@@ -43,6 +43,7 @@ if platform.system() == "Linux":
 
 from .dispatcher import patch_torch, unpatch_torch
 from bigdl.nano.pytorch.inference import InferenceOptimizer
+from bigdl.nano.pytorch.inference import Pipeline
 from bigdl.nano.pytorch.trainer import Trainer
 from bigdl.nano.pytorch.torch_nano import TorchNano
 from bigdl.nano.pytorch.torch_nano import nano

--- a/python/nano/src/bigdl/nano/pytorch/inference/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/__init__.py
@@ -16,3 +16,4 @@
 
 
 from .optimizer import InferenceOptimizer
+from .pipeline import Pipeline

--- a/python/nano/src/bigdl/nano/pytorch/inference/pipeline.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/pipeline.py
@@ -1,0 +1,83 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import itertools
+import multiprocessing as mp
+from multiprocessing.connection import Connection
+from typing import List, Tuple, Dict, Callable
+
+from torch import nn
+
+
+class Pipeline():
+    def __init__(self, stages: List[Tuple]):
+        conns = [reversed(mp.Pipe(duplex=False)) for _i in range(len(stages) + 1)]
+        conns = list(itertools.chain(*conns))
+        self.send_ = conns[0]
+        self.recv_ = conns[-1]
+        self.ps = [
+            self._run_stage(stage, conns[i * 2 + 1], conns[i * 2 + 2])
+            for i, stage in enumerate(stages)
+        ]
+
+    def run(self, inputs):
+        for i in inputs:
+            self.send_.send(i)
+
+        output_list = []
+        for i in inputs:
+            output = self.recv_.recv()
+            output_list.append(output)
+
+        return output_list
+
+    def _run_stage(self, stage: Tuple, recv_: Connection, send_: Connection):
+        name, func, config = stage
+        self._validate_name(name)
+        self._validate_config(config)
+
+        p = mp.Process(target=self._stage_wrapper,
+                       args=(func, recv_, send_),
+                       daemon=True)
+        p.start()
+        return p
+
+    @staticmethod
+    def _stage_wrapper(func: Callable, recv_: Connection, send_: Connection):
+        if isinstance(func, nn.Module):
+            from bigdl.nano.pytorch import InferenceOptimizer
+            with InferenceOptimizer.get_context(func):
+                while True:
+                    inputs = recv_.recv()
+                    outputs = func(inputs)
+                    send_.send(outputs)
+        else:
+            while True:
+                inputs = recv_.recv()
+                outputs = func(inputs)
+                send_.send(outputs)
+
+    @staticmethod
+    def _validate_name(name: str):
+        pass
+
+    @staticmethod
+    def _validate_config(config: Dict):
+        pass
+
+    @staticmethod
+    def _apply_config(config: Dict):
+        pass

--- a/python/nano/src/bigdl/nano/pytorch/inference/pipeline.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/pipeline.py
@@ -34,15 +34,13 @@ class Pipeline():
         ]
 
     def run(self, inputs):
+        outputs = []
         for i in inputs:
             self.send_.send(i)
+            outputs.append(None)
 
-        output_list = []
-        for i in inputs:
-            output = self.recv_.recv()
-            output_list.append(output)
-
-        return output_list
+        outputs = [self.recv_.recv() for _ in outputs]
+        return outputs
 
     def _run_stage(self, stage: Tuple, recv_: Connection, send_: Connection):
         name, func, config = stage

--- a/python/nano/test/pytorch/tests/inference/test_pipeline.py
+++ b/python/nano/test/pytorch/tests/inference/test_pipeline.py
@@ -1,0 +1,42 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+from unittest import TestCase
+from torchvision.models import resnet18
+from bigdl.nano.pytorch import Pipeline
+
+
+class TestPipeline(TestCase):
+    def test_pipeline_create(self):
+        def stage1():
+            pass
+        _pipeline = Pipeline([
+            ("preprocess", stage1, {}),
+            ("inference", stage1, {}),
+        ])
+
+    def test_pipeline_inference(self):
+        def preprocess(_i):
+            return torch.rand((1, 3, 224, 224))
+        model = resnet18(num_classes=10)
+        pipeline = Pipeline([
+            ("preprocess", preprocess, {}),
+            ("inference", model, {}),
+        ])
+        inputs = list(range(10))
+        outputs = pipeline.run(inputs)
+        assert len(outputs) == 10 and all(map(lambda o: o.shape == (1, 10), outputs))


### PR DESCRIPTION
## Description

Add a two stage pipeline, transfer data between stages using `multiprocessing.Pipe`. 

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes
like this:
```python
from bigdl.nano.pytorch.inference.pipeline import Pipeline

pipeline = Pipeline([
    ("preprocess", preprocess, {}),
    ("inference", model, {}),
])
input_paths = [
    "/root/yishuo/test.jpg"
    for i in range(100)
]
outputs = pipeline.run(input_paths)
```

**A complete example:**
```python
import time

import torch
from torchvision import transforms
from torchvision.models import resnet50

from PIL import Image

from bigdl.nano.pytorch.inference.pipeline import Pipeline


transform = transforms.Compose([
    transforms.Resize(256),
    transforms.ColorJitter(),
    transforms.Resize(128),
    transforms.ToTensor(),
])


def preprocess(img_path: str):
    img = Image.open(img_path)
    img = transform(img)
    batch = torch.stack([img for i in range(8)], 0)
    return batch


def test_pipeline(model):
    pipeline = Pipeline([
        ("preprocess", preprocess, {}),
        ("inference", model, {}),
    ])

    input_paths = [
        "/root/yishuo/test.jpg"
        for i in range(100)
    ]
    outputs = pipeline.run(input_paths)


def test_normal(model):
    input_paths = [
        "/root/yishuo/test.jpg"
        for i in range(100)
    ]
    with torch.inference_mode(True):
        for p in input_paths:
            batch = preprocess(p)
            _ = model(batch)

# warmup
model = resnet50()
with torch.inference_mode(True):
    for i in range(5):
        inputs = preprocess("/root/yishuo/test.jpg")
        _ = model(inputs)

st = time.time()
inputs = preprocess("/root/yishuo/test.jpg")
print('preprocess time:', time.time() - st)

st = time.time()
with torch.inference_mode(True):
    _ = model(inputs)
print('inference time:', time.time() - st)

st = time.time()
test_pipeline(model)
print('total pipeline time:', time.time() - st)

st = time.time()
test_normal(model)
print('total baseline time:', time.time() - st)
```

The output maybe:
```
preprocess time: 0.0673820972442627
inference time: 0.06682658195495605
total pipeline time: 8.78221607208252
total baseline time: 13.228902101516724
```

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
