### PR TITLE
Orca:Support Multiple outputs in prediction

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/maincallback.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/maincallback.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 #
 from .base import Callback
+import torch
 from bigdl.dllib.utils.log4Error import invalidInputError
 
 
@@ -91,3 +92,18 @@ class MainCallback(Callback):
         Any behavior inconsistent with the default training behavior should be overridden here.
         """
         self.on_iter_forward(runner)
+
+    def on_pred_forward(self, runner):
+        """
+        Called during validate.
+        Any behavior inconsistent with the default training behavior should be overridden here.
+        """
+        output = runner.model(*runner.batch)
+
+        if len(output.size()) > 1:
+            # In case there is extra trailing dimensions.
+            for i in reversed(range(1, len(output.size()))):
+                output = torch.squeeze(output, i)
+
+        # todo support multi-output model
+        runner.output = output.detach().numpy()

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -378,7 +378,7 @@ class PyTorchRayEstimator(BaseRayEstimator):
 
             remote_worker_stats = []
             for shard, worker in zip(shards, self.remote_workers):
-                worker_stats = worker.predict.remote(data_creator, batch_size, profile)
+                worker_stats = worker.predict.remote(data_creator, batch_size, profile, callbacks)
                 remote_worker_stats.append(worker_stats)
             result = ray.data.from_numpy(remote_worker_stats).map(
                 lambda r: {"prediction_result": r["value"]})

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_spark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_spark_estimator.py
@@ -453,5 +453,3 @@ class PyTorchSparkEstimator(OrcaSparkEstimator):
         :return:
         """
         self.estimator.set_l2_norm_gradient_clipping(clip_norm=clip_norm)
-
-# modified in 1

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_spark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_spark_estimator.py
@@ -453,3 +453,5 @@ class PyTorchSparkEstimator(OrcaSparkEstimator):
         :return:
         """
         self.estimator.set_l2_norm_gradient_clipping(clip_norm=clip_norm)
+
+# modified in 1

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -777,3 +777,5 @@ class TorchRunner(BaseRunner):
         """First or only scheduler(s) created by the ``scheduler_creator``."""
         if self.schedulers:
             return self.schedulers[0]
+
+# Modified in 1

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -581,7 +581,6 @@ class TorchRunner(BaseRunner):
         """Evaluates the model on the validation data set."""
         config = copy.copy(self.config)
         self._toggle_profiling(profile=profile)
-        callbacks = callbacks or []
 
         params = {"batch_size": batch_size, "shuffle": False}
         for arg in ["shuffle", "sampler", "batch_sampler", "num_workers", "collate_fn",
@@ -625,7 +624,7 @@ class TorchRunner(BaseRunner):
                 self.batch_idx = batch_idx
 
                 self.call_hook(callbacks, "before_pred_iter")
-                result.append(self.predict_batch(self.batch))
+                result.append(self.predict_batch(self.batch, callbacks=callbacks))
                 self.call_hook(callbacks, "after_pred_iter")
 
                 del self.batch

--- a/python/orca/src/bigdl/orca/learn/pytorch/utils.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/utils.py
@@ -318,3 +318,24 @@ def mean_reduce_stats(worker_stats, res_stats=None):
         else:
             res_stats[stat_key] = stat_value
     return res_stats
+
+def index_concatenate(x, axis=0):
+    if len(x)==0:
+        return None
+
+    if isinstance(x[0], np.ndarray):
+        return np.concatenate(x, axis)
+    elif isinstance(x[0], tuple):
+        return tuple(index_concatenate(item, axis) for item in x)
+    elif isinstance(x[0], list):
+        return [index_concatenate(item, axis) for item in x]
+    elif isinstance(x[0], dict):
+        res = {}
+        for k in x[0].keys():
+            res[k] = index_concatenate([item[k] for item in x])
+        return res
+    else:
+        invalidInputError(False,
+                          "data should be an ndarray, a dict of ndarrays, a tuple of ndarrays"
+                          " or a list of ndarrays, please check your input")
+

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
@@ -428,7 +428,7 @@ class TestPyTorchEstimator(TestCase):
                                    feature_cols=["f1", "f2"])
         result.collect()
 
-    def test_unenven_data(self):
+    def test_uneven_data(self):
         sc = init_nncontext()
         spark = SparkSession.builder.getOrCreate()
         rdd = sc.range(0, 100).repartition(3)

--- a/python/orca/test/bigdl/orca/learn/test_pytorch_basic.py
+++ b/python/orca/test/bigdl/orca/learn/test_pytorch_basic.py
@@ -85,6 +85,28 @@ class Net(nn.Module):
         return y
 
 
+class MultiOutputNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(50, 50)
+        self.relu1 = nn.ReLU()
+        self.dout = nn.Dropout(0.2)
+        self.fc2 = nn.Linear(50, 100)
+        self.prelu = nn.PReLU(1)
+        self.out = nn.Linear(100, 2)
+        self.out_act = nn.Sigmoid()
+
+    def forward(self, input_):
+        a1 = self.fc1(input_)
+        h1 = self.relu1(a1)
+        dout = self.dout(h1)
+        a2 = self.fc2(dout)
+        h2 = self.prelu(a2)
+        a3 = self.out(h2)
+        y = self.out_act(a3)
+        return y[:0], y[:1]
+
+
 class IdentityNet(nn.Module):
     def __init__(self):
         super().__init__()


### PR DESCRIPTION
### 1. Why the change?

We used to assume our predict output is a single ndarray, but there are many models have multiple outputs. This PR enables multiple outputs in prediction with hook mechanism.

### 2. User API changes

Add callback point `on_pred_forward` in MainCallback for users to implement their own logic.

### 3. Summary of the change 

1. Add callback point `on_pred_forward` in MainCallback
2. Recursively aggregate various forms of outputs.

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

Related issue: https://github.com/intel-analytics/BigDL/issues/7348
