### PR TITLE
Nano: fix tf custom model trace/quantize

### DIFF
--- a/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/tensorflow_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/tensorflow_onnxruntime_model.py
@@ -21,7 +21,8 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 import tensorflow as tf
 from bigdl.nano.utils.common import get_default_args
-from bigdl.nano.utils.tf import KERAS_VERSION_LESS_2_10, fake_tensor_from_spec
+from bigdl.nano.utils.tf import KERAS_VERSION_LESS_2_10
+from bigdl.nano.utils.tf import tensor_spec_to_shape
 from bigdl.nano.tf.model import AcceleratedKerasModel
 from bigdl.nano.utils.common import invalidInputError
 
@@ -52,29 +53,28 @@ class KerasONNXRuntimeModel(ONNXRuntimeModel, AcceleratedKerasModel):
         AcceleratedKerasModel.__init__(self, None)
         with TemporaryDirectory() as tmpdir:
             if isinstance(model, tf.keras.Model):
-                onnx_path = os.path.join(tmpdir, "tmp.onnx")
-                if input_spec is None:
+                if input_spec is not None:
+                    input_shape = tensor_spec_to_shape(input_spec)
+                    self._output_shape = model.compute_output_shape(input_shape)
+                elif hasattr(model, "input_shape"):
+                    # Sequential and functional API model has
+                    # `input_shape` and `output_shape` attributes
                     input_spec = tf.TensorSpec(model.input_shape, model.dtype)
-                if hasattr(model, "output_shape"):
                     self._output_shape = model.output_shape
-                elif isinstance(input_spec, (tuple, list)):
-                    self._output_shape = model.compute_output_shape((i.shape for i in input_spec))
                 else:
-                    self._output_shape = model.compute_output_shape(input_spec.shape)
-                while isinstance(self._output_shape, list) and len(self._output_shape) == 1:
-                    self._output_shape = self._output_shape[0]
+                    invalidInputError(False,
+                                      "Subclassed model must specify `input_spec` parameter.")
                 if not isinstance(input_spec, (tuple, list)):
+                    # ONNX requires that `input_spec` must be a tuple or list
                     input_spec = (input_spec, )
+                self._nesting_level = 0
+                while isinstance(self._output_shape, list) and len(self._output_shape) == 1:
+                    # A workaround, may be changed in the future
+                    self._nesting_level += 1
+                    self._output_shape = self._output_shape[0]
+                onnx_path = os.path.join(tmpdir, "tmp.onnx")
                 tf2onnx.convert.from_keras(model, input_signature=input_spec,
                                            output_path=onnx_path, **export_kwargs)
-                # save the nesting level of inference output
-                fake_inputs = [fake_tensor_from_spec(spec) for spec in input_spec]
-                fake_outputs = model(*fake_inputs)
-                self._nesting_level = 0
-                while isinstance(fake_outputs, (tuple, list)) and len(fake_outputs) == 1:
-                    self._nesting_level += 1
-                    fake_outputs = fake_outputs[0]
-
                 self._inputs_dtypes = [inp.dtype for inp in input_spec]
                 self._default_kwargs = get_default_args(model.call)
                 if KERAS_VERSION_LESS_2_10:

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -22,6 +22,7 @@ from .dataloader import KerasOpenVINODataLoader
 from .metric import KerasOpenVINOMetric
 import tensorflow as tf
 from bigdl.nano.utils.common import invalidInputError
+from bigdl.nano.utils.tf import tensor_spec_to_shape
 from ..core.utils import save
 import pickle
 import os
