### PR TITLE
Add ./zeppelin in trusted-bigdata Dockerfile

### DIFF
--- a/ppml/trusted-bigdata/Dockerfile
+++ b/ppml/trusted-bigdata/Dockerfile
@@ -192,6 +192,7 @@ ADD ./entrypoint.sh /opt/entrypoint.sh
 ADD ./flink-entrypoint.sh /opt/flink-entrypoint.sh
 ADD ./flink-k8s-template.yaml /ppml/flink-k8s-template.yaml
 ADD ./examples /ppml/examples
+ADD ./zeppelin /ppml/zeppelin
 
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
 RUN rm $SPARK_HOME/jars/okhttp-*.jar && \


### PR DESCRIPTION
## Description

Add ./zeppelin in trusted-bigdata Dockerfile