### PR TITLE
Nano: fix saving model compiled without metrics in keras

### DIFF
--- a/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/model.py
@@ -66,10 +66,11 @@ class KerasQuantizedModel(AcceleratedKerasModel):
                 kwargs["loss_weights"] = self.compiled_loss._user_loss_weights
             if self.compiled_metrics is not None:
                 user_metric = self.compiled_metrics._user_metrics
-                if isinstance(user_metric, (list, tuple)):
-                    kwargs["metrics"] = [m._name for m in user_metric]
-                else:
-                    kwargs["metrics"] = user_metric._name
+                if user_metric is not None:
+                    if isinstance(user_metric, (list, tuple)):
+                        kwargs["metrics"] = [m._name for m in user_metric]
+                    else:
+                        kwargs["metrics"] = user_metric._name
                 weighted_metrics = self.compiled_metrics._user_weighted_metrics
                 if weighted_metrics is not None:
                     if isinstance(weighted_metrics, (list, str)):

--- a/python/nano/test/tf/inference/test_inf_optimizer.py
+++ b/python/nano/test/tf/inference/test_inf_optimizer.py
@@ -20,6 +20,7 @@ import os
 from bigdl.nano.tf.keras import InferenceOptimizer
 import numpy as np
 from tensorflow.keras.applications import MobileNetV2
+from tensorflow.keras import layers, Model
 
 
 class TestInferencePipeline(TestCase):
@@ -144,3 +145,38 @@ class TestInferencePipeline(TestCase):
             load_model = InferenceOptimizer.load(tmp_dir_name, model)
             output2 = load_model(train_examples)
             np.testing.assert_almost_equal(output1.numpy(), output2.numpy(), decimal=5)
+
+    def test_compile_model(self):
+        from tensorflow.keras.metrics import CategoricalAccuracy
+        inputs = tf.keras.Input(shape=(28*28,), name='digits')
+        x = layers.Dense(10, name='dense_logits')(inputs)
+        outputs = layers.Activation('softmax', dtype='float32', name='predictions')(x)
+        # test model with metrics in subprocess
+        model = Model(inputs=inputs, outputs=outputs)
+        model.compile(loss='sparse_categorical_crossentropy',
+                      optimizer=tf.keras.optimizers.RMSprop(),
+                      metrics=CategoricalAccuracy())
+
+        x = np.random.random((100, 28*28))
+        y = np.random.randint(0, 10, 100)
+
+        infer_opt = InferenceOptimizer()
+        infer_opt.optimize(model, x=x, y=y,
+                           batch_size=1,
+                           metric=CategoricalAccuracy(),
+                           direction="max",
+                           includes=["static_int8"])
+        assert infer_opt.optimized_model_dict["static_int8"]["status"] == "successful"
+
+        # test model without metrics in subprocess
+        model = Model(inputs=inputs, outputs=outputs)
+        model.compile(loss='sparse_categorical_crossentropy',
+                      optimizer=tf.keras.optimizers.RMSprop())
+
+        infer_opt = InferenceOptimizer()
+        infer_opt.optimize(model, x=x, y=y,
+                           batch_size=1,
+                           metric=CategoricalAccuracy(),
+                           direction="max",
+                           includes=["static_int8"])
+        assert infer_opt.optimized_model_dict["static_int8"]["status"] == "successful"


### PR DESCRIPTION
## Description

fix saving model compiled without metrics in keras

```bash
kwargs["metrics"] = user_metric._name
AttributeError: 'NoneType' object has no attribute '_name'
```

### How to test?
- [x] Unit test

