### PR TITLE
[PPML] Change torchserve start script to allow booting multiple workers

### DIFF
--- a/ppml/trusted-deep-learning/base/start-backend-sgx.sh
+++ b/ppml/trusted-deep-learning/base/start-backend-sgx.sh
@@ -1,15 +1,19 @@
 #!/bin/bash
 port=9000
-while getopts "p:" opt
+core=""
+while getopts ":c:p:" opt
 do
     case $opt in
         p)
             port=$OPTARG
-        ;;
+            ;;
+        c)
+            core=$OPTARG
+            ;;
     esac
 done
 
 cd /ppml
 export sgx_command="/usr/bin/python3 /usr/local/lib/python3.8/dist-packages/ts/model_service_worker.py --sock-type tcp --port $port --metrics-config /ppml/metrics.yaml"
-gramine-sgx bash 2>&1 | tee backend-sgx.log
+taskset -c $core gramine-sgx bash 2>&1 | tee backend-sgx.log
 

--- a/ppml/trusted-deep-learning/base/start-frontend-sgx.sh
+++ b/ppml/trusted-deep-learning/base/start-frontend-sgx.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 configFile=""
-while getopts "c:" opt
+core=""
+while getopts ":f:c:" opt
 do
     case $opt in
         c)
             configFile=$OPTARG
-        ;;
+            ;;
+        f)
+            core=$OPTARG
+            ;;
     esac
 done
 
@@ -13,11 +17,11 @@ cd /ppml
 export sgx_command="/opt/jdk11/bin/java \
         -Dmodel_server_home=/usr/local/lib/python3.8/dist-packages \
         -cp .:/ppml/torchserve/* \
-        -Xmx30g \
-        -Xms30g \
+        -Xmx5g \
+        -Xms1g \
         org.pytorch.serve.ModelServer \
         --python /usr/bin/python3 \
         -f $configFile \
         -ncs"
-gramine-sgx bash 2>&1 | tee frontend-sgx.log
+taskset -c $core gramine-sgx bash 2>&1 | tee frontend-sgx.log
 

--- a/ppml/trusted-deep-learning/base/start-torchserve-sgx.sh
+++ b/ppml/trusted-deep-learning/base/start-torchserve-sgx.sh
@@ -10,7 +10,7 @@ usage() {
         echo "The following example command will launch 2 backend workers (as specified in /ppml/torchserve_config)."
         echo "The first backend worker will be pinned to core 0 while the second backend worker will be pinned to core 1."
         echo "The frontend worker will be pinned to core 5"
-        echo 'Example: $0 -c /ppml/torchserve_config -t "0,1" -f 5'
+        echo "Example: $0 -c /ppml/torchserve_config -t '0,1' -f 5"
         exit 0
 }
 

--- a/ppml/trusted-deep-learning/base/start-torchserve-sgx.sh
+++ b/ppml/trusted-deep-learning/base/start-torchserve-sgx.sh
@@ -73,7 +73,7 @@ do
         done
 done
 (
-        bash /ppml/torchserve/start-frontend-sgx.sh -c $configFile
+        bash /ppml/torchserve/start-frontend-sgx.sh -c $configFile -f $frontend_core
 )&
 wait
 

--- a/ppml/trusted-deep-learning/base/start-torchserve-sgx.sh
+++ b/ppml/trusted-deep-learning/base/start-torchserve-sgx.sh
@@ -1,12 +1,53 @@
 configFile=""
-while getopts "c:" opt
+backend_core_list=""
+frontend_core=""
+
+# TODO: shall we allow the user to now specify core numbers and falls back to default?
+
+usage() {
+        echo "Usage: $0 [-c <configfile>] [-b <core# for each backend worker>] [-f <core# for frontend worker>]"
+
+        echo "The following example command will launch 2 backend workers (as specified in /ppml/torchserve_config)."
+        echo "The first backend worker will be pinned to core 0 while the second backend worker will be pinned to core 1."
+        echo "The frontend worker will be pinned to core 5"
+        echo 'Example: $0 -c /ppml/torchserve_config -t "0,1" -f 5'
+        exit 0
+}
+
+
+while getopts ":b:c:f:" opt
 do
     case $opt in
+        b)
+            backend_core_list=$OPTARG
+            ;;
         c)
             configFile=$OPTARG
-        ;;
+            ;;
+        f)
+            frontend_core=$OPTARG
+            ;;
+        *)
+            echo "Error: unknown positional arguments"
+            usage
+            ;;
     esac
 done
+
+# Check backend_core_list and frontend_core has values
+if [ -z "${backend_core_list}" ] || [ -z "${frontend_core}" ]; then
+    echo "Error: please specify backend core lists and frontend core"
+    usage
+fi
+
+# Check config file exists
+if [ ! -f "${configFile}" ]; then
+    echo "Error: cannot find config file"
+    usage
+fi
+
+declare -a cores=($(echo $backend_core_list | tr "," " "))
+
 cd /ppml
 ./init.sh
 port=9000
@@ -18,10 +59,15 @@ do
                 num=${line%%,*}
                 line=${line#*,}
 
+                if [ ${#cores[@]} != $num ]; then
+                    echo "Error: worker number does not equal to the length of core list"
+                    exit 1
+                fi
+
                 for ((i=0;i<num;i++,port++))
                 do
                 (
-                        bash /ppml/torchserve/start-backend-sgx.sh -p $port
+                        bash /ppml/torchserve/start-backend-sgx.sh -p $port -c ${cores[$i]}
                 )&
                 done
         done


### PR DESCRIPTION
## Description
As stated in Gramine documentation:

`We also recommend to use core pinning via taskset or even isolating cores via isolcpus or disabling interrupts on cores via nohz_full.`

If we want to boot multiple instance of gramine, we'd better pin cores that gramine can use by using `taskset`.

### 1. Why the change?

To provide better throughput, and less enclave memory usage

### 2. User API changes

The new api will be:
```bash
./start-torchserve-sgx.sh [-c <configfile>] [-b <core# for each backend worker>] [-f <core# for frontend worker>]
```

### 3. Summary of the change 
Change torchserve start scripts to allow booting multiple gramine worker instances.

### 4. How to test?
- [x] Manually test

Tested with 16G enclave memory.
