### PR TITLE
Chronos: update dockerfile

### DIFF
--- a/docker/chronos-nightly/Dockerfile
+++ b/docker/chronos-nightly/Dockerfile
@@ -20,8 +20,8 @@ WORKDIR /opt/work
 ARG DEBIAN_FRONTEND=noninteractive
 ENV TZ=Asia/Shanghai
 
-# model: select from pytorch (default), tensorflow, prophet, arima, ml
-ARG model=pytorch
+# model: select from pytorch, tensorflow, prophet, arima, ml (default)
+ARG model=ml
 
 # auto_tuning: y (for yes) or n (default, for no)
 ARG auto_tuning=n
@@ -41,11 +41,8 @@ ADD ./docker/chronos-nightly/install-python-env.sh /opt
 ADD ./python/chronos/colab-notebook /opt/work/colab-notebook
 RUN chmod a+x /opt/install-python-env.sh
 
-RUN apt-get update --fix-missing && \
-    apt-get install -y apt-utils vim curl nano wget unzip git && \
-    apt-get install -y gcc g++ make && \
-    apt-get install -y libsm6 libxext6 libxrender-dev && \
-    apt-get install -y openjdk-8-jre && \
+RUN apt-get update && \
+    apt-get install -y gcc wget && \
     rm /bin/sh && \
     ln -sv /bin/bash /bin/sh && \
     echo "auth required pam_wheel.so use_uid" >> /etc/pam.d/su && \
@@ -56,8 +53,8 @@ RUN apt-get update --fix-missing && \
     ./Miniconda3-py37_4.12.0-Linux-x86_64.sh -b -f -p /usr/local && \
     rm Miniconda3-py37_4.12.0-Linux-x86_64.sh && \
 # python
+    conda create -y -n chronos python=3.7 setuptools=58.0.4 && \
     /opt/install-python-env.sh ${model} ${auto_tuning} ${hardware} ${inference} ${extra_dep}
 
 RUN echo "source activate chronos" > ~/.bashrc
-RUN echo "export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64/" >> ~/.bashrc
 ENV PATH /usr/local/envs/chronos/bin:$PATH

--- a/docker/chronos-nightly/README.md
+++ b/docker/chronos-nightly/README.md
@@ -1,5 +1,5 @@
-# How to use chronos in docker
-This dockerfile helps user to build a docker image where Chronos-nightly build version is deploied.
+# Use Chronos in Container (docker)
+This dockerfile helps user to build a docker image where Chronos-nightly build version is deployed.
 
 ## Build an image
 First clone the repo `BigDL` to the local.
