### PR TITLE
Nano: add compressed saving logic for accelerator=None/ipex

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -117,4 +117,5 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                                        jit_strict=status.get('jit_strict', True),
                                        jit_method=status.get('jit_method', None),
                                        weights_prepack=status.get('weights_prepack', None),
-                                       enable_onednn=status.get('enable_onednn', True))
+                                       enable_onednn=status.get('enable_onednn', True),
+                                       compress_to_bf16=status.get('compress_to_bf16', True),)

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -253,4 +253,5 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                 bf16_sd = transform_state_dict_to_dtype(self.original_state_dict, dtype="bf16")
                 torch.save(bf16_sd, path / "ckpt.pth")
             else:
+                self.compress_to_bf16 = False
                 torch.save(self.original_state_dict, path / "ckpt.pth")

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_quantization_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_quantization_model.py
@@ -165,5 +165,5 @@ class PytorchIPEXQuantizationModel(AcceleratedLightningModule):
                                             inplace=inplace,
                                             jit_strict=status["jit_strict"])
 
-    def _save_model(self, path):
+    def _save_model(self, path, compress_to_bf16=False):
         self.model.save(path / "ckpt.pth")

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
@@ -74,5 +74,5 @@ class PytorchQuantizedModel(AcceleratedLightningModule):
             thread_num = int(status['thread_num'])
         return PytorchQuantizedModel(qmodel, thread_num=thread_num)
 
-    def _save_model(self, path):
+    def _save_model(self, path, compress_to_bf16=False):
         self.quantized.save(path)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/model.py
@@ -51,7 +51,7 @@ class KerasQuantizedModel(AcceleratedKerasModel):
                        "compile_path": "inc_saved_model_compile.pkl"})
         return status
 
-    def _save_model(self, path):
+    def _save_model(self, path, compress_to_bf16=False):
         self.model.save(path)
         # save normal attrs
         attrs = {"_output_shape": self._output_shape}

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/core/onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/core/onnxruntime_model.py
@@ -80,7 +80,7 @@ class ONNXRuntimeModel:
         self.ortsess = ort.InferenceSession(onnx_path_or_bytes, sess_options=sess_options)
         self._forward_args = list(map(lambda x: x.name, self.ortsess.get_inputs()))
 
-    def _save_model(self, path):
+    def _save_model(self, path, compress_to_bf16=False):
         """
         Save ONNXRuntimeModel to local as an onnx file
 

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -141,6 +141,6 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
         return PytorchONNXRuntimeModel(str(onnx_path),
                                        onnxruntime_session_options=onnxruntime_session_options)
 
-    def _save_model(self, path):
+    def _save_model(self, path, compress_to_bf16=False):
         onnx_path = Path(path) / self.status['onnx_path']
         super()._save_model(onnx_path)

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/tensorflow_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/tensorflow_onnxruntime_model.py
@@ -154,7 +154,7 @@ class KerasONNXRuntimeModel(ONNXRuntimeModel, AcceleratedKerasModel):
                 model.compile(**kwargs)
         return model
 
-    def _save_model(self, path):
+    def _save_model(self, path, compress_to_bf16=False):
         onnx_path = Path(path) / self.status['onnx_path']
         super()._save_model(onnx_path)
         attrs = {"_default_kwargs": self._default_kwargs,

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -171,7 +171,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                       config=config)
         return self
 
-    def _save_model(self, path):
+    def _save_model(self, path, compress_to_bf16=False):
         """
         Save PytorchOpenVINOModel to local as xml and bin file
 

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -166,7 +166,7 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
                 model.compile(**kwargs)
         return model
 
-    def _save_model(self, path):
+    def _save_model(self, path, compress_to_bf16=False):
         """
         Save KerasOpenVINOModel to local as xml and bin file
 

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -22,7 +22,8 @@ from bigdl.nano.utils.pytorch import generate_channels_last_available,\
     apply_proper_channels_last
 from bigdl.nano.pytorch.model import AcceleratedLightningModule
 from bigdl.nano.utils.common import invalidInputError
-from bigdl.nano.utils.pytorch import TORCH_VERSION_LESS_1_10, TORCH_VERSION_LESS_1_12
+from bigdl.nano.utils.pytorch import TORCH_VERSION_LESS_1_10, TORCH_VERSION_LESS_1_12, \
+    transform_state_dict_to_dtype
 from bigdl.nano.utils.common import _bf16_checker
 from bigdl.nano.pytorch.context_manager import generate_context_manager
 
@@ -35,7 +36,8 @@ invalidInputError(
 class BF16Model(AcceleratedLightningModule):
     """Model of BFloat16 with auto mixed precision."""
 
-    def __init__(self, model, input_sample=None, channels_last=None, channels_last_available=[], thread_num=None):  # noqa
+    def __init__(self, model, input_sample=None, channels_last=None,
+                 channels_last_available=[], thread_num=None, compress_to_bf16=False):  # noqa
         """
         This is the accelerated model for BFloat16 with auto mixed precision.
 
