### PR TITLE
Nano: fix `__getattr__` of PytorchIPEXJITModel and update attributes related uts

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -19,7 +19,6 @@ from .ipex_inference_model import PytorchIPEXJITModel
 from bigdl.nano.pytorch.context_manager import generate_context_manager
 from bigdl.nano.utils.common import _avx512_checker
 from bigdl.nano.utils.common import invalidInputError
-from bigdl.nano.utils.pytorch import patch_attrs_from_model_to_object
 import torch
 
 

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -19,6 +19,7 @@ from .ipex_inference_model import PytorchIPEXJITModel
 from bigdl.nano.pytorch.context_manager import generate_context_manager
 from bigdl.nano.utils.common import _avx512_checker
 from bigdl.nano.utils.common import invalidInputError
+from bigdl.nano.utils.pytorch import patch_attrs_from_model_to_object
 import torch
 
 

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_quantization_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_quantization_model.py
@@ -19,6 +19,7 @@ import intel_extension_for_pytorch as ipex
 from intel_extension_for_pytorch.quantization import prepare, convert
 from bigdl.nano.pytorch.model import AcceleratedLightningModule
 from bigdl.nano.pytorch.context_manager import generate_context_manager
+from bigdl.nano.utils.pytorch import patch_attrs_from_model_to_object
 import torch
 
 
@@ -109,6 +110,8 @@ class PytorchIPEXQuantizationModel(AcceleratedLightningModule):
             self.model = torch.jit.trace(self.model, input_sample,
                                          strict=jit_strict)
             self.model = torch.jit.freeze(self.model)
+        # patch attributes from original model
+        patch_attrs_from_model_to_object(self.original_model, self)
 
     @property
     def forward_args(self):
@@ -125,17 +128,6 @@ class PytorchIPEXQuantizationModel(AcceleratedLightningModule):
 
     def on_forward_end(self, outputs):
         return outputs
-
-    def __getattr__(self, name: str):
-        # the search order is:
-        # 1. current instance, like channels_last will be found at this place
-        # 2. super class, like model will be found at this place
-        # 3. original model, like additional attributes of original model
-        #    will be found at this place
-        try:
-            return super().__getattr__(name)
-        except AttributeError:
-            return getattr(self.original_model, name)
 
     @property
     def status(self):

--- a/python/nano/test/inc/pytorch/test_quantize.py
+++ b/python/nano/test/inc/pytorch/test_quantize.py
@@ -67,7 +67,7 @@ class ModelCannotCopy(ResNet18):
         invalidOperationError(False, "This model cannot be deepcopy")
 
 
-class TestTrainer(TestCase):
+class TestINC(TestCase):
     model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
     loss = nn.CrossEntropyLoss()
     optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
@@ -218,6 +218,11 @@ class TestTrainer(TestCase):
         assert qmodel
         assert qmodel.channels == 3
         qmodel.hello()
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchQuantizedModel' object has no attribute 'width'"
+        ):
+            qmodel.width
 
         with InferenceOptimizer.get_context(qmodel):
             assert torch.get_num_threads() == 2
@@ -230,6 +235,11 @@ class TestTrainer(TestCase):
             load_model = InferenceOptimizer.load(tmp_dir_name, model=pl_model)
         assert load_model.channels == 3
         load_model.hello()
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchQuantizedModel' object has no attribute 'width'"
+        ):
+            load_model.width
 
     # This UT will fail with INC < 2.0
     @pytest.mark.skipif(compare_version("neural_compressor", operator.lt, "2.0"), reason="")

--- a/python/nano/test/onnx/pytorch/test_inc_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_inc_onnx.py
@@ -238,15 +238,21 @@ class TestOnnx(TestCase):
 
         assert onnx_model.channels == 3
         onnx_model.hello()
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchONNXRuntimeModel' object has no attribute 'width'"
+        ):
             onnx_model.width
 
         # save & load without original model
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(onnx_model, tmp_dir_name)
             load_model = InferenceOptimizer.load(tmp_dir_name)
-        with pytest.raises(AttributeError):
-            load_model.channels == 3
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchONNXRuntimeModel' object has no attribute 'channels'"
+        ):
+            load_model.channels
         with pytest.raises(AttributeError):
             load_model.hello()
 