@@ -16,11 +16,11 @@ The build args are similar to the install options in [Chronos documentation](htt
 
 ```
 model: which model or framework you want. 
-       value: pytorch (default)
+       value: pytorch
               tensorflow
               prophet
               arima
-              ml (for machine learning models).
+              ml (default, for machine learning models).
 
 auto_tuning: whether to enable auto tuning.
              value: y (for yes)
@@ -52,7 +52,7 @@ sudo docker build \
     --build-arg model=pytorch \
     --build-arg auto_tuning=y \
     --build-arg hardware=single \
-    --build-arg inference=y \
+    --build-arg inference=n \
     --build-arg extra_dep=n \
      -t chronos-nightly:b1 . # You may choose any NAME:TAG you want.
 ```
@@ -67,7 +67,7 @@ sudo docker build \
 ```
 According to your network status, this building will cost **15-30 mins**. 
 
-**Tips:** When errors happen like `E: Package 'apt-utils' has no installation candidate`, it's usually related to the bad network status. Please build with a proxy.
+**Tips:** When errors happen like `failed: Connection timed out.`, it's usually related to the bad network status. Please build with a proxy.
 
 ## Run the image
 ```bash
@@ -77,18 +77,28 @@ sudo docker run -it --rm --net=host chronos-nightly:b1 bash
 ## Use Chronos
 A conda environment is created for you automatically. `bigdl-chronos` and the necessary depenencies (based on the build args) are installed inside this environment.
 ```bash
-(chronos) root@cpx-3:/opt/work#
+(chronos) root@icx-5:/opt/work# 
+```
+```eval_rst
+.. important::
+       Considering the image size, we build docker image with the default args and upload it to dockerhub. If you use it directly, only ``bigdl-chronos`` is installed inside this environment. There are two methods to install other necessary dependencies according to your own needs:
+       1. Make sure network is available and run install command following `Install using Conda <https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html#install-using-conda>`_ , such as ``pip install --pre --upgrade bigdl-chronos[pytorch]``.
+       2. Make sure network is available and bash ``/opt/install-python-env.sh`` with build args. The values are introduced in `Build an image <## Build an image>`_.
+       .. code-block:: python
+       # bash /opt/install-python-env.sh ${model} ${auto_tuning} ${hardware} ${inference} ${extra_dep}
+       # For example, if you want to install bigdl-chronos[pytorch,inference]
+       bash /opt/install-python-env.sh pytorch n single y n
 ```
 
 ## Run unittest examples on Jupyter Notebook for a quick use
->To use jupyter notebook, you need to specify the build arg `extra_dep` to `y`.
+> Note: To use jupyter notebook, you need to specify the build arg `extra_dep` to `y`.
 
 You can run these on Jupyter Notebook on single node server if you pursue a quick use on Chronos.
 ```bash
-(chronos) root@cpx-3:/opt/work# cd /opt/work/colab-notebook #Unittest examples are here.
+(chronos) root@icx-5:/opt/work# cd /opt/work/colab-notebook #Unittest examples are here.
 ```
 ```bash
-(chronos) root@cpx-3:/opt/work# jupyter notebook --notebook-dir=./ --ip=* --allow-root #Start the Jupyter Notebook services.
+(chronos) root@icx-5:/opt/work/colab-notebook# jupyter notebook --notebook-dir=./ --ip=* --allow-root #Start the Jupyter Notebook services.
 ```
 After the Jupyter Notebook service is successfully started, you can connect to the Jupyter Notebook service from a browser.
 1. Get the IP address of the container
@@ -101,15 +111,15 @@ After the Jupyter Notebook service is successfully started, you can connect to t
 You should shut down the BigDL Docker container after using it.
 1. First, use `ctrl+p+q` to quit the container when you are still in it. 
 2. Then, you can list all the active Docker containers by command line:
-```bash
-sudo docker ps
-```
-You will see your docker containers:
-```bash
-CONTAINER ID        IMAGE                                        COMMAND                  CREATED             STATUS              PORTS               NAMES
-40de2cdad025        chronos-nightly:b1         "/opt/work/"   3 hours ago         Up 3 hours                              upbeat_al
-```
+   ```bash
+   sudo docker ps
+   ```
+   You will see your docker containers:
+   ```bash
+   CONTAINER ID   IMAGE                     COMMAND   CREATED       STATUS       PORTS     NAMES
+   d6db0ab27cac   chronos-nightly:b1        "bash"    2 hours ago   Up 2 hours             funny_aryabhata
+   ```
 3. Shut down the corresponding docker container by its ID:
-```bash
-sudo docker rm -f 40de2cdad025
-```
+   ```bash
+   sudo docker rm -f d6db0ab27cac
+   ```

--- a/docker/chronos-nightly/README.md
+++ b/docker/chronos-nightly/README.md
@@ -79,16 +79,17 @@ A conda environment is created for you automatically. `bigdl-chronos` and the ne
 ```bash
 (chronos) root@icx-5:/opt/work# 
 ```
-```eval_rst
-.. important::
-       Considering the image size, we build docker image with the default args and upload it to dockerhub. If you use it directly, only ``bigdl-chronos`` is installed inside this environment. There are two methods to install other necessary dependencies according to your own needs:
-       1. Make sure network is available and run install command following `Install using Conda <https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html#install-using-conda>`_ , such as ``pip install --pre --upgrade bigdl-chronos[pytorch]``.
-       2. Make sure network is available and bash ``/opt/install-python-env.sh`` with build args. The values are introduced in `Build an image <## Build an image>`_.
-       .. code-block:: python
-       # bash /opt/install-python-env.sh ${model} ${auto_tuning} ${hardware} ${inference} ${extra_dep}
-       # For example, if you want to install bigdl-chronos[pytorch,inference]
-       bash /opt/install-python-env.sh pytorch n single y n
-```
+> 📝**Highlight**:
+>
+> Considering the image size, we build docker image with the default args and upload it to dockerhub. If you use it directly, only `bigdl-chronos` is installed inside this environment. There are two methods to install other necessary dependencies according to your own needs:
+> 1. Make sure network is available and run install command following [Install using Conda](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html#install-using-conda), such as `pip install --pre --upgrade bigdl-chronos[pytorch]`.
+> 2. Make sure network is available and bash `/opt/install-python-env.sh` with build args. The values are introduced in [Build an image](## Build an image).
+>       ```python
+>       # bash /opt/install-python-env.sh ${model} ${auto_tuning} ${hardware} ${inference} ${extra_dep}
+>       # For example, if you want to install bigdl-chronos[pytorch,inference]
+>       bash /opt/install-python-env.sh pytorch n single y n
+>       ```
+
 
 ## Run unittest examples on Jupyter Notebook for a quick use
 > Note: To use jupyter notebook, you need to specify the build arg `extra_dep` to `y`.

--- a/docker/chronos-nightly/README.md
+++ b/docker/chronos-nightly/README.md
@@ -83,7 +83,7 @@ A conda environment is created for you automatically. `bigdl-chronos` and the ne
 >
 > Considering the image size, we build docker image with the default args and upload it to dockerhub. If you use it directly, only `bigdl-chronos` is installed inside this environment. There are two methods to install other necessary dependencies according to your own needs:
 > 1. Make sure network is available and run install command following [Install using Conda](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html#install-using-conda), such as `pip install --pre --upgrade bigdl-chronos[pytorch]`.
-> 2. Make sure network is available and bash `/opt/install-python-env.sh` with build args. The values are introduced in [Build an image](## Build an image).
+> 2. Make sure network is available and bash `/opt/install-python-env.sh` with build args. The values are introduced in [Build an image](#Build-an-image).
 >       ```python
 >       # bash /opt/install-python-env.sh ${model} ${auto_tuning} ${hardware} ${inference} ${extra_dep}
 >       # For example, if you want to install bigdl-chronos[pytorch,inference]

--- a/docker/chronos-nightly/install-python-env.sh
+++ b/docker/chronos-nightly/install-python-env.sh
@@ -1,4 +1,3 @@
-conda create -y -n chronos python=3.7 setuptools=58.0.4
 source activate chronos
 
 model=$1

--- a/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
+++ b/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
@@ -81,13 +81,19 @@ A conda environment is created for you automatically. `bigdl-chronos` and the ne
 ```
 ```eval_rst
 .. important::
+
        Considering the image size, we build docker image with the default args and upload it to dockerhub. If you use it directly, only ``bigdl-chronos`` is installed inside this environment. There are two methods to install other necessary dependencies according to your own needs:
+
        1. Make sure network is available and run install command following `Install using Conda <https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html#install-using-conda>`_ , such as ``pip install --pre --upgrade bigdl-chronos[pytorch]``.
+
        2. Make sure network is available and bash ``/opt/install-python-env.sh`` with build args. The values are introduced in `Build an image <## Build an image>`_.
+
+       ```eval_rst
        .. code-block:: python
        # bash /opt/install-python-env.sh ${model} ${auto_tuning} ${hardware} ${inference} ${extra_dep}
        # For example, if you want to install bigdl-chronos[pytorch,inference]
        bash /opt/install-python-env.sh pytorch n single y n
+       ```
 ```
 
 ## Run unittest examples on Jupyter Notebook for a quick use

--- a/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
+++ b/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
@@ -89,6 +89,7 @@ A conda environment is created for you automatically. `bigdl-chronos` and the ne
        2. Make sure network is available and bash ``/opt/install-python-env.sh`` with build args. The values are introduced in `Build an image <## Build an image>`_.
 
        .. code-block:: python
+
               # bash /opt/install-python-env.sh ${model} ${auto_tuning} ${hardware} ${inference} ${extra_dep}
               # For example, if you want to install bigdl-chronos[pytorch,inference]
               bash /opt/install-python-env.sh pytorch n single y n

--- a/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
+++ b/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
@@ -88,12 +88,11 @@ A conda environment is created for you automatically. `bigdl-chronos` and the ne
 
        2. Make sure network is available and bash ``/opt/install-python-env.sh`` with build args. The values are introduced in `Build an image <## Build an image>`_.
 
-       ```eval_rst
        .. code-block:: python
-       # bash /opt/install-python-env.sh ${model} ${auto_tuning} ${hardware} ${inference} ${extra_dep}
-       # For example, if you want to install bigdl-chronos[pytorch,inference]
-       bash /opt/install-python-env.sh pytorch n single y n
-       ```
+              # bash /opt/install-python-env.sh ${model} ${auto_tuning} ${hardware} ${inference} ${extra_dep}
+              # For example, if you want to install bigdl-chronos[pytorch,inference]
+              bash /opt/install-python-env.sh pytorch n single y n
+
 ```
 
 ## Run unittest examples on Jupyter Notebook for a quick use

--- a/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
+++ b/docs/readthedocs/source/doc/Chronos/Howto/docker_guide_single_node.md
@@ -16,11 +16,11 @@ The build args are similar to the install options in [Chronos documentation](htt
 
 ```
 model: which model or framework you want. 
-       value: pytorch (default)
+       value: pytorch
               tensorflow
               prophet
               arima
-              ml (for machine learning models).
+              ml (default, for machine learning models).
 
 auto_tuning: whether to enable auto tuning.
              value: y (for yes)
@@ -67,7 +67,7 @@ sudo docker build \
 ```
 According to your network status, this building will cost **15-30 mins**. 
 
-**Tips:** When errors happen like `E: Package 'apt-utils' has no installation candidate`, it's usually related to the bad network status. Please build with a proxy.
+**Tips:** When errors happen like `failed: Connection timed out.`, it's usually related to the bad network status. Please build with a proxy.
 
 ## Run the image
 ```bash
@@ -77,7 +77,17 @@ sudo docker run -it --rm --net=host chronos-nightly:b1 bash
 ## Use Chronos
 A conda environment is created for you automatically. `bigdl-chronos` and the necessary depenencies (based on the build args) are installed inside this environment.
 ```bash
-(chronos) root@cpx-3:/opt/work#
+(chronos) root@icx-5:/opt/work# 
+```
+```eval_rst
+.. important::
+       Considering the image size, we build docker image with the default args and upload it to dockerhub. If you use it directly, only ``bigdl-chronos`` is installed inside this environment. There are two methods to install other necessary dependencies according to your own needs:
+       1. Make sure network is available and run install command following `Install using Conda <https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/install.html#install-using-conda>`_ , such as ``pip install --pre --upgrade bigdl-chronos[pytorch]``.
+       2. Make sure network is available and bash ``/opt/install-python-env.sh`` with build args. The values are introduced in `Build an image <## Build an image>`_.
+       .. code-block:: python
+       # bash /opt/install-python-env.sh ${model} ${auto_tuning} ${hardware} ${inference} ${extra_dep}
+       # For example, if you want to install bigdl-chronos[pytorch,inference]
+       bash /opt/install-python-env.sh pytorch n single y n
 ```
 
 ## Run unittest examples on Jupyter Notebook for a quick use
@@ -85,10 +95,10 @@ A conda environment is created for you automatically. `bigdl-chronos` and the ne
 
 You can run these on Jupyter Notebook on single node server if you pursue a quick use on Chronos.
 ```bash
-(chronos) root@cpx-3:/opt/work# cd /opt/work/colab-notebook #Unittest examples are here.
+(chronos) root@icx-5:/opt/work# cd /opt/work/colab-notebook #Unittest examples are here.
 ```
 ```bash
-(chronos) root@cpx-3:/opt/work# jupyter notebook --notebook-dir=./ --ip=* --allow-root #Start the Jupyter Notebook services.
+(chronos) root@icx-5:/opt/work/colab-notebook# jupyter notebook --notebook-dir=./ --ip=* --allow-root #Start the Jupyter Notebook services.
 ```
 After the Jupyter Notebook service is successfully started, you can connect to the Jupyter Notebook service from a browser.
 1. Get the IP address of the container
@@ -106,10 +116,10 @@ You should shut down the BigDL Docker container after using it.
    ```
    You will see your docker containers:
    ```bash
-   CONTAINER ID        IMAGE                                        COMMAND                  CREATED             STATUS              PORTS               NAMES
-   40de2cdad025        chronos-nightly:b1         "/opt/work/"   3 hours ago         Up 3 hours                              upbeat_al
+   CONTAINER ID   IMAGE                     COMMAND   CREATED       STATUS       PORTS     NAMES
+   d6db0ab27cac   chronos-nightly:b1        "bash"    2 hours ago   Up 2 hours             funny_aryabhata
    ```
 3. Shut down the corresponding docker container by its ID:
    ```bash
-   sudo docker rm -f 40de2cdad025
+   sudo docker rm -f d6db0ab27cac
    ```


### PR DESCRIPTION
## Description

Update dockerfile to prepare for uploading chronos docker image to dockerhub.

### 1. Why the change?

When build docker image based on previous dockerfile, the image size is ~6GB. As a base image, it is really huge.

### 3. Summary of the change 

- Modify default value and simplify apt-get installation in dockerfile (The image size will be 1.48GB)
- Update readme and how-to guide

### 4. How to test?
- [x] Local test
- [x] Document test
https://binbin-doc.readthedocs.io/en/dockerfile/doc/Chronos/Howto/docker_guide_single_node.html#