### PR TITLE
Chronos: fix errors caused by `np.object`

### DIFF
--- a/.github/workflows/chronos-install-option-py38-test.yml
+++ b/.github/workflows/chronos-install-option-py38-test.yml
@@ -19,7 +19,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  chronos-pytorch-test:
+  chronos-pytorch-test-temp:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
     strategy:
       fail-fast: false

--- a/.github/workflows/chronos-install-option-py38-test.yml
+++ b/.github/workflows/chronos-install-option-py38-test.yml
@@ -19,7 +19,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  chronos-pytorch-test-temp:
+  chronos-pytorch-test:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
     strategy:
       fail-fast: false

--- a/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
+++ b/python/chronos/test/bigdl/chronos/data/test_tsdataset.py
@@ -929,8 +929,8 @@ class TestTSDataset(TestCase):
 
         # target_col\extra_feature_col dtype is object(numeric).
         df = get_ts_df()
-        df.value = df.value.astype(np.object)
-        df['extra feature'] = df['extra feature'].astype(np.object)
+        df.value = df.value.astype(object)
+        df['extra feature'] = df['extra feature'].astype(object)
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
                                        extra_feature_col=["extra feature"], id_col="id")
         before_sampling = tsdata.df.columns
@@ -969,8 +969,8 @@ class TestTSDataset(TestCase):
 
         # target_col/extra_feature_col dtype is object(numeric).
         df = get_multi_id_ts_df()
-        df.value = df.value.astype(np.object)
-        df['extra feature'] = df['extra feature'].astype(np.object)
+        df.value = df.value.astype(object)
+        df['extra feature'] = df['extra feature'].astype(object)
         tsdata = TSDataset.from_pandas(df, dt_col="datetime", target_col="value",
                                        extra_feature_col=["extra feature"],
                                        id_col="id", repair=False)


### PR DESCRIPTION
## Description

In https://github.com/intel-analytics/BigDL/pull/7600, limitation of numpy version is removed.
`np.object` may cause errors.(https://github.com/intel-analytics/BigDL/actions/runs/4226018564/jobs/7338998730#step:6:473)

### 4. How to test?
- [x] Unit test