@@ -256,6 +262,11 @@ class TestOnnx(TestCase):
             load_model = InferenceOptimizer.load(tmp_dir_name, model=pl_model)
         assert load_model.channels == 3
         load_model.hello()
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchONNXRuntimeModel' object has no attribute 'width'"
+        ):
+            onnx_model.width
 
     def test_onnx_quantize_dynamic_axes(self):
         class CustomModel(nn.Module):

--- a/python/nano/test/onnx/pytorch/test_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_onnx.py
@@ -206,15 +206,21 @@ class TestOnnx(TestCase):
 
         assert onnx_model.channels == 3
         onnx_model.hello()
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchONNXRuntimeModel' object has no attribute 'width'"
+        ):
             onnx_model.width
 
         # save & load without original model
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(onnx_model, tmp_dir_name)
             load_model = InferenceOptimizer.load(tmp_dir_name)
-        with pytest.raises(AttributeError):
-            load_model.channels == 3
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchONNXRuntimeModel' object has no attribute 'channels'"
+        ):
+            load_model.channels
         with pytest.raises(AttributeError):
             load_model.hello()
 
@@ -224,6 +230,11 @@ class TestOnnx(TestCase):
             load_model = InferenceOptimizer.load(tmp_dir_name, model=pl_model)
         assert load_model.channels == 3
         load_model.hello()
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchONNXRuntimeModel' object has no attribute 'width'"
+        ):
+            load_model.width
 
     def test_onnx_default_values(self):
         # default bool values

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -146,7 +146,10 @@ class TestOpenVINO(TestCase):
                                                   thread_num=2)
         assert openvino_model.channels == 3
         openvino_model.hello()
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchOpenVINOModel' object has no attribute 'width'"
+        ):
             openvino_model.width
 
         with InferenceOptimizer.get_context(openvino_model):
@@ -168,6 +171,11 @@ class TestOpenVINO(TestCase):
             load_model = InferenceOptimizer.load(tmp_dir_name, model=model, device='CPU')
         assert load_model.channels == 3
         load_model.hello()
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchOpenVINOModel' object has no attribute 'width'"
+        ):
+            openvino_model.width
 
         with InferenceOptimizer.get_context(load_model):
             assert torch.get_num_threads() == 2

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -159,7 +159,10 @@ class TestOpenVINO(TestCase):
                                                      thread_num=2)
         assert openvino_model.channels == 3
         openvino_model.hello()
-        with pytest.raises(AttributeError):
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchOpenVINOModel' object has no attribute 'width'"
+        ):
             openvino_model.width
 
         with InferenceOptimizer.get_context(openvino_model):
@@ -170,8 +173,11 @@ class TestOpenVINO(TestCase):
         with tempfile.TemporaryDirectory() as tmp_dir_name:
             InferenceOptimizer.save(openvino_model, tmp_dir_name)
             load_model = InferenceOptimizer.load(tmp_dir_name, device='CPU')
-        with pytest.raises(AttributeError):
-            load_model.channels == 3
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchOpenVINOModel' object has no attribute 'channels'"
+        ):
+            load_model.channels
         with pytest.raises(AttributeError):
             load_model.hello()
 
@@ -181,6 +187,11 @@ class TestOpenVINO(TestCase):
             load_model = InferenceOptimizer.load(tmp_dir_name, model=model, device='CPU')
         assert load_model.channels == 3
         load_model.hello()
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchOpenVINOModel' object has no attribute 'width'"
+        ):
+            openvino_model.width
 
     def test_openvino_quantize_dynamic_axes(self):
         class CustomModel(nn.Module):

--- a/python/nano/test/pytorch/tests/inference/test_bf16.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16.py
@@ -169,6 +169,11 @@ class Pytorch1_12:
         assert y_hat1.shape == (10, 10) and y_hat1.dtype == torch.bfloat16
         assert bf16_model.channels == 3
         bf16_model.hello()
