### PR TITLE
[PPML]fix local pyspark sqlexamples in bigdata toolkit

### DIFF
--- a/ppml/trusted-bigdata/Dockerfile
+++ b/ppml/trusted-bigdata/Dockerfile
@@ -215,7 +215,7 @@ RUN rm $SPARK_HOME/jars/okhttp-*.jar && \
     chmod -R 777 ${FLINK_HOME} && \
     chown -R flink:flink ${FLINK_HOME} && \
 # Python packages
-    pip3 install numpy
+    pip3 install numpy pandas
 
 RUN cp /ppml/jars/*.jar ${SPARK_HOME}/jars
 

--- a/ppml/trusted-bigdata/scripts/start-pyspark-sqlexamples-on-local-sgx.sh
+++ b/ppml/trusted-bigdata/scripts/start-pyspark-sqlexamples-on-local-sgx.sh
@@ -38,6 +38,7 @@ fi
 
 if [ $status_7_local_spark_hive -ne 0 ]; then
 echo "example.7 local spark, Hive"
+export MALLOC_ARENA_MAX=16
 export sgx_command="/opt/jdk8/bin/java \
   -cp /ppml/spark-$SPARK_VERSION/conf/:/ppml/spark-$SPARK_VERSION/jars/*:/ppml/spark-$SPARK_VERSION/examples/jars/* \
   -Xmx2g org.apache.spark.deploy.SparkSubmit \


### PR DESCRIPTION
## Description

to successfully pass local pyspark sqlexamples, need to add numpy package and malloc more when running hive.py
