### PR TITLE
[PPML] Changed app_key to api_key

### DIFF
--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-driver-template.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-driver-template.yaml
@@ -19,7 +19,7 @@ spec:
       #  valueFrom:
       #    secretKeyRef:
       #      name: kms-secret
-      #      key: app_key
+      #      key: api_key
       #- name: ATTESTATION_POLICYID
       #  valueFrom:
       #    secretKeyRef:

--- a/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-executor-template.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-gramine/base/spark-executor-template.yaml
@@ -19,7 +19,7 @@ spec:
       #  valueFrom:
       #    secretKeyRef:
       #      name: kms-secret
-      #      key: app_key
+      #      key: api_key
       #- name: ATTESTATION_POLICYID
       #  valueFrom:
       #    secretKeyRef:

--- a/ppml/trusted-big-data-ml/python/docker-graphene/spark-driver-template.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-graphene/spark-driver-template.yaml
@@ -19,7 +19,7 @@ spec:
       #  valueFrom:
       #    secretKeyRef:
       #      name: kms-secret
-      #      key: app_key
+      #      key: api_key
     volumeMounts:
       - name: enclave-key
         mountPath: /graphene/Pal/src/host/Linux-SGX/signer/enclave-key.pem

--- a/ppml/trusted-big-data-ml/python/docker-graphene/spark-executor-template.yaml
+++ b/ppml/trusted-big-data-ml/python/docker-graphene/spark-executor-template.yaml
@@ -19,7 +19,7 @@ spec:
       #  valueFrom:
       #    secretKeyRef:
       #      name: kms-secret
-      #      key: app_key
+      #      key: api_key
     volumeMounts:
       - name: enclave-key
         mountPath: /graphene/Pal/src/host/Linux-SGX/signer/enclave-key.pem

--- a/ppml/trusted-bigdata/spark-driver-template.yaml
+++ b/ppml/trusted-bigdata/spark-driver-template.yaml
@@ -25,7 +25,7 @@ spec:
       #  valueFrom:
       #    secretKeyRef:
       #      name: kms-secret
-      #      key: app_key
+      #      key: api_key
       #- name: ATTESTATION_POLICYID
       #  valueFrom:
       #    secretKeyRef:

--- a/ppml/trusted-bigdata/spark-executor-template.yaml
+++ b/ppml/trusted-bigdata/spark-executor-template.yaml
@@ -25,7 +25,7 @@ spec:
       #  valueFrom:
       #    secretKeyRef:
       #      name: kms-secret
-      #      key: app_key
+      #      key: api_key
       #- name: ATTESTATION_POLICYID
       #  valueFrom:
       #    secretKeyRef:


### PR DESCRIPTION
## Description

changed some parameter names from `app_key` to `api_key`

### 1. Why the change?

the parameter called `app_key` before is named `api_key` now


