### PR TITLE
Chronos: support numpy in and out onnx/openvino models without converting to tensors

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1964,11 +1964,11 @@ class BasePytorchForecaster(Forecaster):
                                               onnxruntime_session_options=sess_options,
                                               thread_num=thread_num)
         if accelerator == 'onnxruntime':
-            q_model.output_tensors=False
+            q_model.output_tensors = False
             self.accelerated_model = q_model
             self.accelerate_method = "onnxruntime_int8"
         if accelerator == 'openvino':
-            q_model.output_tensors=False
+            q_model.output_tensors = False
             self.accelerated_model = q_model
             self.accelerate_method = "openvino_int8"
         if accelerator is None:

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -760,11 +760,11 @@ class BasePytorchForecaster(Forecaster):
                                                           batch_size=batch_size)
                     else:
                         self.accelerated_model.eval()
-                        yhat = _pytorch_fashion_inference(model=self.accelerated_model,
-                                                          input_data=data,
-                                                          batch_size=batch_size,
-                                                          output_tensor=
-                                                            self.optimized_model_output_tensor)
+                        yhat = _pytorch_fashion_inference(
+                            model=self.accelerated_model,
+                            input_data=data,
+                            batch_size=batch_size,
+                            output_tensor=self.optimized_model_output_tensor)
             if not is_local_data:
                 yhat = np_to_xshard(yhat, self.workers_per_node, prefix="prediction")
             return yhat
@@ -1123,10 +1123,11 @@ class BasePytorchForecaster(Forecaster):
                                                           batch_size=batch_size)
                     else:
                         self.accelerated_model.eval()
-                        yhat = _pytorch_fashion_inference(model=self.accelerated_model,
-                                                          input_data=input_data,
-                                                          batch_size=batch_size,
-                                                          output_tensor=self.optimized_model_output_tensor)
+                        yhat = _pytorch_fashion_inference(
+                            model=self.accelerated_model,
+                            input_data=input_data,
+                            batch_size=batch_size,
+                            output_tensor=self.optimized_model_output_tensor)
 
             aggregate = 'mean' if multioutput == 'uniform_average' else None
             return Evaluator.evaluate(self.metrics, target,
@@ -1218,7 +1219,6 @@ class BasePytorchForecaster(Forecaster):
                 target = np.concatenate(tuple(val[1] for val in data), axis=0)
         else:
             input_data, target = data
-
         if not self.context_enabled:
             self.cxt_manager = ForecasterContextManager(self, self.thread_num, True)
         else:

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -763,7 +763,7 @@ class BasePytorchForecaster(Forecaster):
                         yhat = _pytorch_fashion_inference(model=self.accelerated_model,
                                                           input_data=data,
                                                           batch_size=batch_size,
-                                                          output_tensor=\
+                                                          output_tensor=
                                                             self.optimized_model_output_tensor)
             if not is_local_data:
                 yhat = np_to_xshard(yhat, self.workers_per_node, prefix="prediction")

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1554,7 +1554,8 @@ class BasePytorchForecaster(Forecaster):
         self.accelerated_model = InferenceOptimizer.trace(self.internal,
                                                           input_sample=dummy_input,
                                                           accelerator="onnxruntime",
-                                                          onnxruntime_session_options=sess_options)
+                                                          onnxruntime_session_options=sess_options,
+                                                          output_tensors=False)
         self.accelerate_method = "onnxruntime_fp32"
         self.optimized_model_thread_num = thread_num
 
@@ -1592,7 +1593,8 @@ class BasePytorchForecaster(Forecaster):
         self.accelerated_model = InferenceOptimizer.trace(self.internal,
                                                           input_sample=dummy_input,
                                                           accelerator="openvino",
-                                                          thread_num=thread_num)
+                                                          thread_num=thread_num,
+                                                          output_tensors=False)
         self.accelerate_method = "openvino_fp32"
         self.optimized_model_thread_num = thread_num
 
@@ -1962,9 +1964,11 @@ class BasePytorchForecaster(Forecaster):
                                               onnxruntime_session_options=sess_options,
                                               thread_num=thread_num)
         if accelerator == 'onnxruntime':
+            q_model.output_tensors=False
             self.accelerated_model = q_model
             self.accelerate_method = "onnxruntime_int8"
         if accelerator == 'openvino':
+            q_model.output_tensors=False
             self.accelerated_model = q_model
             self.accelerate_method = "openvino_int8"
         if accelerator is None:

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -1231,7 +1231,8 @@ class BasePytorchForecaster(Forecaster):
                                       "please call .quantize() method first")
                 yhat = _pytorch_fashion_inference(model=self.accelerated_model,
                                                   input_data=input_data,
-                                                  batch_size=batch_size)
+                                                  batch_size=batch_size,
+                                                  output_tensor=self.optimized_model_output_tensor)
             else:
                 if self.accelerate_method != "onnxruntime_fp32":
                     self.build_onnx()

--- a/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
@@ -160,6 +160,7 @@ class LSTMForecaster(BasePytorchForecaster):
         self.quantize_available = True
         self.checkpoint_callback = True
         self.use_hpo = True
+        self.optimized_model_output_tensor = True
 
         super().__init__()
 

--- a/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
@@ -168,6 +168,7 @@ class NBeatsForecaster(BasePytorchForecaster):
         self.quantize_available = True
         self.checkpoint_callback = True
         self.use_hpo = True
+        self.optimized_model_output_tensor = True
 
         super().__init__()
 

