### PR TITLE
[Nano] Add reminder in TF BF16 infer how-to for custom Keras model

### DIFF
--- a/python/nano/tutorial/notebook/inference/tensorflow/accelerate_tensorflow_inference_onnx.ipynb
+++ b/python/nano/tutorial/notebook/inference/tensorflow/accelerate_tensorflow_inference_onnx.ipynb
@@ -99,7 +99,7 @@
       "source": [
         "> 📝 **Note**\n",
         ">\n",
-        "> Note that when you have a custom model (e.g. inherated from `tf.keras.Model`), parameter `input_spec`, which should be a (list or tuple of) `tf.TensorSpec`, is required for the `trace` function to let ONNXRuntime accelerator know the shape of the model input.\n",
+        "> Note that when you have a custom model (e.g. inherited from `tf.keras.Model`), parameter `input_spec`, which should be a (list or tuple of) `tf.TensorSpec`, is required for the `trace` function to let ONNXRuntime accelerator know the shape of the model input.\n",
         ">\n",
         "> Please refer to [API documentation](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/tensorflow.html#bigdl.nano.tf.keras.InferenceOptimizer.trace) for more information on `InferenceOptimizer.trace`."
       ]

--- a/python/nano/tutorial/notebook/inference/tensorflow/accelerate_tensorflow_inference_openvino.ipynb
+++ b/python/nano/tutorial/notebook/inference/tensorflow/accelerate_tensorflow_inference_openvino.ipynb
@@ -99,7 +99,7 @@
       "source": [
         "> 📝 **Note**\n",
         ">\n",
-        "> Note that when you have a custom model (e.g. inherated from `tf.keras.Model`), parameter `input_spec`, which should be a (list or tuple of) `tf.TensorSpec`, is required for the `trace` function to let OpenVINO accelerator know the shape of the model input.\n",
+        "> Note that when you have a custom model (e.g. inherited from `tf.keras.Model`), parameter `input_spec`, which should be a (list or tuple of) `tf.TensorSpec`, is required for the `trace` function to let OpenVINO accelerator know the shape of the model input.\n",
         ">\n",
         "> Please refer to [API documentation](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/tensorflow.html#bigdl.nano.tf.keras.InferenceOptimizer.trace) for more information on `InferenceOptimizer.trace`."
       ]

--- a/python/nano/tutorial/notebook/inference/tensorflow/tensorflow_inference_bf16.ipynb
+++ b/python/nano/tutorial/notebook/inference/tensorflow/tensorflow_inference_bf16.ipynb
@@ -134,7 +134,7 @@
       "source": [
        "> 📝 Note\n",
        ">\n",
-       "> Currently, Nano does not support BF16 quantization without extra accelerator on a custon Keras model (e.g. inherated from tf.keras.Model).\n",
+       "> Currently, Nano does not support BF16 quantization without extra accelerator on a custon Keras model (e.g. inherated from `tf.keras.Model`).\n",
        ">\n",
        "> If you want to quantize a custom Keras model in BF16, you could try to set `accelerator='openvino'` together with `precision='bf16'` instead. See the next section for more information."
       ]

--- a/python/nano/tutorial/notebook/inference/tensorflow/tensorflow_inference_bf16.ipynb
+++ b/python/nano/tutorial/notebook/inference/tensorflow/tensorflow_inference_bf16.ipynb
@@ -114,7 +114,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-       "To conduct BF16 mixed preision inference, one approach is to convert the layers (except for the input one) in the Keras model to have `bfloat16_mixed` as their dtype policy. To achieve this, you could simply **import BigDL-Nano** `InferenceOptimizer`**, and quantize your model without extra accelerator**:"
+       "To conduct BF16 mixed preision inference, one approach is to convert the layers (except for the input one) in the Keras model to have `mixed_bfloat16` as their dtype policy. To achieve this, you could simply **import BigDL-Nano** `InferenceOptimizer`**, and quantize your model without extra accelerator**:"
       ]
      },
      {

--- a/python/nano/tutorial/notebook/inference/tensorflow/tensorflow_inference_bf16.ipynb
+++ b/python/nano/tutorial/notebook/inference/tensorflow/tensorflow_inference_bf16.ipynb
@@ -134,7 +134,7 @@
       "source": [
        "> 📝 Note\n",
        ">\n",
-       "> Currently, Nano does not support BF16 quantization without extra accelerator on a custon Keras model (e.g. inherated from `tf.keras.Model`).\n",
+       "> Currently, Nano does not support BF16 quantization without extra accelerator on a custom Keras model (e.g. inherited from `tf.keras.Model`).\n",
        ">\n",
        "> If you want to quantize a custom Keras model in BF16, you could try to set `accelerator='openvino'` together with `precision='bf16'` instead. See the next section for more information."
       ]
@@ -172,7 +172,7 @@
       "source": [
        "> 📝 Note\n",
        ">\n",
-       "> Please note that, when you have a custom model to quantize (e.g. inherated from `tf.keras.Model`), you need to specify the `input_spec` parameter to let OpenVINO accelerator know the shape of the model input.\n",
+       "> Please note that, when you have a custom model to quantize (e.g. inherited from `tf.keras.Model`), you need to specify the `input_spec` parameter to let OpenVINO accelerator know the shape of the model input.\n",
        ">\n",
        "> Please refer to [API documentation](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/tensorflow.html#bigdl.nano.tf.keras.InferenceOptimizer.quantize) for more information on `InferenceOptimizer.quantize`."
       ]

--- a/python/nano/tutorial/notebook/inference/tensorflow/tensorflow_inference_bf16.ipynb
+++ b/python/nano/tutorial/notebook/inference/tensorflow/tensorflow_inference_bf16.ipynb
@@ -132,6 +132,17 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
+       "> 📝 Note\n",
+       ">\n",
+       "> Currently, Nano does not support BF16 quantization without extra accelerator on a custon Keras model (e.g. inherated from tf.keras.Model).\n",
+       ">\n",
+       "> If you want to quantize a custom Keras model in BF16, you could try to set `accelerator='openvino'` together with `precision='bf16'` instead. See the next section for more information."
+      ]
+     },
+     {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
        "## With Extra Accelerator"
       ]
      },
@@ -148,10 +159,6 @@
       "metadata": {},
       "outputs": [],
       "source": [
-       "# load the model again if you run the previous code cell \n",
-       "# to conduct bf16 quantization without extra accelerator\n",
-       "fp32_model = keras.applications.MobileNetV2(weights=\"imagenet\")\n",
-       "\n",
        "from bigdl.nano.tf.keras import InferenceOptimizer\n",
        "\n",
        "bf16_ov_model = InferenceOptimizer.quantize(fp32_model, \n",


### PR DESCRIPTION
## Description

Add note box in TF BF16 inference how-to guide to remind users that currently custom model is not supported for bf16 quantization without extra accelerator.


### How to test?
- [x] Document test: https://yuwentestdocs.readthedocs.io/en/tf-bf16-howto-custom-model-reminding/doc/Nano/Howto/Inference/TensorFlow/tensorflow_inference_bf16.html#Without-Extra-Accelertor