@@ -51,28 +52,24 @@ class KerasOpenVINOModel(AcceleratedKerasModel):
         :param **kwargs: will be passed to model optimizer function.
         """
         ov_model_path = model
-        with TemporaryDirectory() as dir:
-            dir = Path(dir)
+        with TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
             if isinstance(model, tf.keras.Model):
-                saved_model_input_spec_set = model._saved_model_inputs_spec is not None
-                if not model.built and not saved_model_input_spec_set:
-                    invalidInputError(input_spec is not None,
-                                      "`input_spec` cannot be None when passing unbuilt model.")
-                    # model cannot be saved either because the input shape is not available
-                    # or because the forward pass of the model is not defined
-                    if isinstance(input_spec, (tuple, list)):
-                        input_shape = (i.shape for i in input_spec)
-                    else:
-                        input_shape = input_spec.shape
+                if input_spec is not None:
+                    input_shape = tensor_spec_to_shape(input_spec)
                     self._output_shape = model.compute_output_shape(input_shape)
-                else:
+                elif hasattr(model, "input_shape"):
+                    # Sequential and functional API model has
+                    # `input_shape` and `output_shape` attributes
                     self._output_shape = model.output_shape
-
-                export(model, str(dir / 'tmp.xml'),
+                else:
+                    invalidInputError(False,
+                                      "Subclassed model must specify `input_spec` parameter.")
+                export(model, str(tmp_dir / 'tmp.xml'),
                        precision=precision,
                        logging=logging,
                        **kwargs)
-                ov_model_path = dir / 'tmp.xml'
+                ov_model_path = tmp_dir / 'tmp.xml'
             self.ov_model = OpenVINOModel(ov_model_path,
                                           device=device,
                                           precision=precision,

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -44,6 +44,7 @@ from bigdl.nano.deps.onnxruntime.onnxruntime_api import load_onnxruntime_model
 from bigdl.nano.deps.neural_compressor.inc_api import load_inc_model
 from bigdl.nano.tf.keras.amp import BF16Model, load_bf16_model
 from bigdl.nano.utils.common import compare_version
+from bigdl.nano.utils.tf import tensor_spec_to_shape
 
 
 class TFAccelerationOption(AccelerationOption):
@@ -624,20 +625,16 @@ class InferenceOptimizer(BaseInferenceOptimizer):
             if batch:
                 calib_dataset = calib_dataset.batch(batch)
 
-            saved_model_input_spec_set = model._saved_model_inputs_spec is not None
-            if not model.built and not saved_model_input_spec_set or \
-                    not hasattr(model, 'output_shape'):
-                invalidInputError(input_spec is not None,
-                                  "`input_spec` cannot be None when passing unbuilt model.")
-                # model cannot be saved either because the input shape is not available
-                # or because the forward pass of the model is not defined
-                if isinstance(input_spec, (tuple, list)):
-                    input_shape = (i.shape for i in input_spec)
-                else:
-                    input_shape = input_spec.shape
+            if input_spec is not None:
+                input_shape = tensor_spec_to_shape(input_spec)
                 _output_shape = model.compute_output_shape(input_shape)
-            else:
+            elif hasattr(model, "input_shape"):
+                # Sequential and functional API model has
+                # `input_shape` and `output_shape` attributes
                 _output_shape = model.output_shape
+            else:
+                invalidInputError(False,
+                                  "Subclassed model must specify `input_spec` parameter.")
             if model.inputs is None or model.outputs is None:
                 INC_LESS_14 = compare_version("neural_compressor", operator.lt, "1.14")
                 # oly works for inc version >= 1.14

--- a/python/nano/src/bigdl/nano/utils/tf/__init__.py
+++ b/python/nano/src/bigdl/nano/utils/tf/__init__.py
@@ -25,4 +25,4 @@ from .attributes import patch_compiled_and_attrs
 
 from .backend import MultiprocessingBackend
 
-from .preprocess import fake_tensor_from_spec
+from .preprocess import tensor_spec_to_shape

--- a/python/nano/src/bigdl/nano/utils/tf/preprocess.py
+++ b/python/nano/src/bigdl/nano/utils/tf/preprocess.py
@@ -14,15 +14,14 @@
 # limitations under the License.
 #
 
+from typing import Sequence, Union
+
 import tensorflow as tf
 
 
-def fake_tensor_from_spec(tensor_spec: tf.TensorSpec):
-    """Fake a `Tensor` from `TensorSpec`."""
-    shape = tensor_spec.shape
-    dtype = tensor_spec.dtype
-    shape = tuple(dim if dim is not None else 1 for dim in shape)
-    if shape == () and dtype == tf.bool:
-        # This may be the `training` parameter, we should assume it is False
-        return False
-    return tf.ones(shape=shape, dtype=dtype)
+def tensor_spec_to_shape(tensor_specs: Union[tf.TensorSpec, Sequence[tf.TensorSpec]]):
+    """Convert TensorSpec(s) to shape(s)."""
+    if isinstance(tensor_specs, Sequence):
+        return tuple(spec.shape for spec in tensor_specs)
+    else:
+        return tensor_specs.shape


### PR DESCRIPTION
## Description

After this PR, user must specify `input_spec` parameter when trace/quantize tf subclassed model.

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
