### PR TITLE
Orca: Save the tensorflow model in NCF tutorial in h5 format

### DIFF
--- a/python/orca/tutorial/NCF/tf_predict_spark_dataframe.py
+++ b/python/orca/tutorial/NCF/tf_predict_spark_dataframe.py
@@ -34,7 +34,7 @@ df = spark.read.parquet(os.path.join(args.data_dir, "test_processed_dataframe.pa
 # Step 3: Load the model
 est = Estimator.from_keras(backend=args.backend,
                            workers_per_node=args.workers_per_node)
-est.load(os.path.join(args.model_dir, "NCF_model"))
+est.load(os.path.join(args.model_dir, "NCF_model.h5"))
 
 
 # Step 4: Distributed inference of the loaded model

--- a/python/orca/tutorial/NCF/tf_predict_xshards.py
+++ b/python/orca/tutorial/NCF/tf_predict_xshards.py
@@ -34,7 +34,7 @@ data = XShards.load_pickle(os.path.join(args.data_dir, "test_processed_xshards")
 # Step 3: Load the model
 est = Estimator.from_keras(backend=args.backend,
                            workers_per_node=args.workers_per_node)
-est.load(os.path.join(args.model_dir, "NCF_model"))
+est.load(os.path.join(args.model_dir, "NCF_model.h5"))
 
 
 # Step 4: Distributed inference of the loaded model

--- a/python/orca/tutorial/NCF/tf_resume_train_spark_dataframe.py
+++ b/python/orca/tutorial/NCF/tf_resume_train_spark_dataframe.py
@@ -41,7 +41,7 @@ test_df = spark.read.parquet(os.path.join(args.data_dir,
 # Step 3: Distributed training with Orca TF2 Estimator after loading the model
 est = Estimator.from_keras(backend=args.backend,
                            workers_per_node=args.workers_per_node)
-est.load(os.path.join(args.model_dir, "NCF_model"))
+est.load(os.path.join(args.model_dir, "NCF_model.h5"))
 
 batch_size = 10240
 train_steps = math.ceil(train_df.count() / batch_size)
@@ -70,7 +70,7 @@ for k, v in train_stats.items():
 
 
 # Step 4: Save the trained TensorFlow model
-est.save(os.path.join(args.model_dir, "NCF_resume_model"))
+est.save(os.path.join(args.model_dir, "NCF_resume_model.h5"))
 
 
 # Step 5: Shutdown the Estimator and stop Orca Context when the program finishes

--- a/python/orca/tutorial/NCF/tf_resume_train_xshards.py
+++ b/python/orca/tutorial/NCF/tf_resume_train_xshards.py
@@ -39,7 +39,7 @@ test_data = XShards.load_pickle(os.path.join(args.data_dir, "test_processed_xsha
 # Step 3: Distributed training with Orca TF2 Estimator after loading the model
 est = Estimator.from_keras(backend=args.backend,
                            workers_per_node=args.workers_per_node)
-est.load(os.path.join(args.model_dir, "NCF_model"))
+est.load(os.path.join(args.model_dir, "NCF_model.h5"))
 
 batch_size = 10240
 train_steps = math.ceil(len(train_data) / batch_size)
@@ -68,7 +68,7 @@ for k, v in train_stats.items():
 
 
 # Step 4: Save the trained TensorFlow model
-est.save(os.path.join(args.model_dir, "NCF_resume_model"))
+est.save(os.path.join(args.model_dir, "NCF_resume_model.h5"))
 
 
 # Step 5: Shutdown the Estimator and stop Orca Context when the program finishes

--- a/python/orca/tutorial/NCF/tf_train_spark_dataframe.py
+++ b/python/orca/tutorial/NCF/tf_train_spark_dataframe.py
@@ -106,8 +106,7 @@ for k, v in eval_stats.items():
 
 
 # Step 6: Save the trained TensorFlow model and processed data for resuming training or prediction
-# TODO: fix save model to HDFS
-est.save(os.path.join(args.model_dir, "NCF_model"), save_format="h5")
+est.save(os.path.join(args.model_dir, "NCF_model.h5"))
 save_model_config(config, args.model_dir, "config.json")
 train_df.write.parquet(os.path.join(args.data_dir,
                                     "train_processed_dataframe.parquet"), mode="overwrite")

--- a/python/orca/tutorial/NCF/tf_train_spark_dataframe.py
+++ b/python/orca/tutorial/NCF/tf_train_spark_dataframe.py
@@ -107,7 +107,7 @@ for k, v in eval_stats.items():
 
 # Step 6: Save the trained TensorFlow model and processed data for resuming training or prediction
 # TODO: fix save model to HDFS
-est.save(os.path.join(args.model_dir, "NCF_model"))
+est.save(os.path.join(args.model_dir, "NCF_model"), save_format="h5")
 save_model_config(config, args.model_dir, "config.json")
 train_df.write.parquet(os.path.join(args.data_dir,
                                     "train_processed_dataframe.parquet"), mode="overwrite")

--- a/python/orca/tutorial/NCF/tf_train_xshards.py
+++ b/python/orca/tutorial/NCF/tf_train_xshards.py
@@ -106,8 +106,7 @@ for k, v in eval_stats.items():
 
 
 # Step 6: Save the trained TensorFlow model and processed data for resuming training or prediction
-# TODO: fix save model to HDFS
-est.save(os.path.join(args.model_dir, "NCF_model"), save_format="h5")
+est.save(os.path.join(args.model_dir, "NCF_model.h5"))
 save_model_config(config, args.model_dir, "config.json")
 train_data.save_pickle(os.path.join(args.data_dir, "train_processed_xshards"))
 test_data.save_pickle(os.path.join(args.data_dir, "test_processed_xshards"))

--- a/python/orca/tutorial/NCF/tf_train_xshards.py
+++ b/python/orca/tutorial/NCF/tf_train_xshards.py
@@ -107,7 +107,7 @@ for k, v in eval_stats.items():
 
 # Step 6: Save the trained TensorFlow model and processed data for resuming training or prediction
 # TODO: fix save model to HDFS
-est.save(os.path.join(args.model_dir, "NCF_model"))
+est.save(os.path.join(args.model_dir, "NCF_model"), save_format="h5")
 save_model_config(config, args.model_dir, "config.json")
 train_data.save_pickle(os.path.join(args.data_dir, "train_processed_xshards"))
 test_data.save_pickle(os.path.join(args.data_dir, "test_processed_xshards"))


### PR DESCRIPTION
## Description

Save the tensorflow model in NCF tutorial in h5 format.

### 1. Why the change?

Sometimes saving tf model in default format `Tensorflow SavedModel` on hdfs requires the permission of `mkdir`, and saving tf model as a `HDF5` single file does not need to get the permission.