@@ -50,6 +52,7 @@ class BF16Model(AcceleratedLightningModule):
         self.model = model  # use mixed precision instead of complete precision
         self.channels_last = channels_last
         self.thread_num = thread_num
+        self.compress_to_bf16 = compress_to_bf16
         if self.channels_last is True:
             try:
                 self.model = self.model.to(memory_format=torch.channels_last)
@@ -190,7 +193,8 @@ class BF16Model(AcceleratedLightningModule):
         status.update({"channels_last": self.channels_last,
                        "channels_last_available": self.channels_last_available,
                        "checkpoint": "ckpt.pth",
-                       "thread_num": self.thread_num})
+                       "thread_num": self.thread_num,
+                       "compress_to_bf16": self.compress_to_bf16})
         return status
 
     @staticmethod
@@ -199,6 +203,8 @@ class BF16Model(AcceleratedLightningModule):
         checkpoint_path = path / status['checkpoint']
         state_dict = torch.load(checkpoint_path)
         model.eval()
+        if status['compress_to_bf16']:
+            state_dict = transform_state_dict_to_dtype(state_dict, dtype="fp32")
         model.load_state_dict(state_dict)
         thread_num = status.get('thread_num', None)
         if thread_num == {}:
@@ -207,12 +213,15 @@ class BF16Model(AcceleratedLightningModule):
             thread_num = int(status['thread_num'])
         return BF16Model(model, channels_last=status['channels_last'],
                          channels_last_available=status['channels_last_available'],
-                         thread_num=thread_num)
+                         thread_num=thread_num,
+                         compress_to_bf16=status['compress_to_bf16'])
 
     def _save_model(self, path, compress_to_bf16=False):
         if compress_to_bf16:
             bf16_model = self.model.bfloat16()
             torch.save(bf16_model.state_dict(), path / "ckpt.pth")
+            self.compress_to_bf16 = True
             self.model.float()
         else:
             torch.save(self.model.state_dict(), path / "ckpt.pth")
+            self.compress_to_bf16 = False

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -209,5 +209,10 @@ class BF16Model(AcceleratedLightningModule):
                          channels_last_available=status['channels_last_available'],
                          thread_num=thread_num)
 
-    def _save_model(self, path):
-        torch.save(self.model.state_dict(), path / "ckpt.pth")
+    def _save_model(self, path, compress_to_bf16=False):
+        if compress_to_bf16:
+            bf16_model = self.model.bfloat16()
+            torch.save(bf16_model.state_dict(), path / "ckpt.pth")
+            self.model.float()
+        else:
+            torch.save(self.model.state_dict(), path / "ckpt.pth")

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -1143,15 +1143,17 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             return _context_manager
 
     @staticmethod
-    def save(model: nn.Module, path):
+    def save(model: nn.Module, path, compress_to_bf16=False):
         """
         Save the model to local file.
 
         :param model: Any model of torch.nn.Module, including all models accelareted by
                InferenceOptimizer.trace/InferenceOptimizer.quantize.
         :param path: Path to saved model. Path should be a directory.
+        :param compress_to_bf16: Bool. This parameter only effective for jit, ipex or pure
+               pytorch model with fp32 or bf16 precision.
         """