+        with pytest.raises(
+            AttributeError,
+            match="'ResNet' object has no attribute 'strange_call'"
+        ):
+            bf16_model.strange_call()
 
         # test bf16 + channels_last
         bf16_model = InferenceOptimizer.quantize(model, precision='bf16',
@@ -187,6 +192,11 @@ class Pytorch1_12:
             load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
         assert load_model.channels == 3
         load_model.hello()
+        with pytest.raises(
+            AttributeError,
+            match="'ResNet' object has no attribute 'strange_call'"
+        ):
+            load_model.strange_call()
 
     def test_bf16_channels_last_various_input_sample(self):
 

--- a/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
@@ -165,6 +165,11 @@ class Pytorch1_11:
             load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
         assert load_model.channels == 3
         load_model.hello()
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchIPEXJITBF16Model' object has no attribute 'strange_call'"
+        ):
+            load_model.strange_call()
 
         # test jit + bf16
         new_model = InferenceOptimizer.trace(model, precision='bf16',
@@ -180,6 +185,11 @@ class Pytorch1_11:
             load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
         assert load_model.channels == 3
         load_model.hello()
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchIPEXJITBF16Model' object has no attribute 'strange_call'"
+        ):
+            load_model.strange_call()
 
         # test iepx + bf16
         new_model = InferenceOptimizer.trace(model, precision='bf16',
@@ -196,6 +206,11 @@ class Pytorch1_11:
             load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
         assert load_model.channels == 3
         load_model.hello()
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchIPEXJITBF16Model' object has no attribute 'strange_call'"
+        ):
+            load_model.strange_call()
 
     def test_bf16_ipex_jit_method(self):
 

--- a/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
@@ -152,9 +152,11 @@ class Pytorch1_11:
         model.hello = hello
 
         # test jit + ipex + bf16
-        new_model = InferenceOptimizer.trace(model, precision='bf16',
-                                             accelerator="jit", use_ipex=True,
-                                             input_sample=x)
+        new_model = InferenceOptimizer.quantize(model,
+                                                precision='bf16',
+                                                accelerator="jit",
+                                                use_ipex=True,
+                                                input_sample=x)
         with InferenceOptimizer.get_context(new_model):
             new_model(x)
         assert new_model.channels == 3
@@ -172,9 +174,9 @@ class Pytorch1_11:
             load_model.strange_call()
 
         # test jit + bf16
-        new_model = InferenceOptimizer.trace(model, precision='bf16',
-                                             accelerator="jit",
-                                             input_sample=x)
+        new_model = InferenceOptimizer.quantize(model, precision='bf16',
+                                                accelerator="jit",
+                                                input_sample=x)
         with InferenceOptimizer.get_context(new_model):
             new_model(x)
         assert new_model.channels == 3
@@ -191,9 +193,9 @@ class Pytorch1_11:
         ):
             load_model.strange_call()
 
-        # test iepx + bf16
-        new_model = InferenceOptimizer.trace(model, precision='bf16',
-                                             use_ipex=True)
+        # test ipex + bf16
+        new_model = InferenceOptimizer.quantize(model, precision='bf16',
+                                                use_ipex=True)
         with InferenceOptimizer.get_context(new_model):
             new_model(x)
         assert new_model.channels == 3
@@ -243,7 +245,6 @@ class Pytorch1_11:
             output = loaded_model(input)
         assert output.shape[0] == expected_output_len
         assert loaded_model.jit_method == 'script'
