### PR TITLE
Nano: support compressed saving logic for JIT model

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -132,14 +132,16 @@ def PytorchIPEXQuantizationModel(model, calib_data, q_config=None,
                                         jit_strict=jit_strict)
 
 
-def load_ipexjit_model(path, model, inplace=False):
+def load_ipexjit_model(path, model, inplace=False, input_sample=None):
     from .ipex_inference_model import PytorchIPEXJITModel
-    return PytorchIPEXJITModel._load(path, model, inplace=inplace)
+    return PytorchIPEXJITModel._load(path, model, inplace=inplace,
+                                     input_sample=input_sample)
 
 
-def load_ipexjitbf16_model(path, model, inplace=False):
+def load_ipexjitbf16_model(path, model, inplace=False, input_sample=None):
     from .ipex_inference_bf16_model import PytorchIPEXJITBF16Model
-    return PytorchIPEXJITBF16Model._load(path, model, inplace=inplace)
+    return PytorchIPEXJITBF16Model._load(path, model, inplace=inplace,
+                                         input_sample=input_sample)
 
 
 def load_ipex_quantization_model(path, model, inplace=False):

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -19,7 +19,9 @@ from .ipex_inference_model import PytorchIPEXJITModel
 from bigdl.nano.pytorch.context_manager import generate_context_manager
 from bigdl.nano.utils.common import _avx512_checker
 from bigdl.nano.utils.common import invalidInputError
+from bigdl.nano.utils.pytorch import transform_state_dict_to_dtype
 import torch
+import copy
 
 
 class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
@@ -94,17 +96,25 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         return status
 
     @staticmethod
-    def _load(path, model, inplace=False):
+    def _load(path, model, inplace=False, input_sample=None):
         status = PytorchIPEXJITBF16Model._load_status(path)
         checkpoint_path = path / status['checkpoint']
         if status["use_jit"]:
-            if status["use_ipex"]:
-                import intel_extension_for_pytorch as ipex
-            model = torch.jit.load(checkpoint_path)
-            model.eval()
-            if status["use_ipex"]:
-                model = torch.jit.freeze(model)
-            from_load = True
+            if status['compression'] == "bf16":
+                state_dict = torch.load(checkpoint_path, map_location='cpu')
+                if status['compression'] == "bf16":
+                    state_dict = transform_state_dict_to_dtype(state_dict, dtype="fp32")
+                model = copy.deepcopy(model)
+                model.load_state_dict(state_dict)
+                from_load = False
+            else:
+                if status["use_ipex"]:
+                    import intel_extension_for_pytorch as ipex
+                model = torch.jit.load(checkpoint_path)
+                model.eval()
+                if status["use_ipex"]:
+                    model = torch.jit.freeze(model)
+                from_load = True
         else:
             state_dict = torch.load(checkpoint_path)
             model.eval()
@@ -117,7 +127,9 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
             thread_num = None
         if thread_num is not None:
             thread_num = int(status['thread_num'])