-        save_model(model, path)
+        save_model(model, path, compress_to_bf16)
 
     @staticmethod
     def load(path, model: Optional[nn.Module] = None, input_sample=None,

--- a/python/nano/src/bigdl/nano/utils/common/model.py
+++ b/python/nano/src/bigdl/nano/utils/common/model.py
@@ -47,7 +47,7 @@ class AcceleratedModel(ABC):
         with open(meta_path, 'w') as f:
             yaml.safe_dump(self.status, f)
 
-    def _save_model(self, path):
+    def _save_model(self, path, compress_to_bf16=False):
         """
         Save the model file to directory.
 
@@ -55,7 +55,7 @@ class AcceleratedModel(ABC):
         """
         invalidInputError(False, "Saving function is not implemented.")
 
-    def _save(self, path):
+    def _save(self, path, compress_to_bf16=False):
         """
         Save the model to local file.
 
@@ -63,7 +63,7 @@ class AcceleratedModel(ABC):
         """
         path = Path(path)
         Path.mkdir(path, exist_ok=True)
-        self._save_model(path)
+        self._save_model(path, compress_to_bf16=compress_to_bf16)
         self._dump_status(path)
 
     @property

--- a/python/nano/src/bigdl/nano/utils/common/model.py
+++ b/python/nano/src/bigdl/nano/utils/common/model.py
@@ -64,7 +64,7 @@ class AcceleratedModel(ABC):
         path = Path(path)
         Path.mkdir(path, exist_ok=True)
         self._save_model(path, compress_to_bf16=compress_to_bf16)
-        self._dump_status(path)
+        self._dump_status(path)  # don't move this before _save_model
 
     @property
     def status(self):

--- a/python/nano/src/bigdl/nano/utils/pytorch/__init__.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/__init__.py
@@ -47,4 +47,5 @@ from .input_sample import complement_input_sample
 from .convert import export_to_onnx
 
 from .save import save_model
+from .save import transform_state_dict_to_dtype
 from .load import load_model

--- a/python/nano/src/bigdl/nano/utils/pytorch/load.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/load.py
@@ -24,7 +24,8 @@ import torch.nn as nn
 import pytorch_lightning as pl
 
 from bigdl.nano.utils.common import invalidInputError
-from bigdl.nano.utils.pytorch import patch_attrs_from_model_to_object
+from bigdl.nano.utils.pytorch import patch_attrs_from_model_to_object, \
+    transform_state_dict_to_dtype
 
 
 def load_model(path, model: pl.LightningModule = None, input_sample=None,
@@ -92,6 +93,8 @@ def load_model(path, model: pl.LightningModule = None, input_sample=None,
         if checkpoint_path:
             checkpoint_path = path / metadata['checkpoint']
             state_dict = torch.load(checkpoint_path, map_location='cpu')
+            if metadata['compress_to_bf16']:
+                state_dict = transform_state_dict_to_dtype(state_dict, dtype="fp32")
             model.load_state_dict(state_dict)
             # patch ContextMagager to original model to keep behaviour consitent
             model._nano_context_manager = \

--- a/python/nano/src/bigdl/nano/utils/pytorch/save.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/save.py
@@ -16,31 +16,55 @@
 
 import yaml
 from pathlib import Path
+import copy
 
 import torch
 import pytorch_lightning as pl
 
 
-def save_model(model: pl.LightningModule, path):
+def save_model(model: pl.LightningModule, path, compress_to_bf16=False):
     """
     Save the model to local file.
 
     :param model: Any model of torch.nn.Module, including all models accelareted by
             Trainer.trace/Trainer.quantize.
     :param path: Path to saved model. Path should be a directory.
+    :param compress_to_bf16: Bool. This parameter only effective for jit, ipex or pure
+            pytorch model with fp32 or bf16 precision.
     """
     path = Path(path)
     path.mkdir(parents=path.parent, exist_ok=True)
     if hasattr(model, '_save'):
-        model._save(path)
+        model._save(path, compress_to_bf16=compress_to_bf16)
     else:
         # typically for models of nn.Module, pl.LightningModule type
         meta_path = Path(path) / "nano_model_meta.yml"
-        with open(meta_path, 'w+') as f:
-            metadata = {
-                'ModelType': 'PytorchModel',
-                'checkpoint': 'saved_weight.pt'
-            }
-            yaml.safe_dump(metadata, f)
+        metadata = {
+            'ModelType': 'PytorchModel',
+            'checkpoint': 'saved_weight.pt',
+            'compress_to_bf16': False
+        }
         checkpoint_path = path / metadata['checkpoint']
-        torch.save(model.state_dict(), checkpoint_path)
+        if compress_to_bf16:
+            bf16_sd = transform_state_dict_to_dtype(model.state_dict(), dtype="bf16")
+            torch.save(bf16_sd, checkpoint_path)
+            metadata['compress_to_bf16'] = True
+        else:
+            torch.save(model.state_dict(), checkpoint_path)
+        with open(meta_path, 'w+') as f:
+            yaml.safe_dump(metadata, f)
+
+
+def transform_state_dict_to_dtype(original_state_dict, dtype="bf16"):
+    '''
+    This function will transform a state dict to bf16
+    '''
+    # following block may fail
+    sd_copy = copy.deepcopy(original_state_dict)
+    for name in original_state_dict:
+        if sd_copy[name].is_floating_point():
+            if dtype == "bf16":
+                sd_copy[name] = original_state_dict[name].bfloat16()
+            if dtype == "fp32":
+                sd_copy[name] = original_state_dict[name].float()
+    return sd_copy


### PR DESCRIPTION
## Description

### 1. Why the change?
Currently, `InferenceOptimizer.save` save fp32 parameter for all models with `accelerator=None/"ipex"/"jit"`, this PR add a new saving and loading logic for compressed saving file.



- [x] original model
- [x] bf16 model
- [x] ipex model
- [ ] jit model

### 2. User API changes
A new parameter `compress_to_bf16` is added to `InferenceOptimizer.save`.
```python
InferenceOptimizer.save(opt_model, path)  # uncompressed file saved
InferenceOptimizer.save(opt_model, path, compress_to_bf16=True)  # compressed file saved

InferenceOptimizer.load(path, ...)  # both files can be loaded the same way
```

### 3. Summary of the change 
The logic basic works like this
<img width="857" alt="image" src="https://user-images.githubusercontent.com/35031544/220017782-06c6f43f-3521-4e6c-972d-a652fc6e45bf.png">

### 4. How to test?
- [ ] Unit test
