### PR TITLE
Chronos: add nbeatsforecaster hpo and uts

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
@@ -167,7 +167,7 @@ class NBeatsForecaster(BasePytorchForecaster):
         self.onnx_available = True
         self.quantize_available = True
         self.checkpoint_callback = True
-        self.use_hpo = False
+        self.use_hpo = True
 
         super().__init__()
 


### PR DESCRIPTION
## Description

### 1. Why the change?

per #7560 request, NbeatsForecaster now support hpo and `tune` methods. A workaround to use this function in previous stable version is also stated in the issue.

### 2. User API changes

nothing, the `tune` method for NBeatsForecaster is the same as other forecasters

### 3. Summary of the change 

1. make the hpo support flag true
2. add some uts

### 4. How to test?
- [ ] Unit test
