### PR TITLE
[PPML] add pccs env check in start scripts

### DIFF
--- a/ppml/services/pccs/docker/run-docker-container.sh
+++ b/ppml/services/pccs/docker/run-docker-container.sh
@@ -14,6 +14,47 @@ export COMMON_NAME=server_fqdn_or_your_name
 export EMAIL_ADDRESS=your_email_address
 export HTTPS_CERT_PASSWORD=your_https_cert_password_to_use
 
+if [[ "$PCCS_IMAGE_NAME" == "your_pccs_image_name" ]] || \
+   [[ "$PCCS_IMAGE_VERSION" == "your_pccs_image_version" ]] || \
+   [[ "$PCCS_CONTAINER_NAME" == "your_pccs_container_name_to_run" ]] || \
+   [[ "$PCCS_PORT" == "pccs_port_to_use" ]]
+then
+    echo "modify pccs container configurations in the script please!"
+    exit -1
+fi
+
+if [[ "$API_KEY" == "your_intel_pcs_server_subscription_key_obtained_through_web_registeration" ]]
+then
+    echo "register PCS and modify API_KEY in the script please!"
+    exit -1
+fi
+
+if [[ "$HTTPS_PROXY_URL" == "your_usable_https_proxy_url" ]]
+then
+    echo "set proxy for pccs container please!"
+    echo "if no proxy is needed in your container environment, set HTTPS_PROXY_URL= "" "
+    exit -1
+fi
+
+if [[ "$USER_PASSWORD" == "a_password_for_pccs_user" ]] || \
+   [[ "$ADMIN_PASSWORD" == "a_password_for_pccs_admin" ]] || \
+   [[ "$HTTPS_CERT_PASSWORD" == "your_https_cert_password_to_use " ]]
+then
+    echo "modify password configurations in the script please!"
+    echo "USER_PASSWORD for pccs user token, ADMIN_PASSWORD for pccs admin token and HTTPS_CERT_PASSWORD for https cert signing"
+    exit -1
+fi
+
+if [[ "$COUNTRY_NAME" == "your_country_name" ]] || \
+   [[ "$CITY_NAME" == "your_city_name" ]] || \
+   [[ "$ORGANIZATION_NAME" == "your_organizaition_name" ]] || \
+   [[ "$EMAIL_ADDRESS" == "your_email_address" ]] || \
+   [[ "$COMMON_NAME" == "server_fqdn_or_your_name" ]]
+then
+    echo "modify https cert configurations in the script please!"
+    exit -1
+fi
+
 docker run -itd \
 --net=host \
 --name $PCCS_CONTAINER_NAME \

--- a/ppml/services/pccs/kubernetes/install-bigdl-pccs.sh
+++ b/ppml/services/pccs/kubernetes/install-bigdl-pccs.sh
@@ -14,6 +14,45 @@ export commonName=server_fqdn_or_your_name
 export emailAddress=your_email_address
 export httpsCertPassword=your_https_cert_password_to_use 
 
+if [[ "$pccsImageName" == "your_pccs_image_name" ]] || \
+   [[ "$pccsIP" == "your_pccs_ip_to_use_as" ]]
+then
+    echo "modify pccs container configurations in the script please!"
+    exit -1
+fi
+
+if [[ "$apiKey" == "your_intel_pcs_server_subscription_key_obtained_through_web_registeration" ]]
+then
+    echo "register PCS and modify API_KEY in the script please!"
+    exit -1
+fi
+
+if [[ "$httpsProxyUrl" == "your_usable_https_proxy_url" ]]
+then
+    echo "set proxy for pccs container please!"
+    echo "if no proxy is needed in your container environment, set HTTPS_PROXY_URL= "" "
+    exit -1
+fi
+
+if [[ "$userPassword" == "a_password_for_pccs_user" ]] || \
+   [[ "$adminPassword" == "a_password_for_pccs_admin" ]] || \
+   [[ "$httpsCertPassword" == "your_https_cert_password_to_use" ]]
+then
+    echo "modify password configurations in the script please!"
+    echo "USER_PASSWORD for pccs user token, ADMIN_PASSWORD for pccs admin token and HTTPS_CERT_PASSWORD for https cert signing"
+    exit -1
+fi
+
+if [[ "$countryName" == "your_country_name" ]] || \
+   [[ "$cityName" == "your_city_name" ]] || \
+   [[ "$organizaitonName" == "your_organizaition_name" ]] || \
+   [[ "$emailAddress" == "your_email_address" ]] || \
+   [[ "$commonName" == "server_fqdn_or_your_name" ]]
+then
+    echo "modify https cert configurations in the script please!"
+    exit -1
+fi
+
 ## Create k8s namespace and apply BigDL-PCCS
 kubectl create namespace bigdl-pccs
 envsubst < bigdl-pccs.yaml | kubectl apply -f -


### PR DESCRIPTION
## Description

as the title

### 1. Why the change?

to avoid user miss use a default node string as env e.g. https_url

### 2. User API changes

no

### 3. Summary of the change 

add pccs env check in start scripts

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...
