### PR TITLE
[PPML] Add 0x0000 or 0xa000 condition for eHSM attestation

### DIFF
--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/attestation/service/EHSMAttestationService.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/attestation/service/EHSMAttestationService.scala
@@ -155,7 +155,7 @@ class EHSMAttestationService(kmsServerIP: String, kmsServerPort: String,
     val sign = postResult.getString(RES_SIGN)
     val result = postResult.getInt(RES_RESULT)
     var verifyQuoteResult = false;
-    if (result == 0x0000) {
+    if (result == 0x0000 || result == 0xa000) {
       verifyQuoteResult = true;
     } else if (result == 0xa001 || result == 0xa002 || result == 0xa003
       || result == 0xa007 || result == 0xa008) {


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

Admit both 0x0000 and 0xa000 as SGX_QL_QV_RESULT_OK