### PR TITLE
[ORCA] Refactor Load Checkpoint with PyTorch Pyspark

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/core/modelIO.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/core/modelIO.py
@@ -22,7 +22,6 @@ from abc import ABCMeta, abstractmethod
 
 import torch
 
-from bigdl.orca.data.file import get_remote_file_to_local
 from bigdl.dllib.utils.log4Error import invalidInputError
 
 
@@ -59,6 +58,7 @@ class ModelIO(metaclass=ABCMeta):
         return self.load_state_dict(state_dict)
 
     def load_checkpoint(self, filepath):
+        from bigdl.orca.data.file import get_remote_file_to_local
         file_name = os.path.basename(filepath)
         temp_dir = tempfile.mkdtemp()
         temp_path = os.path.join(temp_dir, file_name)


### PR DESCRIPTION
## Description
To fix https://github.com/intel-analytics/BigDL/issues/7574, remove fsspec and pyarrow using.

### 1. Why the change?
Fix bug caused by pyarrow when loading checkpoint from remote storage like HDFS.

### 2. User API changes
N/A

### 3. Summary of the change 
Re-write this part according to the `load` implementation.

### 4. How to test?
- [x] Unit test
- [x] Yarn test


