### PR TITLE
[Nano] Add installation option for users to choose stock TensorFlow

### DIFF
--- a/.github/workflows/nano_unit_tests_tensorflow.yml
+++ b/.github/workflows/nano_unit_tests_tensorflow.yml
@@ -34,6 +34,10 @@ jobs:
           "tensorflow_28",
           "tensorflow_29",
           "tensorflow_210",
+          "stock_tensorflow_27",
+          "stock_tensorflow_28",
+          "stock_tensorflow_29",
+          "stock_tensorflow_210"
           ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
@@ -81,6 +85,10 @@ jobs:
           "tensorflow_28",
           "tensorflow_29",
           "tensorflow_210",
+          "stock_tensorflow_27",
+          "stock_tensorflow_28",
+          "stock_tensorflow_29",
+          "stock_tensorflow_210"
           ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -104,19 +104,19 @@ def setup_package():
                                "tensorflow-estimator==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
 
     # options for stock tensorflow
-    stock_tensorflow_27_requires = ["tensorflow==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
+    stock_tensorflow_27_requires = ["tensorflow==2.7.4; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
                                     "keras==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
                                     "tensorflow-estimator==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
 
-    stock_tensorflow_28_requires = ["tensorflow==2.8.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
+    stock_tensorflow_28_requires = ["tensorflow==2.8.4; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
                                     "keras==2.8.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
                                     "tensorflow-estimator==2.8.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
 
-    stock_tensorflow_29_requires = ["tensorflow==2.9.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
+    stock_tensorflow_29_requires = ["tensorflow==2.9.3; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
                                     "keras==2.9.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
                                     "tensorflow-estimator==2.9.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]                         
 
-    stock_tensorflow_210_requires = ["tensorflow==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
+    stock_tensorflow_210_requires = ["tensorflow==2.10.1; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
                                     "keras==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
                                     "tensorflow-estimator==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]  
 

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -78,47 +78,31 @@ def setup_package():
     tensorflow_27_requires = ["intel-tensorflow==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
                               platform_system!='Darwin'",
                               "tensorflow==2.7.0; platform_machine=='x86_64' and \
-                              platform_system=='Darwin'",
-                              "keras==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
-                              "tensorflow-estimator==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
+                              platform_system=='Darwin'"]
 
     tensorflow_28_requires = ["intel-tensorflow==2.8.0; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
                               platform_system!='Darwin'",
                               "tensorflow==2.8.0; platform_machine=='x86_64' and \
-                              platform_system=='Darwin'",
-                              "keras==2.8.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
-                              "tensorflow-estimator==2.8.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
+                              platform_system=='Darwin'"]
 
     tensorflow_29_requires = ["intel-tensorflow==2.9.1; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
                               platform_system!='Darwin'",
                               "tensorflow==2.9.0; platform_machine=='x86_64' and \
-                              platform_system=='Darwin'",
-                              "keras==2.9.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
-                              "tensorflow-estimator==2.9.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
+                              platform_system=='Darwin'"]
 
     tensorflow_210_requires = ["intel-tensorflow==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
                                platform_system!='Darwin'",
                                "tensorflow==2.10.0; platform_machine=='x86_64' and \
-                               platform_system=='Darwin'",
-                               "keras==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
-                               "tensorflow-estimator==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
+                               platform_system=='Darwin'"]
 
     # options for stock tensorflow
-    stock_tensorflow_27_requires = ["tensorflow==2.7.4; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
-                                    "keras==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
-                                    "tensorflow-estimator==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
+    stock_tensorflow_27_requires = ["tensorflow==2.7.4; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
 
-    stock_tensorflow_28_requires = ["tensorflow==2.8.4; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
-                                    "keras==2.8.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
-                                    "tensorflow-estimator==2.8.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
+    stock_tensorflow_28_requires = ["tensorflow==2.8.4; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
 
-    stock_tensorflow_29_requires = ["tensorflow==2.9.3; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
-                                    "keras==2.9.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
-                                    "tensorflow-estimator==2.9.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]                         
+    stock_tensorflow_29_requires = ["tensorflow==2.9.3; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]                         
 
-    stock_tensorflow_210_requires = ["tensorflow==2.10.1; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
-                                    "keras==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
-                                    "tensorflow-estimator==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]  
+    stock_tensorflow_210_requires = ["tensorflow==2.10.1; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]  
 
     tensorflow_common_requires = ["tf2onnx==1.13.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
 

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -74,43 +74,64 @@ def download_libs(url: str):
 
 def setup_package():
 
-    # all intel-tensorflow is only avaliable for linux now
+    # all intel-tensorflow is only avaliable for linux and windows now
     tensorflow_27_requires = ["intel-tensorflow==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
                               platform_system!='Darwin'",
                               "tensorflow==2.7.0; platform_machine=='x86_64' and \
                               platform_system=='Darwin'",
                               "keras==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
                               "tensorflow-estimator==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
-    
+
     tensorflow_28_requires = ["intel-tensorflow==2.8.0; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
                               platform_system!='Darwin'",
                               "tensorflow==2.8.0; platform_machine=='x86_64' and \
                               platform_system=='Darwin'",
                               "keras==2.8.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
                               "tensorflow-estimator==2.8.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
-    
+
     tensorflow_29_requires = ["intel-tensorflow==2.9.1; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
                               platform_system!='Darwin'",
                               "tensorflow==2.9.0; platform_machine=='x86_64' and \
                               platform_system=='Darwin'",
                               "keras==2.9.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
                               "tensorflow-estimator==2.9.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
-    
+
     tensorflow_210_requires = ["intel-tensorflow==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
                                platform_system!='Darwin'",
                                "tensorflow==2.10.0; platform_machine=='x86_64' and \
                                platform_system=='Darwin'",
                                "keras==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
                                "tensorflow-estimator==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
-    
+
+    # options for stock tensorflow
+    stock_tensorflow_27_requires = ["tensorflow==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
+                                    "keras==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
+                                    "tensorflow-estimator==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
+
+    stock_tensorflow_28_requires = ["tensorflow==2.8.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
+                                    "keras==2.8.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
+                                    "tensorflow-estimator==2.8.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
+
+    stock_tensorflow_29_requires = ["tensorflow==2.9.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
+                                    "keras==2.9.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
+                                    "tensorflow-estimator==2.9.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]                         
+
+    stock_tensorflow_210_requires = ["tensorflow==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
+                                    "keras==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')",
+                                    "tensorflow-estimator==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]  
+
     tensorflow_common_requires = ["tf2onnx==1.13.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
 
-    # default pytorch_dep
+    # default tensorflow_dep
     tensorflow_requires = tensorflow_29_requires + tensorflow_common_requires
     tensorflow_210_requires += tensorflow_common_requires
     tensorflow_29_requires += tensorflow_common_requires
     tensorflow_28_requires += tensorflow_common_requires
     tensorflow_27_requires += tensorflow_common_requires
+    stock_tensorflow_27_requires += tensorflow_common_requires
+    stock_tensorflow_28_requires += tensorflow_common_requires
+    stock_tensorflow_29_requires += tensorflow_common_requires
+    stock_tensorflow_210_requires += tensorflow_common_requires
 
     # ipex is only avaliable for linux now
     pytorch_113_requires = ["torch==1.13.1",
@@ -196,6 +217,10 @@ def setup_package():
                         "tensorflow_28": tensorflow_28_requires,
                         "tensorflow_29": tensorflow_29_requires,
                         "tensorflow_210": tensorflow_210_requires,
+                        "stock_tensorflow_27": stock_tensorflow_27_requires,
+                        "stock_tensorflow_28": stock_tensorflow_28_requires,
+                        "stock_tensorflow_29": stock_tensorflow_29_requires,
+                        "stock_tensorflow_210": stock_tensorflow_210_requires,
                         "pytorch": pytorch_requires,
                         "pytorch_113": pytorch_113_requires,
                         "pytorch_112": pytorch_112_requires,


### PR DESCRIPTION
## Description

Add installation option for users to choose stock TensorFlow when installing Nano

### 1. Why the change?

- For TensorFlow users, they may want to use `tensorflow` instead of `intel-tensorflow` for some cases.
- For the further integration of ITEX (release version 1.0.0 and 1.1.0), which currently requires stock TensorFlow, the installation option of stock TensorFlow may also be needed. 

### 2. User API changes

N/A

### 3. Summary of the change 

- Add installation option for users to choose stock TensorFlow when installing Nano
- Removed the manually-added requirements for `keras` and `tensorflow-estimator`
- Add related workflows for action tests

### 4. How to test?
- [x] Unit test

### 5. New dependencies

N/A

**TO DO:** In the next PR, we need to update the installation panel.