### PR TITLE
Add data sampler for val_dataloader when train with MMCVRayRunner

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/core/lifecycle.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/core/lifecycle.py
@@ -76,7 +76,7 @@ class LifeCycle(metaclass=ABCMeta):
             world_size=world_size)
         self.backend = "torch-distributed"
 
-    def with_sampler(self, loader):
+    def with_sampler(self, loader, shuffle=True):
         self.logger.debug("Wrapping DistributedSampler on DataLoader")
         data_loader_args = {
             "dataset": loader.dataset,
@@ -90,7 +90,8 @@ class LifeCycle(metaclass=ABCMeta):
             "worker_init_fn": loader.worker_init_fn,
             "sampler": DistributedSampler(loader.dataset,
                                           num_replicas=self.size,
-                                          rank=self.rank)
+                                          rank=self.rank,
+                                          shuffle=shuffle)
         }
         return DataLoader(**data_loader_args)
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
@@ -188,7 +188,8 @@ class MMCVRayEpochRunner(BaseRunner, EpochBasedRunner):
         # so add sampler for val_dataloder if there is a DistEvalHook.
         for hook in self._hooks:
             if isinstance(hook, DistEvalHook):
-                hook.dataloader = self.with_sampler(hook.dataloader)
+                # don't shuffle the val data
+                hook.dataloader = self.with_sampler(hook.dataloader, shuffle=False)
 
         return self.run(data_loaders, workflow, max_epochs, **kwargs)
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
@@ -184,7 +184,7 @@ class MMCVRayEpochRunner(BaseRunner, EpochBasedRunner):
                         creator in data_loaders_creators]
         # runner was created in method setup_components, which may contains the
         # creation of DistEvalHook. At that time, ddp env was not initialized, so
-        # the val_dataloder in DistEvalHook is not correctly build with a sampler.
+        # the val_dataloder in DistEvalHook is not correctly built with a sampler.
         # so add sampler for val_dataloder if there is a DistEvalHook.
         for hook in self._hooks:
             if isinstance(hook, DistEvalHook):

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
@@ -24,7 +24,7 @@ import torch
 import warnings
 from collections import OrderedDict
 from torch.optim import Optimizer
-from mmcv.runner import EpochBasedRunner
+from mmcv.runner import EpochBasedRunner, DistEvalHook
 from mmcv.runner.utils import get_host_info
 from mmcv.parallel import is_module_wrapper
 from mmcv.parallel.distributed import MMDistributedDataParallel
@@ -182,6 +182,14 @@ class MMCVRayEpochRunner(BaseRunner, EpochBasedRunner):
                      **kwargs) -> List[Dict]:
         data_loaders = [self.with_sampler(creator(self.config)) for
                         creator in data_loaders_creators]
+        # runner was created in method setup_components, which may contains the
+        # creation of DistEvalHook. At that time, ddp env was not initialized, so
+        # the val_dataloder in DistEvalHook is not correctly build with a sampler.
+        # so add sampler for val_dataloder if there is a DistEvalHook.
+        for hook in self._hooks:
+            if isinstance(hook, DistEvalHook):
+                hook.dataloader = self.with_sampler(hook.dataloader)
+
         return self.run(data_loaders, workflow, max_epochs, **kwargs)
 
     def run(self,

--- a/python/orca/test/bigdl/orca/learn/ray/experimental/test_mmcv_estimator_ray_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/experimental/test_mmcv_estimator_ray_backend.py
@@ -47,10 +47,10 @@ class DistEvalHook(BaseDistEvalHook):
         """
         worker_nums = 2
         samples_per_worker = NUM_SAMPLES / worker_nums
-        actual_samplers_per_worker = 0
+        actual_samples_per_worker = 0
         for data, label in self.dataloader:
-            actual_samplers_per_worker += len(data)
-        assert samples_per_worker == actual_samplers_per_worker
+            actual_samples_per_worker += len(data)
+        assert samples_per_worker == actual_samples_per_worker
 
 
 class Model(nn.Module):
@@ -144,7 +144,7 @@ def runner_creator(cfg):
         checkpoint_config=checkpoint_config,
         log_config=log_config)
 
-    if cfg.add_eval_hook:
+    if cfg.get('add_eval_hook'):
         val_set = LinearDataset(size=NUM_SAMPLES)
         val_loader = DataLoader(
             val_set, batch_size=64, shuffle=True, num_workers=2)


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
user need to provide a `mmcv_runner_creator` when they train with MMCVRayEstimator, they may register a DistEvalHook in the runner creator.
```python
def runner_creator(config):
    model = ...
    optimizer = ...
    if validate:
        val_dataloader = build_dataloader()
        runner.register_hook(
            DistEvalHook(val_dataloader, **eval_cfg), priority='LOW')
```

the runner will be created in `MMCVRayRunner.setup_component()`, at this time, ddp env was not initialized, so the val_dataloder in DistEvalHook is not correctly build with a sampler. so add sampler for val_dataloder if there is a DistEvalHook. 