### PR TITLE
[PPML] Fix SGX_QL_QV_RESULT_OK code in eHSM Attestation service

### DIFF
--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/attestation/service/EHSMAttestationService.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/attestation/service/EHSMAttestationService.scala
@@ -155,7 +155,7 @@ class EHSMAttestationService(kmsServerIP: String, kmsServerPort: String,
     val sign = postResult.getString(RES_SIGN)
     val result = postResult.getInt(RES_RESULT)
     var verifyQuoteResult = false;
-    if (result == 0xa000) {
+    if (result == 0x0000) {
       verifyQuoteResult = true;
     } else if (result == 0xa001 || result == 0xa002 || result == 0xa003
       || result == 0xa007 || result == 0xa008) {


### PR DESCRIPTION
## Description

Replace eHSM attestation OK result from 0xa000 with 0x0000.