--- a/python/chronos/src/bigdl/chronos/forecaster/seq2seq_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/seq2seq_forecaster.py
@@ -164,5 +164,6 @@ class Seq2SeqForecaster(BasePytorchForecaster):
         self.quantize_available = False
         self.checkpoint_callback = True
         self.use_hpo = True
+        self.optimized_model_output_tensor = True
 
         super().__init__()

--- a/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
@@ -184,5 +184,6 @@ class TCNForecaster(BasePytorchForecaster):
         self.quantize_available = True
         self.checkpoint_callback = True
         self.use_hpo = True
+        self.optimized_model_output_tensor = True
 
         super().__init__()

--- a/python/chronos/src/bigdl/chronos/pytorch/utils.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/utils.py
@@ -81,7 +81,8 @@ def _pytorch_fashion_inference(model, input_data, batch_size=None, output_tensor
     else:
         # Reduce time of type transforms between tensor and numpy
         if isinstance(input_data, DataLoader):
-            input_sample_list = list(map(lambda x: x[0].numpy(), input_data))
+            input_sample = tuple(batch[0].numpy() for batch in input_data)
+            input_sample_list = [np.concatenate(input_sample, axis=0)]
         elif isinstance(input_data, np.ndarray):
             input_sample_list = [input_data]
         else:

--- a/python/chronos/src/bigdl/chronos/pytorch/utils.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/utils.py
@@ -19,7 +19,7 @@ import numpy as np
 from torch.utils.data.dataloader import DataLoader
 
 
-def _inference(model, input_sample_list, batch_size):
+def _tensor_inference(model, input_sample_list, batch_size):
     if batch_size is None:
         # this branch is only to speed up the inferencing when batch_size is set to None.
         return model(*input_sample_list).numpy()
@@ -39,7 +39,26 @@ def _inference(model, input_sample_list, batch_size):
             return yhat
 
 
-def _pytorch_fashion_inference(model, input_data, batch_size=None):
+def _numpy_inference(model, input_sample_list, batch_size):
+    if batch_size is None:
+        return model(*input_sample_list)
+    else:
+        yhat_list = []
+        sample_num = input_sample_list[0].shape[0]  # the first dim should be sample_num
+        if sample_num <= batch_size:
+            return model(*input_sample_list)
+        else:
+            batch_num = math.ceil(sample_num / batch_size)
+            for batch_id in range(batch_num):
+                yhat_list.append(model(
+                    *tuple(map(lambda x: x[batch_id * batch_size: (batch_id + 1) * batch_size],
+                               input_sample_list))))
+            # this operation may cause performance degradation
+            yhat = np.concatenate(yhat_list, axis=0)
+            return yhat
+
+
+def _pytorch_fashion_inference(model, input_data, batch_size=None, output_tensor=True):
     '''
     This is an internal inference pattern for any models which can be used like:
     `model(x)  # x is a pytorch tensor`
@@ -47,14 +66,25 @@ def _pytorch_fashion_inference(model, input_data, batch_size=None):
     :param model: The model to inference
     :param input_data: numpy ndarray
     :param batch_size: batch size
+    :param output_tensor: whether original output of the model is Tensor.
 
     :return: numpy ndarray
     '''
-    if isinstance(input_data, list):
-        input_sample_list = list(map(lambda x: torch.from_numpy(x), input_data))
-    elif isinstance(input_data, DataLoader):
-        input_sample_list = [torch.cat(tuple(batch[0] for batch in input_data), dim=0)]
+    if output_tensor:
+        if isinstance(input_data, list):
+            input_sample_list = list(map(lambda x: torch.from_numpy(x), input_data))
+        elif isinstance(input_data, DataLoader):
+            input_sample_list = [torch.cat(tuple(batch[0] for batch in input_data), dim=0)]
+        else:
+            input_sample_list = [torch.from_numpy(input_data)]
+        yhat = _tensor_inference(model, input_sample_list, batch_size=batch_size)
     else:
-        input_sample_list = [torch.from_numpy(input_data)]
-    yhat = _inference(model, input_sample_list, batch_size=batch_size)
+        # Reduce time of type transforms between tensor and numpy
+        if isinstance(input_data, DataLoader):
+            input_sample_list = list(map(lambda x: x[0].numpy(), input_data))
+        elif isinstance(input_data, np.ndarray):
+            input_sample_list = [input_data]
+        else:
+            input_sample_list = input_data
+        yhat = _numpy_inference(model, input_sample_list, batch_size=batch_size)
     return yhat

--- a/python/chronos/src/bigdl/chronos/pytorch/utils.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/utils.py
@@ -90,17 +90,4 @@ def _pytorch_fashion_inference(model, input_data, batch_size=None, output_tensor
             else:
                 input_sample_list = input_data
             yhat = _numpy_inference(model, input_sample_list, batch_size=batch_size)
-<<<<<<< HEAD
-    else:
-        # Reduce time of type transforms between tensor and numpy
-        if isinstance(input_data, DataLoader):
-            input_sample = tuple(batch[0].numpy() for batch in input_data)
-            input_sample_list = [np.concatenate(input_sample, axis=0)]
-        elif isinstance(input_data, np.ndarray):
-            input_sample_list = [input_data]
-        else:
-            input_sample_list = input_data
-        yhat = _numpy_inference(model, input_sample_list, batch_size=batch_size)
-=======
->>>>>>> 4eb52fe1b (fix)
     return yhat

--- a/python/chronos/src/bigdl/chronos/pytorch/utils.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/utils.py
@@ -70,14 +70,17 @@ def _pytorch_fashion_inference(model, input_data, batch_size=None, output_tensor
 
     :return: numpy ndarray
     '''
-    if output_tensor:
-        if isinstance(input_data, list):
-            input_sample_list = list(map(lambda x: torch.from_numpy(x), input_data))
-        elif isinstance(input_data, DataLoader):
-            input_sample_list = [torch.cat(tuple(batch[0] for batch in input_data), dim=0)]
-        else:
-            input_sample_list = [torch.from_numpy(input_data)]
-        yhat = _tensor_inference(model, input_sample_list, batch_size=batch_size)
+    if hasattr(model, "output_tensors") and not model.output_tensors:
+        # Reduce time of type transformation between tensor and numpy
+        with torch.inference_mode():
+            if isinstance(input_data, DataLoader):
+                input_sample = tuple(batch[0].numpy() for batch in input_data)
+                input_sample_list = [np.concatenate(input_sample, axis=0)]
+            elif isinstance(input_data, np.ndarray):
+                input_sample_list = [input_data]
+            else:
+                input_sample_list = input_data
+            yhat = _numpy_inference(model, input_sample_list, batch_size=batch_size)
     else:
         # Reduce time of type transforms between tensor and numpy
         if isinstance(input_data, DataLoader):

--- a/python/chronos/src/bigdl/chronos/pytorch/utils.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/utils.py
@@ -71,23 +71,21 @@ def _pytorch_fashion_inference(model, input_data, batch_size=None, output_tensor
     :return: numpy ndarray
     '''
     if output_tensor:
-        with torch.inference_mode():
-            if isinstance(input_data, list):
-                input_sample_list = list(map(lambda x: torch.from_numpy(x), input_data))
-            elif isinstance(input_data, DataLoader):
-                input_sample_list = [torch.cat(tuple(batch[0] for batch in input_data), dim=0)]
-            else:
-                input_sample_list = [torch.from_numpy(input_data)]
-            yhat = _tensor_inference(model, input_sample_list, batch_size=batch_size)
+        if isinstance(input_data, list):
+            input_sample_list = list(map(lambda x: torch.from_numpy(x), input_data))
+        elif isinstance(input_data, DataLoader):
+            input_sample_list = [torch.cat(tuple(batch[0] for batch in input_data), dim=0)]
+        else:
+            input_sample_list = [torch.from_numpy(input_data)]
+        yhat = _tensor_inference(model, input_sample_list, batch_size=batch_size)
     else:
         # Reduce time of type transforms between tensor and numpy
-        with torch.inference_mode():
-            if isinstance(input_data, DataLoader):
-                input_sample = tuple(batch[0].numpy() for batch in input_data)
-                input_sample_list = [np.concatenate(input_sample, axis=0)]
-            elif isinstance(input_data, np.ndarray):
-                input_sample_list = [input_data]
-            else:
-                input_sample_list = input_data
-            yhat = _numpy_inference(model, input_sample_list, batch_size=batch_size)
+        if isinstance(input_data, DataLoader):
+            input_sample = tuple(batch[0].numpy() for batch in input_data)
+            input_sample_list = [np.concatenate(input_sample, axis=0)]
+        elif isinstance(input_data, np.ndarray):
+            input_sample_list = [input_data]
+        else:
+            input_sample_list = input_data
+        yhat = _numpy_inference(model, input_sample_list, batch_size=batch_size)
     return yhat

--- a/python/chronos/src/bigdl/chronos/pytorch/utils.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/utils.py
@@ -70,8 +70,17 @@ def _pytorch_fashion_inference(model, input_data, batch_size=None, output_tensor
 
     :return: numpy ndarray
     '''
-    if hasattr(model, "output_tensors") and not model.output_tensors:
-        # Reduce time of type transformation between tensor and numpy
+    if output_tensor:
+        with torch.inference_mode():
+            if isinstance(input_data, list):
+                input_sample_list = list(map(lambda x: torch.from_numpy(x), input_data))
+            elif isinstance(input_data, DataLoader):
+                input_sample_list = [torch.cat(tuple(batch[0] for batch in input_data), dim=0)]
+            else:
+                input_sample_list = [torch.from_numpy(input_data)]
+            yhat = _tensor_inference(model, input_sample_list, batch_size=batch_size)
+    else:
+        # Reduce time of type transforms between tensor and numpy
         with torch.inference_mode():
             if isinstance(input_data, DataLoader):
                 input_sample = tuple(batch[0].numpy() for batch in input_data)
@@ -81,6 +90,7 @@ def _pytorch_fashion_inference(model, input_data, batch_size=None, output_tensor
             else:
                 input_sample_list = input_data
             yhat = _numpy_inference(model, input_sample_list, batch_size=batch_size)
+<<<<<<< HEAD
     else:
         # Reduce time of type transforms between tensor and numpy
         if isinstance(input_data, DataLoader):
@@ -91,4 +101,6 @@ def _pytorch_fashion_inference(model, input_data, batch_size=None, output_tensor
         else:
             input_sample_list = input_data
         yhat = _numpy_inference(model, input_sample_list, batch_size=batch_size)
+=======
+>>>>>>> 4eb52fe1b (fix)
     return yhat

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -854,3 +854,79 @@ class TestChronosModelLSTMForecaster(TestCase):
             assert current_thread == num
             for x, y in test_loader:
                 yhat = forecaster.predict(x.numpy())
+
+    @op_inference
+    def test_lstm_forecaster_numpy_inference(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = LSTMForecaster(past_seq_len=24,
+                                    input_feature_num=2,
+                                    output_feature_num=2,
+                                    loss="mse",
+                                    lr=0.01)
+        forecaster.fit(train_data, epochs=1)
+        # onnx model
+        forecaster.quantize(calib_data=train_data,
+                            val_data=val_data,
+                            framework="onnxrt_qlinearops")
+        q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_data[0], quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_data[0], quantize=True)
+        np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
+        # openvino model
+        forecaster.quantize(calib_data=train_data,
+                            val_data=val_data,
+                            framework="openvino")
+        q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_data[0], quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_data[0], quantize=True)
+        np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
+
+    @op_inference
+    def test_lstm_forecaster_numpy_inference_loader(self):
+        train_loader, val_loader, test_loader = create_data(loader=True)
+        forecaster = LSTMForecaster(past_seq_len=24,
+                                    input_feature_num=2,
+                                    output_feature_num=2,
+                                    loss="mse",
+                                    lr=0.01)
+        forecaster.fit(train_loader, epochs=1)
+        # onnx model
+        forecaster.quantize(calib_data=train_loader,
+                            val_data=val_loader,
+                            framework="onnxrt_qlinearops")
+        q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
+        np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
+        # openvino model
+        forecaster.quantize(calib_data=train_loader,
+                            val_data=val_loader,
+                            framework="openvino")
+        q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_loader, quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_loader, quantize=True)
+        np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
+
+    @op_inference
+    def test_lstm_forecaster_numpy_inference_tsdataset(self):
+        train, test = create_tsdataset(roll=True)
+        forecaster = LSTMForecaster(past_seq_len=24,
+                                    input_feature_num=2,
+                                    output_feature_num=2,
+                                    loss="mse",
+                                    lr=0.01)
+        forecaster.fit(train, epochs=1)
+        # onnx model
+        forecaster.quantize(calib_data=train,
+                            framework="onnxrt_qlinearops")
+        q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test, quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test, quantize=True)
+        np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
+        # openvino model
+        forecaster.quantize(calib_data=train,
+                            framework="openvino")
+        q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test, quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test, quantize=True)
+        np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -870,6 +870,7 @@ class TestChronosModelLSTMForecaster(TestCase):
                             framework="onnxrt_qlinearops")
         q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_data[0], quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_data[0], quantize=True)
         np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
         # openvino model
@@ -878,6 +879,7 @@ class TestChronosModelLSTMForecaster(TestCase):
                             framework="openvino")
         q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_data[0], quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_data[0], quantize=True)
         np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
 
@@ -896,6 +898,7 @@ class TestChronosModelLSTMForecaster(TestCase):
                             framework="onnxrt_qlinearops")
         q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
         np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
         # openvino model
@@ -904,6 +907,7 @@ class TestChronosModelLSTMForecaster(TestCase):
                             framework="openvino")
         q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_loader, quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_loader, quantize=True)
         np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
 
@@ -921,6 +925,7 @@ class TestChronosModelLSTMForecaster(TestCase):
                             framework="onnxrt_qlinearops")
         q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test, quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test, quantize=True)
         np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
         # openvino model
@@ -928,5 +933,6 @@ class TestChronosModelLSTMForecaster(TestCase):
                             framework="openvino")
         q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test, quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test, quantize=True)
         np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -831,3 +831,77 @@ class TestChronosNBeatsForecaster(TestCase):
                         n_trials=2, target_metric=['mse', 'latency'], 
                         directions=["minimize", "minimize"],
                         acceleration=True, direction=None)
+
+    @op_inference
+    def test_nbeats_forecaster_numpy_inference(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = NBeatsForecaster(past_seq_len=24,
+                                      future_seq_len=5,
+                                      loss='mae',
+                                      lr=0.01)
+        forecaster.fit(train_data, epochs=1)
+        # onnx model
+        forecaster.quantize(calib_data=train_data,
+                            val_data=val_data,
+                            framework="onnxrt_qlinearops")
+        q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_data[0], quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_data[0], quantize=True)
+        np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
+        # openvino model
+        forecaster.quantize(calib_data=train_data,
+                            val_data=val_data,
+                            framework="openvino")
+        q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_data[0], quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_data[0], quantize=True)
+        np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
+
+    @op_inference
+    def test_nbeats_forecaster_numpy_inference_loader(self):
+        train_loader, val_loader, test_loader = create_data(loader=True)
+        forecaster = NBeatsForecaster(past_seq_len=24,
+                                      future_seq_len=5,
+                                      loss='mae',
+                                      lr=0.01)
+        forecaster.fit(train_loader, epochs=1)
+        # onnx model
+        forecaster.quantize(calib_data=train_loader,
+                            val_data=val_loader,
+                            framework="onnxrt_qlinearops")
+        q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
+        np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
+        # openvino model
+        forecaster.quantize(calib_data=train_loader,
+                            val_data=val_loader,
+                            framework="openvino")
+        q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_loader, quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_loader, quantize=True)
+        np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
+
+    @op_inference
+    def test_nbeats_forecaster_numpy_inference_tsdataset(self):
+        train, test = create_tsdataset(roll=True)
+        forecaster = NBeatsForecaster(past_seq_len=24,
+                                      future_seq_len=5,
+                                      loss='mae',
+                                      lr=0.01)
+        forecaster.fit(train, epochs=1)
+        # onnx model
+        forecaster.quantize(calib_data=train,
+                            framework="onnxrt_qlinearops")
+        q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test, quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test, quantize=True)
+        np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
+        # openvino model
+        forecaster.quantize(calib_data=train,
+                            framework="openvino")
+        q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test, quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test, quantize=True)
+        np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
+

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -846,6 +846,7 @@ class TestChronosNBeatsForecaster(TestCase):
                             framework="onnxrt_qlinearops")
         q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_data[0], quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_data[0], quantize=True)
         np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
         # openvino model
@@ -854,6 +855,7 @@ class TestChronosNBeatsForecaster(TestCase):
                             framework="openvino")
         q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_data[0], quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_data[0], quantize=True)
         np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
 
@@ -871,6 +873,7 @@ class TestChronosNBeatsForecaster(TestCase):
                             framework="onnxrt_qlinearops")
         q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
         np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
         # openvino model
@@ -879,6 +882,7 @@ class TestChronosNBeatsForecaster(TestCase):
                             framework="openvino")
         q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_loader, quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_loader, quantize=True)
         np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
 
@@ -895,6 +899,7 @@ class TestChronosNBeatsForecaster(TestCase):
                             framework="onnxrt_qlinearops")
         q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test, quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test, quantize=True)
         np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
         # openvino model
@@ -902,6 +907,7 @@ class TestChronosNBeatsForecaster(TestCase):
                             framework="openvino")
         q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test, quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test, quantize=True)
         np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
 

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -742,3 +742,66 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
             assert current_thread == num
             for x, y in test_loader:
                 yhat = forecaster.predict(x.numpy())
+
+    @op_inference
+    def test_s2s_forecaster_numpy_inference(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = Seq2SeqForecaster(past_seq_len=24,
+                                       future_seq_len=5,
+                                       input_feature_num=1,
+                                       output_feature_num=1,
+                                       loss="mse",
+                                       lr=0.01)
+        forecaster.fit(train_data, epochs=1)
+        # onnx model
+        q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_data[0])
+        forecaster.accelerated_model.output_tensors = True
+        q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_data[0])
+        np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
+        # openvino model
+        q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_data[0])
+        forecaster.accelerated_model.output_tensors = True
+        q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_data[0])
+        np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
+
+    @op_inference
+    def test_s2s_forecaster_numpy_inference_loader(self):
+        train_loader, val_loader, test_loader = create_data(loader=True)
+        forecaster = Seq2SeqForecaster(past_seq_len=24,
+                                       future_seq_len=5,
+                                       input_feature_num=1,
+                                       output_feature_num=1,
+                                       loss="mse",
+                                       lr=0.01)
+        forecaster.fit(train_loader, epochs=1)
+        # onnx model
+        q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_loader)
+        forecaster.accelerated_model.output_tensors = True
+        q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_loader)
+        np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
+        # openvino model
+        q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_loader)
+        forecaster.accelerated_model.output_tensors = True
+        q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_loader)
+        np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
+
+    @op_inference
+    def test_s2s_forecaster_numpy_inference_tsdataset(self):
+        train, test = create_tsdataset(roll=True)
+        forecaster = Seq2SeqForecaster(past_seq_len=24,
+                                       future_seq_len=5,
+                                       input_feature_num=2,
+                                       output_feature_num=2,
+                                       loss="mse",
+                                       lr=0.01)
+        forecaster.fit(train, epochs=1)
+        # onnx model
+        q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test)
+        forecaster.accelerated_model.output_tensors = True
+        q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test)
+        np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
+        # openvino model
+        q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test)
+        forecaster.accelerated_model.output_tensors = True
+        q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test)
+        np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -756,11 +756,13 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         # onnx model
         q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_data[0])
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_data[0])
         np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
         # openvino model
         q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_data[0])
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_data[0])
         np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
 
@@ -777,11 +779,13 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         # onnx model
         q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_loader)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_loader)
         np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
         # openvino model
         q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_loader)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_loader)
         np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
 
@@ -798,10 +802,12 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
         # onnx model
         q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test)
         np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
         # openvino model
         q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test)
         np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -1518,6 +1518,7 @@ class TestChronosModelTCNForecaster(TestCase):
                             framework="onnxrt_qlinearops")
         q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_data[0], quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_data[0], quantize=True)
         np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
         # openvino model
@@ -1526,6 +1527,7 @@ class TestChronosModelTCNForecaster(TestCase):
                             framework="openvino")
         q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_data[0], quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_data[0], quantize=True)
         np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
 
@@ -1547,6 +1549,7 @@ class TestChronosModelTCNForecaster(TestCase):
                             framework="onnxrt_qlinearops")
         q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
         np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
         # openvino model
@@ -1555,6 +1558,7 @@ class TestChronosModelTCNForecaster(TestCase):
                             framework="openvino")
         q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_loader, quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_loader, quantize=True)
         np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
 
@@ -1575,6 +1579,7 @@ class TestChronosModelTCNForecaster(TestCase):
                             framework="onnxrt_qlinearops")
         q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test, quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test, quantize=True)
         np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
         # openvino model
@@ -1582,5 +1587,6 @@ class TestChronosModelTCNForecaster(TestCase):
                             framework="openvino")
         q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test, quantize=True)
         forecaster.accelerated_model.output_tensors = True
+        forecaster.optimized_model_output_tensor = True
         q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test, quantize=True)
         np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -1499,3 +1499,88 @@ class TestChronosModelTCNForecaster(TestCase):
             assert current_thread == num
             for x, y in test_loader:
                 yhat = forecaster.predict(x.numpy())
+
+    @op_inference
+    def test_tcn_forecaster_numpy_inference(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = TCNForecaster(past_seq_len=24,
+                                   future_seq_len=5,
+                                   input_feature_num=1,
+                                   output_feature_num=1,
+                                   kernel_size=4,
+                                   num_channels=[16, 16],
+                                   loss="mae",
+                                   lr=0.01)
+        forecaster.fit(train_data, epochs=1)
+        # onnx model
+        forecaster.quantize(calib_data=train_data,
+                            val_data=val_data,
+                            framework="onnxrt_qlinearops")
+        q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_data[0], quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_data[0], quantize=True)
+        np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
+        # openvino model
+        forecaster.quantize(calib_data=train_data,
+                            val_data=val_data,
+                            framework="openvino")
+        q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_data[0], quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_data[0], quantize=True)
+        np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
+
+    @op_inference
+    def test_tcn_forecaster_numpy_inference_loader(self):
+        train_loader, val_loader, test_loader = create_data(loader=True)
+        forecaster = TCNForecaster(past_seq_len=24,
+                                    future_seq_len=5,
+                                    input_feature_num=1,
+                                    output_feature_num=1,
+                                    kernel_size=4,
+                                    num_channels=[16, 16],
+                                    loss="mae",
+                                    lr=0.01)
+        forecaster.fit(train_loader, epochs=1)
+        # onnx model
+        forecaster.quantize(calib_data=train_loader,
+                            val_data=val_loader,
+                            framework="onnxrt_qlinearops")
+        q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test_loader, quantize=True)
+        np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
+        # openvino model
+        forecaster.quantize(calib_data=train_loader,
+                            val_data=val_loader,
+                            framework="openvino")
+        q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test_loader, quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test_loader, quantize=True)
+        np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
+
+    @op_inference
+    def test_tcn_forecaster_numpy_inference_tsdataset(self):
+        train, test = create_tsdataset(roll=True)
+        forecaster = TCNForecaster(past_seq_len=24,
+                                    future_seq_len=5,
+                                    input_feature_num=2,
+                                    output_feature_num=2,
+                                    kernel_size=4,
+                                    num_channels=[16, 16],
+                                    loss="mae",
+                                    lr=0.01)
+        forecaster.fit(train, epochs=1)
+        # onnx model
+        forecaster.quantize(calib_data=train,
+                            framework="onnxrt_qlinearops")
+        q_onnx_numpy_yhat = forecaster.predict_with_onnx(data=test, quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_onnx_tensor_yhat = forecaster.predict_with_onnx(data=test, quantize=True)
+        np.testing.assert_almost_equal(q_onnx_numpy_yhat, q_onnx_tensor_yhat, decimal=5)
+        # openvino model
+        forecaster.quantize(calib_data=train,
+                            framework="openvino")
+        q_openvino_numpy_yhat = forecaster.predict_with_openvino(data=test, quantize=True)
+        forecaster.accelerated_model.output_tensors = True
+        q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test, quantize=True)
+        np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/onnxruntime_api.py
@@ -20,6 +20,7 @@ def PytorchONNXRuntimeModel(model, input_sample=None,
                             onnxruntime_session_options=None,
                             simplification=True,
                             dynamic_axes=True,
+                            output_tensors=True,
                             **export_kwargs):
     """
         Create a ONNX Runtime model from pytorch.
@@ -47,6 +48,8 @@ def PytorchONNXRuntimeModel(model, input_sample=None,
                              | are axis names. If a list, each element is an axis index.
 
                              If accelerator != 'openvino'/'onnxruntime', it will be ignored.
+        :param output_tensors: boolean, default to True and output of the model will be Tensors.
+                               If output_tensors=False, output of the ONNX model will be ndarray.
         :param **export_kwargs: will be passed to torch.onnx.export function.
         :return: A PytorchONNXRuntimeModel instance
         """
@@ -55,6 +58,7 @@ def PytorchONNXRuntimeModel(model, input_sample=None,
                                    onnxruntime_session_options=onnxruntime_session_options,
                                    simplification=simplification,
                                    dynamic_axes=dynamic_axes,
+                                   output_tensors=output_tensors,
                                    **export_kwargs)
 
 

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -36,7 +36,7 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
     '''
 
     def __init__(self, model, input_sample=None, onnxruntime_session_options=None,
-                 simplification=True, dynamic_axes=True, output_tensors=True,**export_kwargs):
+                 simplification=True, dynamic_axes=True, output_tensors=True, **export_kwargs):
         """
         Create a ONNX Runtime model from pytorch.
 

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -36,7 +36,7 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
     '''
 
     def __init__(self, model, input_sample=None, onnxruntime_session_options=None,
-                 simplification=True, dynamic_axes=True, **export_kwargs):
+                 simplification=True, dynamic_axes=True, output_tensors=True,**export_kwargs):
         """
         Create a ONNX Runtime model from pytorch.
 
@@ -63,6 +63,8 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
                              | are axis names. If a list, each element is an axis index.
 
                              If accelerator != 'openvino'/'onnxruntime', it will be ignored.
+        :param output_tensors: boolean, default to True and output of the model will be Tensors.
+                               If output_tensors=False, output of the ONNX model will be ndarray.
         :param **export_kwargs: will be passed to torch.onnx.export function.
         """
         # Typically, when model is int8, we use this path
@@ -94,6 +96,7 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
         if isinstance(model, torch.nn.Module):
             # patch original model's attr to current new model
             patch_attrs_from_model_to_object(model, self)
+        self.output_tensors = output_tensors
 
     def on_forward_start(self, inputs):
         if self.ortsess is None:
@@ -103,7 +106,10 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
         return inputs
 
     def on_forward_end(self, outputs):
-        outputs = self.numpy_to_tensors(outputs)
+        if self.output_tensors:
+            outputs = self.numpy_to_tensors(outputs)
+        elif len(outputs) == 1:
+            outputs = outputs[0]
         return outputs
 
     @property

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -19,7 +19,7 @@ from bigdl.nano.utils.common import invalidInputError
 def PytorchOpenVINOModel(model, input_sample=None, precision='fp32',
                          thread_num=None, device='CPU',
                          dynamic_axes=True, logging=True,
-                         config=None, **kwargs):
+                         config=None, output_tensors=True, **kwargs):
     """
     Create a OpenVINO model from pytorch.
 
@@ -49,6 +49,8 @@ def PytorchOpenVINOModel(model, input_sample=None, precision='fp32',
                          If accelerator != 'openvino'/'onnxruntime', it will be ignored.
     :param logging: whether to log detailed information of model conversion. default: True.
     :param config: The config to be inputted in core.compile_model.
+    :param output_tensors: boolean, default to True and output of the model will be Tensors.
+                           If output_tensors=False, output of the OpenVINO model will be ndarray.
     :param **kwargs: will be passed to torch.onnx.export function or model optimizer function.
     :return: PytorchOpenVINOModel model for OpenVINO inference.
     """
@@ -61,6 +63,7 @@ def PytorchOpenVINOModel(model, input_sample=None, precision='fp32',
                                 dynamic_axes=dynamic_axes,
                                 logging=logging,
                                 config=config,
+                                output_tensors=output_tensors,
                                 **kwargs)
 
 

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -32,7 +32,7 @@ from bigdl.nano.utils.pytorch import patch_attrs_from_model_to_object
 class PytorchOpenVINOModel(AcceleratedLightningModule):
     def __init__(self, model, input_sample=None, precision='fp32',
                  thread_num=None, device='CPU', dynamic_axes=True,
-                 logging=True, config=None, **kwargs):
+                 logging=True, config=None, output_tensors=True, **kwargs):
         """
         Create a OpenVINO model from pytorch.
 
@@ -63,6 +63,8 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                              If accelerator != 'openvino'/'onnxruntime', it will be ignored.
         :param logging: whether to log detailed information of model conversion. default: True.
         :param config: The config to be inputted in core.compile_model.
+        :param output_tensors: boolean, default to True and output of the model will be Tensors. If
+                               output_tensors=False, output of the OpenVINO model will be ndarray.
         :param **kwargs: will be passed to torch.onnx.export function or model optimizer function.
         """
         ov_model_path = model
@@ -89,6 +91,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         if isinstance(model, torch.nn.Module):
             # patch original model's attr to current new model
             patch_attrs_from_model_to_object(model, self)
+        self.output_tensors = output_tensors
 
     def on_forward_start(self, inputs):
         self.ov_model._model_exists_or_err()
@@ -99,7 +102,11 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         return self.ov_model.forward_step(*inputs)
 
     def on_forward_end(self, outputs):
-        outputs = self.numpy_to_tensors(outputs.values())
+        outputs = list(outputs.values())
+        if self.output_tensors:
+            outputs = self.numpy_to_tensors(outputs)
+        elif len(outputs) == 1:
+            outputs = outputs[0]
         return outputs
 
     @property

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -1022,7 +1022,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                               onednn#pytorch---onednn-graph-api-bridge.
         :param output_tensors: boolean, default to True and output of the model will be Tensors,
                                only valid when accelerator='onnxruntime' or accelerator='openvino',
-                               otherwise will be ignored. If output_tensors=False, output of the 
+                               otherwise will be ignored. If output_tensors=False, output of the
                                export model will be ndarray.
         :param **kwargs: Other extra advanced settings include:
                          1. those be passed to torch.onnx.export function,

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -950,6 +950,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
               inplace: bool = False,
               weights_prepack: Optional[bool] = None,
               enable_onednn: bool = True,
+              output_tensors: bool = True,
               **kwargs):
         """
         Trace a torch.nn.Module and convert it into an accelerated module for inference.
@@ -1019,6 +1020,10 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                               ignored. For more details, please refer https://github.com/pytorch/
                               pytorch/tree/master/torch/csrc/jit/codegen/
                               onednn#pytorch---onednn-graph-api-bridge.
+        :param output_tensors: boolean, default to True and output of the model will be Tensors,
+                               only valid when accelerator='onnxruntime' or accelerator='openvino',
+                               otherwise will be ignored. If output_tensors=False, output of the 
+                               export model will be ndarray.
         :param **kwargs: Other extra advanced settings include:
                          1. those be passed to torch.onnx.export function,
                          only valid when accelerator='onnxruntime'/'openvino',
@@ -1059,6 +1064,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                         dynamic_axes=dynamic_axes,
                                         logging=logging,
                                         config=final_openvino_option,
+                                        output_tensors=output_tensors,
                                         **kwargs)
         if accelerator == 'onnxruntime':  # onnxruntime backend will not care about ipex usage
             if onnxruntime_session_options is None:
@@ -1071,6 +1077,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                            onnxruntime_session_options,
                                            simplification=simplification,
                                            dynamic_axes=dynamic_axes,
+                                           output_tensors=output_tensors,
                                            **kwargs)
         if accelerator == 'jit' or use_ipex is True or channels_last is True:
             if use_ipex:

--- a/python/nano/test/onnx/pytorch/test_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_onnx.py
@@ -333,6 +333,29 @@ class TestOnnx(TestCase):
         accmodel(x2)
         accmodel(x3)
 
+    def test_onnx_trace_output_tensors(self):
+        model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
+        loss = nn.CrossEntropyLoss()
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+        trainer = Trainer(max_epochs=1)
+
+        pl_model = Trainer.compile(model, loss, optimizer)
+        x = torch.rand((10, 3, 256, 256))
+        y = torch.ones((10, ), dtype=torch.long)
+        ds = TensorDataset(x, y)
+        train_loader = DataLoader(ds, batch_size=2)
+        trainer.fit(pl_model, train_loader)
+
+        onnx_model = InferenceOptimizer.trace(pl_model, accelerator="onnxruntime",
+                                              input_sample=train_loader)
+        test_onnx_model = InferenceOptimizer.trace(pl_model, accelerator="onnxruntime",
+                                                   input_sample=train_loader, output_tensors=False)
+
+        for x, y in train_loader:
+            model.eval()
+            forward_res_tensor = onnx_model(x).numpy()
+            forward_res_numpy = test_onnx_model(x)
+            np.testing.assert_almost_equal(forward_res_tensor, forward_res_numpy, decimal=5)
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/python/nano/test/onnx/pytorch/test_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_onnx.py
@@ -334,17 +334,15 @@ class TestOnnx(TestCase):
         accmodel(x3)
 
     def test_onnx_trace_output_tensors(self):
-        model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
+        model = ResNet18(10, pretrained=True, include_top=False, freeze=True)
         loss = nn.CrossEntropyLoss()
         optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
-        trainer = Trainer(max_epochs=1)
 
         pl_model = Trainer.compile(model, loss, optimizer)
         x = torch.rand((10, 3, 256, 256))
         y = torch.ones((10, ), dtype=torch.long)
         ds = TensorDataset(x, y)
         train_loader = DataLoader(ds, batch_size=2)
-        trainer.fit(pl_model, train_loader)
 
         onnx_model = InferenceOptimizer.trace(pl_model, accelerator="onnxruntime",
                                               input_sample=train_loader)

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -364,3 +364,26 @@ class TestOpenVINO(TestCase):
             new_model = InferenceOptimizer.load(tmp_dir_name)
         new_model(image_latents, torch.Tensor([980]).long(), encoder_hidden_states)
         new_model(image_latents2, torch.Tensor([980]).long(), encoder_hidden_states2)
+
+    def test_openvino_trace_output_tensors(self):
+        trainer = Trainer(max_epochs=1)
+        model = mobilenet_v3_small(num_classes=10)
+
+        x = torch.rand((10, 3, 256, 256))
+        y = torch.ones((10, ), dtype=torch.long)
+
+        pl_model = Trainer.compile(model, loss=torch.nn.CrossEntropyLoss(),
+                                   optimizer=torch.optim.SGD(model.parameters(), lr=0.01))
+        ds = TensorDataset(x, y)
+        dataloader = DataLoader(ds, batch_size=2)
+        trainer.fit(pl_model, dataloader)
+
+        openvino_model = InferenceOptimizer.trace(model, accelerator='openvino', input_sample=dataloader)
+        test_openvino_model = InferenceOptimizer.trace(model, accelerator='openvino',
+                                                       input_sample=dataloader, output_tensors=False)
+        
+        for x, y in dataloader:
+            model.eval()
+            forward_model_tensor = openvino_model(x).numpy()
+            forward_model_numpy = test_openvino_model(x)
+            np.testing.assert_almost_equal(forward_model_tensor, forward_model_numpy, decimal=5)


### PR DESCRIPTION
## Description

When call `predict_with_onnx` or `predict_with_openvino`, type transforms between tensor and numpy cause a little bit overhead.
In this PR, support numpy in and out onnx/openvino models without converting to tensors to reduce inference overhead.

### 1. Why the change?

Reduce inference overhead by reducing type transforms between tensor and numpy.
Experiment results are as following:

TCNForecaster, 4 cores, lookback 96, horizon 96
| dataset | onnx latency(before) | onnx latency(after) | openvino latency(before) | openvino latency(after) |
| ---- | ---- | ---- | ---- | ---- |
| ETTh1 | 0.054ms | 0.045ms | 0.130ms | 0.116ms |

### 2. User API changes

Chronos - None
Nano - a new param `output_tensors` in `InferenceOptimizer.trace`
```bash
def trace(..., output_tensors: bool = True, **kwargs)
# output_tensors: boolean, default to True and output of the model will be Tensors, only valid when accelerator='onnxruntime' or accelerator='openvino', otherwise will be ignored. If output_tensors=False, output of the export model will be ndarray.
```

### 3. Summary of the change 

- add a new param `output_tensors` in `InferenceOptimizer.trace`, `PytorchONNXRuntimeModel`, `PytorchOpenVINOModel`
- during inference of forecasters, provide `_numpy_inference`(for numpy input case) and `_tensor_inference`(for tensor input case)
- uts (forecaster related, onnx trace related, openvino trace related)

### 4. How to test?
- [x] Unit test

