### PR TITLE
Nano: Fix affinity detection

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/__init__.py
+++ b/python/nano/src/bigdl/nano/pytorch/__init__.py
@@ -35,7 +35,7 @@ if platform.system() == "Linux":
     preset_thread_nums = torch.get_num_threads()
     affinity_core_num = get_affinity_core_num()
 
-    if preset_thread_nums > affinity_core_num:
+    if affinity_core_num is not None and preset_thread_nums > affinity_core_num:
         register_suggestion(f"CPU Affinity is set to this program and {affinity_core_num} "
                             f"cores are binded. While PyTorch OpenMP code block will use "
                             f"{preset_thread_nums} cores, which may cause severe performance "

--- a/python/nano/src/bigdl/nano/utils/common/__init__.py
+++ b/python/nano/src/bigdl/nano/utils/common/__init__.py
@@ -44,7 +44,7 @@ from .inspect import get_default_args
 
 from .decorator import deprecated
 
-from .affinity_core import get_affinity_core_num
+from .affinity import get_affinity_core_num
 
 from .env import _env_variable_is_set
 from .env import _find_library

--- a/python/nano/src/bigdl/nano/utils/common/affinity.py
+++ b/python/nano/src/bigdl/nano/utils/common/affinity.py
@@ -16,17 +16,15 @@
 
 import os
 import warnings
-import torch
 
 
 def get_affinity_core_num():
     # When using proclist to bind cores,
     # `os.sched_getaffinity(0)` will return only the first bound core,
     # so we need to parse KMP_AFFINITY manually in this case
-    preset_thread_nums = torch.get_num_threads()
     KMP_AFFINITY = os.environ.get("KMP_AFFINITY", "")
     if "compact" in KMP_AFFINITY:
-        affinity_core_num = preset_thread_nums
+        affinity_core_num = None
     elif "proclist" in KMP_AFFINITY:
         try:
             start_pos = KMP_AFFINITY.find('[', KMP_AFFINITY.find("proclist")) + 1
@@ -42,7 +40,7 @@ def get_affinity_core_num():
             affinity_core_num = len(core_list)
         except Exception as _e:
             warnings.warn(f"Failed to parse KMP_AFFINITY: '{KMP_AFFINITY}'.")
-            affinity_core_num = preset_thread_nums
+            affinity_core_num = None
     else:
         affinity_core_num = len(os.sched_getaffinity(0))
 

--- a/python/nano/src/bigdl/nano/utils/common/affinity.py
+++ b/python/nano/src/bigdl/nano/utils/common/affinity.py
@@ -15,16 +15,19 @@
 #
 
 import os
+import warnings
+import torch
 
 
 def get_affinity_core_num():
     # When using proclist to bind cores,
     # `os.sched_getaffinity(0)` will return only the first bound core,
     # so we need to parse KMP_AFFINITY manually in this case
+    preset_thread_nums = torch.get_num_threads()
     KMP_AFFINITY = os.environ.get("KMP_AFFINITY", "")
-    if "proclist" not in KMP_AFFINITY:
-        affinity_core_num = len(os.sched_getaffinity(0))
-    else:
+    if "compact" in KMP_AFFINITY:
+        affinity_core_num = preset_thread_nums
+    elif "proclist" in KMP_AFFINITY:
         try:
             start_pos = KMP_AFFINITY.find('[', KMP_AFFINITY.find("proclist")) + 1
             end_pos = KMP_AFFINITY.find(']', start_pos)
@@ -38,7 +41,9 @@ def get_affinity_core_num():
                     core_list.extend(range(int(start), int(end) + 1))
             affinity_core_num = len(core_list)
         except Exception as _e:
-            warnings.warn(f"Failed to parse KMP_AFFINITY: '{KMP_AFFINITY}'."
-                          f" Will use default thread number: {preset_thread_nums}")
+            warnings.warn(f"Failed to parse KMP_AFFINITY: '{KMP_AFFINITY}'.")
             affinity_core_num = preset_thread_nums
+    else:
+        affinity_core_num = len(os.sched_getaffinity(0))
+
     return affinity_core_num


### PR DESCRIPTION
## Description

"compact,1,0" will cause `os.sched_getaffinity(0)` return 1, fix it.