-        return PytorchIPEXJITBF16Model(model, use_ipex=status['use_ipex'],
+        return PytorchIPEXJITBF16Model(model,
+                                       input_sample=input_sample,
+                                       use_ipex=status['use_ipex'],
                                        use_jit=status['use_jit'],
                                        channels_last=status['channels_last'],
                                        channels_last_available=status['channels_last_available'],

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -214,7 +214,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                 state_dict = torch.load(checkpoint_path, map_location='cpu')
                 if status['compression'] == "bf16":
                     state_dict = transform_state_dict_to_dtype(state_dict, dtype="fp32")
-                model = copy.deepcopy(model)
+                if inplace is False:
+                    model = copy.deepcopy(model)
                 model.load_state_dict(state_dict)
                 from_load = False
             else:

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -153,7 +153,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                                                          strict=jit_strict)
                         except Exception:
                             self.model = torch.jit.script(self.model)
-                    # self.model = torch.jit.freeze(self.model)
+                    self.model = torch.jit.freeze(self.model)
         _accelerator = "jit" if use_jit is True else None
         self._nano_context_manager = generate_context_manager(accelerator=_accelerator,
                                                               precision="fp32",

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -263,6 +263,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                 torch.save(bf16_sd, path / "ckpt.pth")
             elif compression == "fp32":
                 # normal torch.jit.save for fp32 model
+                self.compression = "fp32"
                 self.model.save(path / "ckpt.pth")
             else:
                 invalidInputError(False,

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -239,11 +239,17 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                                    compression=status.get('compression', "fp32"),)
 
     def _save_model(self, path, compression="fp32"):
-        if self.use_jit:
+        if self.use_jit and not self.use_ipex:
+            # for pure jit
             if compression == "bf16":
+                bf16_jit = self.model.bfloat16()
+                bf16_jit.save(path / "ckpt.pth")
+            elif compression == "fp32":
+                self.model.save(path / "ckpt.pth")
+            else:
                 invalidInputError(False,
-                                  "compression does not support jit accelerator fow now.")
-            self.model.save(path / "ckpt.pth")
+                                  "compression does not support {} precision for jit accelerator "
+                                  "fow now.".format(compression))
         else:
             if compression == "bf16":
                 self.compression = "bf16"

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -1176,7 +1176,10 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                you always pass in the original model for this case.
                3. you want to the loaded model contains the attributes of original model.
         :param input_sample: Input sample for your model, could be a Tensor or a tuple.
-               Only valid for inc ipex quantization model, otherwise will be ignored.
+               This parameter is needed if:
+               1. saving model is accelerated by INC IPEX quantization.
+               2. saving model is accelerated by JIT and you set compression='bf16'
+               when saving.
         :param inplace: whether to perform inplace optimization. Default: ``False``.
         :param device: A string represents the device of the inference. Default to None.
                Only valid for openvino model, otherwise will be ignored.

--- a/python/nano/src/bigdl/nano/utils/pytorch/load.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/load.py
@@ -21,14 +21,13 @@ from pathlib import Path
 
 import torch
 import torch.nn as nn
-import pytorch_lightning as pl
 
 from bigdl.nano.utils.common import invalidInputError
 from bigdl.nano.utils.pytorch import patch_attrs_from_model_to_object, \
     transform_state_dict_to_dtype
 
 
-def load_model(path, model: pl.LightningModule = None, input_sample=None,
+def load_model(path, model: nn.Module = None, input_sample=None,
                inplace=False, device=None):
     """
     Load a model from local.

--- a/python/nano/src/bigdl/nano/utils/pytorch/load.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/load.py
@@ -38,7 +38,10 @@ def load_model(path, model: nn.Module = None, input_sample=None,
                InferenceOptimizer.trace/InferenceOptimizer.quantize.
                2. you want to the loaded model contains the attributes of original model.
     :param input_sample: Input sample for your model, could be a Tensor or a tuple.
-            Only valid for inc ipex quantization model, otherwise will be ignored.
+               This parameter is needed if:
+               1. saving model is accelerated by INC IPEX quantization.
+               2. saving model is accelerated by JIT and you set compression='bf16'
+               when saving.
     :param inplace: whether to perform inplace optimization. Default: ``False``.
     :param device: A string represents the device of the inference. Default to None.
                    Only valid for openvino model, otherwise will be ignored.

--- a/python/nano/src/bigdl/nano/utils/pytorch/load.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/load.py
@@ -70,9 +70,11 @@ def load_model(path, model: nn.Module = None, input_sample=None,
     if model_type == 'PytorchQuantizedModel':
         result = load_inc_model(path, model, 'pytorch', input_sample=input_sample)
     if model_type == 'PytorchIPEXJITModel':
-        result = load_ipexjit_model(path, model, inplace=inplace)
+        result = load_ipexjit_model(path, model, inplace=inplace,
+                                    input_sample=input_sample)
     if model_type == 'PytorchIPEXJITBF16Model':
-        result = load_ipexjitbf16_model(path, model, inplace=inplace)
+        result = load_ipexjitbf16_model(path, model, inplace=inplace,
+                                        input_sample=input_sample)
     if model_type == 'PytorchIPEXQuantizationModel':
         result = load_ipex_quantization_model(path, model, inplace=inplace)
     if model_type == 'BF16Model':

--- a/python/nano/src/bigdl/nano/utils/pytorch/save.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/save.py
@@ -17,17 +17,15 @@
 import yaml
 from pathlib import Path
 import copy
-
 import torch
-import pytorch_lightning as pl
 
 
-def save_model(model: pl.LightningModule, path, compression="fp32"):
+def save_model(model: torch.nn.Module, path, compression="fp32"):
     """
     Save the model to local file.
 
     :param model: Any model of torch.nn.Module, including all models accelareted by
-            Trainer.trace/Trainer.quantize.
+            InferenceOptimizer.trace/InferenceOptimizer.quantize.
     :param path: Path to saved model. Path should be a directory.
     :param compression: str. This parameter only effective for jit, ipex or pure
                pytorch model with fp32 or bf16 precision. Defaultly, all models are saved

--- a/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
@@ -17,7 +17,7 @@
 import os
 import numpy as np
 from torch import nn
-import torch
+import tempfile
 from unittest import TestCase
 import pytest
 import torchvision.transforms as transforms
@@ -690,58 +690,101 @@ class TestInferencePipeline(TestCase):
 
         # original model
         self.model.eval()
-        opt_output = self.model(input_sample)
-        InferenceOptimizer.save(self.model, "original")
-        original_size = os.path.getsize("original/saved_weight.pt")
-        opt_output_after_saving = self.model(input_sample)
-        InferenceOptimizer.save(self.model, "compressed", compression="bf16")
-
-        opt_model_load = InferenceOptimizer.load("compressed", self.model)
-        opt_output_after_loading = opt_model_load(input_sample)
-
-        compressed_size_ipex = os.path.getsize("compressed/saved_weight.pt")
-        assert compressed_size_ipex < 0.8 * original_size
+        with InferenceOptimizer.get_context(self.model):
+            opt_output = self.model(input_sample)
+        # test save load original model
+        with tempfile.TemporaryDirectory() as tmpdir:
+            InferenceOptimizer.save(self.model, tmpdir)
+            original_size = os.path.getsize(os.path.join(tmpdir, "saved_weight.pt"))
+        with InferenceOptimizer.get_context(self.model):
+            opt_output_after_saving = self.model(input_sample)
         assert torch.equal(opt_output, opt_output_after_saving)
+
+        # test save load compressed model
+        with tempfile.TemporaryDirectory() as tmpdir:
+            InferenceOptimizer.save(self.model, tmpdir, compression="bf16")
+            opt_model_load = InferenceOptimizer.load(tmpdir, self.model)
+            compressed_size_ipex = os.path.getsize(os.path.join(tmpdir, "saved_weight.pt"))
+        with InferenceOptimizer.get_context(self.model):
+            opt_output_after_saving = self.model(input_sample)
+        assert torch.equal(opt_output, opt_output_after_saving)  # output is the same with model before saving compression
+        opt_output_after_loading = opt_model_load(input_sample)
+        assert compressed_size_ipex < 0.8 * original_size
         assert torch.allclose(opt_output, opt_output_after_loading, atol=5e-02)
 
-        # ipex
+        # test ipex
         opt_model = InferenceOptimizer.trace(self.model, use_ipex=True)
         with InferenceOptimizer.get_context(opt_model):
             opt_output = opt_model(input_sample)
 
-        InferenceOptimizer.save(opt_model, "original")
-        original_size = os.path.getsize("original/ckpt.pth")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            InferenceOptimizer.save(opt_model, tmpdir)
+            original_size = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
         with InferenceOptimizer.get_context(opt_model):
             opt_output_after_saving = opt_model(input_sample)
-        InferenceOptimizer.save(opt_model, "compressed", compression="bf16")
+        assert torch.equal(opt_output, opt_output_after_saving)  # output is the same with model before saving
 
-        opt_model_load = InferenceOptimizer.load("compressed", self.model)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            InferenceOptimizer.save(opt_model, tmpdir, compression="bf16")
+            opt_model_load = InferenceOptimizer.load(tmpdir, self.model)
+            compressed_size_ipex = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
+        with InferenceOptimizer.get_context(opt_model):
+            opt_output_after_saving = opt_model(input_sample)
+        assert torch.equal(opt_output, opt_output_after_saving)  # output is the same with model before saving compression
         with InferenceOptimizer.get_context(opt_model_load):
             opt_output_after_loading = opt_model_load(input_sample)
-
-        compressed_size_ipex = os.path.getsize("compressed/ckpt.pth")
         assert compressed_size_ipex < 0.8 * original_size
-        assert torch.equal(opt_output, opt_output_after_saving)
         assert torch.allclose(opt_output, opt_output_after_loading, atol=5e-02)
 
-        # bf16
+        # test bf16
         if TORCH_VERSION_LESS_1_12:
             return
         opt_model = InferenceOptimizer.quantize(self.model, precision="bf16")
         with InferenceOptimizer.get_context(opt_model):
             opt_output = opt_model(input_sample)
 
-        InferenceOptimizer.save(opt_model, "original")
-        original_size = os.path.getsize("original/ckpt.pth")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            InferenceOptimizer.save(opt_model, tmpdir)
+            original_size = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
         with InferenceOptimizer.get_context(opt_model):
             opt_output_after_saving = opt_model(input_sample)
-        InferenceOptimizer.save(opt_model, "compressed", compression="bf16")
+        assert torch.equal(opt_output, opt_output_after_saving)  # output is the same with model before saving
 
-        opt_model_load = InferenceOptimizer.load("compressed", self.model)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            InferenceOptimizer.save(opt_model, tmpdir, compression="bf16")
+            opt_model_load = InferenceOptimizer.load(tmpdir, self.model)
+            compressed_size_ipex = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
+        with InferenceOptimizer.get_context(opt_model):
+            opt_output_after_saving = opt_model(input_sample)
+        assert torch.equal(opt_output, opt_output_after_saving)  # output is the same with model before saving compression
         with InferenceOptimizer.get_context(opt_model_load):
             opt_output_after_loading = opt_model_load(input_sample)
-
-        compressed_size_ipex = os.path.getsize("compressed/ckpt.pth")
         assert compressed_size_ipex < 0.8 * original_size
-        assert torch.equal(opt_output, opt_output_after_saving)
+        assert torch.allclose(opt_output, opt_output_after_loading, atol=5e-02)
+
+        # test pure jit
+        opt_model = InferenceOptimizer.trace(self.model,
+                                             accelerator="jit",
+                                             input_sample=input_sample,
+                                             use_ipex=False)
+        with InferenceOptimizer.get_context(opt_model):
+            opt_output = opt_model(input_sample)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            InferenceOptimizer.save(opt_model, tmpdir)
+            original_size = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
+        with InferenceOptimizer.get_context(opt_model):
+            opt_output_after_saving = opt_model(input_sample)
+        assert torch.equal(opt_output, opt_output_after_saving)  # output is the same with model before saving
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            InferenceOptimizer.save(opt_model, tmpdir, compression="bf16")
+            opt_model_load = InferenceOptimizer.load(tmpdir, self.model)
+            compressed_size_ipex = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
+        with InferenceOptimizer.get_context(opt_model):
+            opt_output_after_saving = opt_model(input_sample)
+        assert torch.equal(opt_output, opt_output_after_saving)  # output is the same with model before saving compression
+        with InferenceOptimizer.get_context(opt_model_load):
+            opt_output_after_loading = opt_model_load(input_sample)
+        assert compressed_size_ipex < 0.8 * original_size
         assert torch.allclose(opt_output, opt_output_after_loading, atol=5e-02)

--- a/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
@@ -738,29 +738,30 @@ class TestInferencePipeline(TestCase):
 
         # test bf16
         if TORCH_VERSION_LESS_1_12:
-            return
-        opt_model = InferenceOptimizer.quantize(self.model, precision="bf16")
-        with InferenceOptimizer.get_context(opt_model):
-            opt_output = opt_model(input_sample)
+            pass
+        else:
+            opt_model = InferenceOptimizer.quantize(self.model, precision="bf16")
+            with InferenceOptimizer.get_context(opt_model):
+                opt_output = opt_model(input_sample)
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            InferenceOptimizer.save(opt_model, tmpdir)
-            original_size = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
-        with InferenceOptimizer.get_context(opt_model):
-            opt_output_after_saving = opt_model(input_sample)
-        assert torch.equal(opt_output, opt_output_after_saving)  # output is the same with model before saving
+            with tempfile.TemporaryDirectory() as tmpdir:
+                InferenceOptimizer.save(opt_model, tmpdir)
+                original_size = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
+            with InferenceOptimizer.get_context(opt_model):
+                opt_output_after_saving = opt_model(input_sample)
+            assert torch.equal(opt_output, opt_output_after_saving)  # output is the same with model before saving
 
-        with tempfile.TemporaryDirectory() as tmpdir:
-            InferenceOptimizer.save(opt_model, tmpdir, compression="bf16")
-            opt_model_load = InferenceOptimizer.load(tmpdir, self.model)
-            compressed_size_ipex = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
-        with InferenceOptimizer.get_context(opt_model):
-            opt_output_after_saving = opt_model(input_sample)
-        assert torch.equal(opt_output, opt_output_after_saving)  # output is the same with model before saving compression
-        with InferenceOptimizer.get_context(opt_model_load):
-            opt_output_after_loading = opt_model_load(input_sample)
-        assert compressed_size_ipex < 0.8 * original_size
-        assert torch.allclose(opt_output, opt_output_after_loading, atol=5e-02)
+            with tempfile.TemporaryDirectory() as tmpdir:
+                InferenceOptimizer.save(opt_model, tmpdir, compression="bf16")
+                opt_model_load = InferenceOptimizer.load(tmpdir, self.model)
+                compressed_size_ipex = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
+            with InferenceOptimizer.get_context(opt_model):
+                opt_output_after_saving = opt_model(input_sample)
+            assert torch.equal(opt_output, opt_output_after_saving)  # output is the same with model before saving compression
+            with InferenceOptimizer.get_context(opt_model_load):
+                opt_output_after_loading = opt_model_load(input_sample)
+            assert compressed_size_ipex < 0.8 * original_size
+            assert torch.allclose(opt_output, opt_output_after_loading, atol=5e-02)
 
         # test pure jit
         opt_model = InferenceOptimizer.trace(self.model,
@@ -773,17 +774,120 @@ class TestInferencePipeline(TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             InferenceOptimizer.save(opt_model, tmpdir)
             original_size = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
+            opt_model_load = InferenceOptimizer.load(tmpdir)
         with InferenceOptimizer.get_context(opt_model):
             opt_output_after_saving = opt_model(input_sample)
-        assert torch.equal(opt_output, opt_output_after_saving)  # output is the same with model before saving
+        assert torch.allclose(opt_output, opt_output_after_saving, atol=1e-05)  # output is the same with model before saving
+        with InferenceOptimizer.get_context(opt_model_load):
+            opt_output_after_loading= opt_model(input_sample)
+        assert torch.allclose(opt_output, opt_output_after_loading, atol=1e-05)  # output is the same with model after loading
 
         with tempfile.TemporaryDirectory() as tmpdir:
             InferenceOptimizer.save(opt_model, tmpdir, compression="bf16")
-            opt_model_load = InferenceOptimizer.load(tmpdir, self.model)
+            opt_model_load = InferenceOptimizer.load(tmpdir, model=self.model,
+                                                     input_sample=input_sample)
             compressed_size_ipex = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
         with InferenceOptimizer.get_context(opt_model):
             opt_output_after_saving = opt_model(input_sample)
-        assert torch.equal(opt_output, opt_output_after_saving)  # output is the same with model before saving compression
+        assert torch.allclose(opt_output, opt_output_after_saving, atol=1e-05)  # output is the same with model before saving
+        with InferenceOptimizer.get_context(opt_model_load):
+            opt_output_after_loading = opt_model_load(input_sample)
+        assert compressed_size_ipex < 0.8 * original_size
+        assert torch.allclose(opt_output, opt_output_after_loading, atol=5e-02)
+
+        # test jit + ipex
+        opt_model = InferenceOptimizer.trace(self.model,
+                                             accelerator="jit",
+                                             input_sample=input_sample,
+                                             use_ipex=True)
+        with InferenceOptimizer.get_context(opt_model):
+            opt_output = opt_model(input_sample)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            InferenceOptimizer.save(opt_model, tmpdir)
+            original_size = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
+            opt_model_load = InferenceOptimizer.load(tmpdir)
+        with InferenceOptimizer.get_context(opt_model):
+            opt_output_after_saving = opt_model(input_sample)
+        assert torch.allclose(opt_output, opt_output_after_saving, atol=1e-05)  # output is the same with model before saving
+        with InferenceOptimizer.get_context(opt_model_load):
+            opt_output_after_loading= opt_model(input_sample)
+        assert torch.allclose(opt_output, opt_output_after_loading, atol=1e-05)  # output is the same with model after loading
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            InferenceOptimizer.save(opt_model, tmpdir, compression="bf16")
+            opt_model_load = InferenceOptimizer.load(tmpdir, model=self.model,
+                                                     input_sample=input_sample)
+            compressed_size_ipex = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
+        with InferenceOptimizer.get_context(opt_model):
+            opt_output_after_saving = opt_model(input_sample)
+        assert torch.allclose(opt_output, opt_output_after_saving, atol=1e-05)  # output is the same with model before saving
+        with InferenceOptimizer.get_context(opt_model_load):
+            opt_output_after_loading = opt_model_load(input_sample)
+        assert compressed_size_ipex < 0.8 * original_size
+        assert torch.allclose(opt_output, opt_output_after_loading, atol=5e-02)
+
+        # test jit bf16
+        opt_model = InferenceOptimizer.quantize(self.model,
+                                                accelerator="jit",
+                                                input_sample=input_sample,
+                                                use_ipex=False,
+                                                precision='bf16')
+        with InferenceOptimizer.get_context(opt_model):
+            opt_output = opt_model(input_sample)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            InferenceOptimizer.save(opt_model, tmpdir)
+            original_size = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
+            opt_model_load = InferenceOptimizer.load(tmpdir)
+        with InferenceOptimizer.get_context(opt_model):
+            opt_output_after_saving = opt_model(input_sample)
+        assert torch.allclose(opt_output, opt_output_after_saving, atol=1e-05)  # output is the same with model before saving
+        with InferenceOptimizer.get_context(opt_model_load):
+            opt_output_after_loading= opt_model(input_sample)
+        assert torch.allclose(opt_output, opt_output_after_loading, atol=1e-05)  # output is the same with model after loading
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            InferenceOptimizer.save(opt_model, tmpdir, compression="bf16")
+            opt_model_load = InferenceOptimizer.load(tmpdir, model=self.model,
+                                                     input_sample=input_sample)
+            compressed_size_ipex = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
+        with InferenceOptimizer.get_context(opt_model):
+            opt_output_after_saving = opt_model(input_sample)
+        assert torch.allclose(opt_output, opt_output_after_saving, atol=1e-05)  # output is the same with model before saving
+        with InferenceOptimizer.get_context(opt_model_load):
+            opt_output_after_loading = opt_model_load(input_sample)
+        assert compressed_size_ipex < 0.8 * original_size
+        assert torch.allclose(opt_output, opt_output_after_loading, atol=5e-02)
+
+        # test jit + ipex + bf16
+        opt_model = InferenceOptimizer.quantize(self.model,
+                                                accelerator="jit",
+                                                input_sample=input_sample,
+                                                use_ipex=True,
+                                                precision='bf16')
+        with InferenceOptimizer.get_context(opt_model):
+            opt_output = opt_model(input_sample)
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            InferenceOptimizer.save(opt_model, tmpdir)
+            original_size = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
+            opt_model_load = InferenceOptimizer.load(tmpdir)
+        with InferenceOptimizer.get_context(opt_model):
+            opt_output_after_saving = opt_model(input_sample)
+        assert torch.allclose(opt_output, opt_output_after_saving, atol=1e-05)  # output is the same with model before saving
+        with InferenceOptimizer.get_context(opt_model_load):
+            opt_output_after_loading= opt_model(input_sample)
+        assert torch.allclose(opt_output, opt_output_after_loading, atol=1e-05)  # output is the same with model after loading
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            InferenceOptimizer.save(opt_model, tmpdir, compression="bf16")
+            opt_model_load = InferenceOptimizer.load(tmpdir, model=self.model,
+                                                     input_sample=input_sample)
+            compressed_size_ipex = os.path.getsize(os.path.join(tmpdir, "ckpt.pth"))
+        with InferenceOptimizer.get_context(opt_model):
+            opt_output_after_saving = opt_model(input_sample)
+        assert torch.allclose(opt_output, opt_output_after_saving, atol=1e-05)  # output is the same with model before saving
         with InferenceOptimizer.get_context(opt_model_load):
             opt_output_after_loading = opt_model_load(input_sample)
         assert compressed_size_ipex < 0.8 * original_size


### PR DESCRIPTION
## Description

Support compressed saving logic for `accelerator=jit` by saving state dict of bf16 model, and when loading, load the state_dict to fp32 and then convert again.

### 1. Why the change?

https://github.com/intel-analytics/BigDL/pull/7616
https://github.com/analytics-zoo/nano/issues/294

### 2. User API changes
makes `compression='bf16'` works for JIT model.
```python
# for pure jit
opt_model = InferenceOptimizer.trace(model,
                                     accelerator="jit",
                                     input_sample=input_sample,
                                     use_ipex=False)
InferenceOptimizer.save(opt_model, dir, compression="bf16")
opt_model_load = InferenceOptimizer.load(dir, model=model,
                                         input_sample=input_sample)
# for jit ipex
opt_model = InferenceOptimizer.trace(model,
                                     accelerator="jit",
                                     input_sample=input_sample,
                                     use_ipex=True)
InferenceOptimizer.save(opt_model, dir, compression="bf16")
opt_model_load = InferenceOptimizer.load(dir, model=model,
                                         input_sample=input_sample)
```

### 3. Summary of the change 

- support compressed saving logic for `accelerator=jit` by saving state dict of bf16 model, and when loading, load the state_dict to fp32 and then convert again
![image](https://user-images.githubusercontent.com/105281011/220317672-03d4c049-eea8-4a5f-94cf-3dbf8008626a.png)

- update and complete related uts

### 4. How to test?
- [x] Unit test

TODO:
locate why jit model will generate different result for the same input sample.