-
 
         # test with jit.trace (with ipex)
         accmodel = InferenceOptimizer.quantize(model, precision='bf16',
@@ -353,11 +354,11 @@ class Pytorch1_11:
         model = DummyModelWith3d()
         x1 = torch.rand(32, 3, 3, 224, 224) # 5-dim input test
         x2 = 3
-        ipex_jit_channels_last_model = InferenceOptimizer.trace(model, accelerator="jit", 
-                                                                use_ipex=True, precision='bf16',
-                                                                input_sample=(x1, x2),
-                                                                enable_onednn=True,
-                                                                channels_last=True)
+        ipex_jit_channels_last_model = InferenceOptimizer.quantize(model, accelerator="jit", 
+                                                                   use_ipex=True, precision='bf16',
+                                                                   input_sample=(x1, x2),
+                                                                   enable_onednn=True,
+                                                                   channels_last=True)
         with InferenceOptimizer.get_context(ipex_jit_channels_last_model):
             ipex_jit_channels_last_model(x1, x2)
         with tempfile.TemporaryDirectory() as tmp_dir_name:

--- a/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
@@ -354,11 +354,12 @@ class Pytorch1_11:
         model = DummyModelWith3d()
         x1 = torch.rand(32, 3, 3, 224, 224) # 5-dim input test
         x2 = 3
-        ipex_jit_channels_last_model = InferenceOptimizer.quantize(model, accelerator="jit", 
-                                                                   use_ipex=True, precision='bf16',
-                                                                   input_sample=(x1, x2),
-                                                                   enable_onednn=True,
-                                                                   channels_last=True)
+        # TODO: quantize will fail here, will fix it in next PR
+        ipex_jit_channels_last_model = InferenceOptimizer.trace(model, accelerator="jit", 
+                                                                use_ipex=True, precision='bf16',
+                                                                input_sample=(x1, x2),
+                                                                enable_onednn=True,
+                                                                channels_last=True)
         with InferenceOptimizer.get_context(ipex_jit_channels_last_model):
             ipex_jit_channels_last_model(x1, x2)
         with tempfile.TemporaryDirectory() as tmp_dir_name:

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -229,6 +229,11 @@ class IPEXJITInference_gt_1_10:
             new_model(self.data_sample)
         assert new_model.channels == 3
         new_model.hello()
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchIPEXJITModel' object has no attribute 'strange_call'"
+        ):
+            new_model.strange_call()
 
         # save & load with original model
         with tempfile.TemporaryDirectory() as tmp_dir_name:
@@ -236,6 +241,11 @@ class IPEXJITInference_gt_1_10:
             load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
         assert load_model.channels == 3
         load_model.hello()
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchIPEXJITModel' object has no attribute 'strange_call'"
+        ):
+            load_model.strange_call()
 
         # test jit + ipex + inplace
         new_model = InferenceOptimizer.trace(model, accelerator="jit",
@@ -270,6 +280,12 @@ class IPEXJITInference_gt_1_10:
         assert load_model.channels == 3
         load_model.hello()
 
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchIPEXJITModel' object has no attribute 'strange_call'"
+        ):
+            load_model.strange_call()
+
         # test ipex
         new_model = InferenceOptimizer.trace(model, use_ipex=True)
         with InferenceOptimizer.get_context(new_model):
@@ -285,6 +301,12 @@ class IPEXJITInference_gt_1_10:
             load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
         assert load_model.channels == 3
         load_model.hello()
+
+        with pytest.raises(
+            AttributeError,
+            match="'PytorchIPEXJITModel' object has no attribute 'strange_call'"
+        ):
+            load_model.strange_call()
 
         # test ipex inplace
         new_model = InferenceOptimizer.trace(model, use_ipex=True, inplace=True)


### PR DESCRIPTION
## Description

Fix `RecursionError: maximum recursion depth exceeded while calling a Python object` when calling a non-existing method on a loaded `PytorchIPEXJITModel`/`PytorchIPEXJITBF16Model` and fix/complete/update attributes related uts to make sure accelerated model behave normally.

### 1. Why the change?

Fix `RecursionError: maximum recursion depth exceeded while calling a Python object` when calling a non-existing method on a loaded `PytorchIPEXJITModel`/`PytorchIPEXJITBF16Model`.

### 2. User API changes

No change, just update inside logic about how to obtain additional attributes of `PytorchIPEXJITModel`/`PytorchIPEXJITBF16Model`.

### 3. Summary of the change 

- Fix `RecursionError: maximum recursion depth exceeded while calling a Python object` when calling a non-existing method on a loaded `PytorchIPEXJITModel`/`PytorchIPEXJITBF16Model` 
- Fix/complete/update attributes related uts of IPEXJIT/OpenVINO/ONNXRuntime/INC/BF16

### 4. How to test?
- [x] Unit test

Todo:
`TestIPEXBF16::test_ipex_jit_channels_last_3d_inference` will fail with quantization, locate this issue later and raise another PR for this issue