### PR TITLE
Chronos: fix quantization of openvino

### DIFF
--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -936,3 +936,15 @@ class TestChronosModelLSTMForecaster(TestCase):
         forecaster.optimized_model_output_tensor = True
         q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test, quantize=True)
         np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
+
+    @op_inference
+    def test_lstm_forecaster_quantization_openvino(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = LSTMForecaster(past_seq_len=24,
+                                    input_feature_num=2,
+                                    output_feature_num=2,
+                                    loss="mae",
+                                    lr=0.01)
+        forecaster.fit(train_data, epochs=1)
+        forecaster.quantize(train_data, metric='mae', framework='openvino')
+        pred_q = forecaster.predict_with_openvino(test_data[0], quantize=True)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -911,3 +911,13 @@ class TestChronosNBeatsForecaster(TestCase):
         q_openvino_tensor_yhat = forecaster.predict_with_openvino(data=test, quantize=True)
         np.testing.assert_almost_equal(q_openvino_numpy_yhat, q_openvino_tensor_yhat, decimal=5)
 
+    @op_inference
+    def test_nbeats_forecaster_quantization_openvino(self):
+        train_data, val_data, test_data = create_data()
+        forecaster = NBeatsForecaster(past_seq_len=24,
+                                      future_seq_len=5,
+                                      loss='mae',
+                                      lr=0.01)
+        forecaster.fit(train_data, epochs=1)
+        forecaster.quantize(train_data, metric='mae', framework='openvino')
+        pred_q = forecaster.predict_with_openvino(test_data[0], quantize=True)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -434,6 +434,7 @@ class TestChronosModelTCNForecaster(TestCase):
             pass
 
         forecaster.quantize(calib_data=train_data,
+                            metric="mae",
                             framework="openvino")
         q_openvino_yhat = forecaster.predict_with_openvino(test_data[0], quantize=True)
         openvino_yhat = forecaster.predict_with_openvino(test_data[0])
@@ -466,6 +467,7 @@ class TestChronosModelTCNForecaster(TestCase):
             pass
 
         forecaster.quantize(calib_data=train_data,
+                            metric="mae",
                             framework="openvino")
         q_openvino_yhat = forecaster.predict_with_openvino(test_data[0], quantize=True)
         openvino_yhat = forecaster.predict_with_openvino(test_data[0])
@@ -496,6 +498,7 @@ class TestChronosModelTCNForecaster(TestCase):
             pass
 
         forecaster.quantize(calib_data=train_loader,
+                            metric="mse",
                             framework="openvino")
         q_openvino_yhat = forecaster.predict_with_openvino(test_loader, quantize=True)
         openvino_yhat = forecaster.predict_with_openvino(test_loader)
@@ -520,6 +523,7 @@ class TestChronosModelTCNForecaster(TestCase):
             pass
 
         forecaster.quantize(calib_data=train,
+                            metric="mse",
                             framework="openvino")
         q_openvino_yhat = forecaster.predict_with_openvino(test, quantize=True)
         openvino_yhat = forecaster.predict_with_openvino(test)

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/metric.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/metric.py
@@ -21,8 +21,11 @@ from torchmetrics import Metric
 
 class PytorchOpenVINOMetric(BaseOpenVINOMetric):
     def __init__(self, metric, higher_better=True):
-        forecast_metric = hasattr(metric, '__name__') and\
-                          metric.__name__ in ['mae', 'mse', 'rmse', 'mape', 'smape', 'r2']
+        # to support openvino quantization of chronos forecasters
+        if hasattr(metric, '__name__'):
+            forecast_metric = metric.__name__ in ['mae', 'mse', 'rmse', 'mape', 'smape', 'r2']
+        else:
+            forecast_metric = False
         invalidInputError(isinstance(metric, Metric) or forecast_metric,
                           "Please provide an instance of torchmetrics.Metric.")
         super().__init__(metric, higher_better)

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/metric.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/metric.py
@@ -17,17 +17,17 @@ from bigdl.nano.utils.common import invalidInputError
 from ..core.metric import BaseOpenVINOMetric
 import torch
 from torchmetrics import Metric
+import inspect
 
 
 class PytorchOpenVINOMetric(BaseOpenVINOMetric):
     def __init__(self, metric, higher_better=True):
-        # to support openvino quantization of chronos forecasters
-        if hasattr(metric, '__name__'):
-            forecast_metric = metric.__name__ in ['mae', 'mse', 'rmse', 'mape', 'smape', 'r2']
-        else:
-            forecast_metric = False
-        invalidInputError(isinstance(metric, Metric) or forecast_metric,
-                          "Please provide an instance of torchmetrics.Metric.")
+        if not isinstance(metric, Metric):
+            invalidInputError(len(inspect.signature(metric).parameters)==2,
+                              "Please provide an instance of torchmetrics.Metric or"
+                              "a metric function with input (preds, targets).")
+        # invalidInputError(isinstance(metric, Metric),
+        #                   "Please provide an instance of torchmetrics.Metric.")
         super().__init__(metric, higher_better)
 
     def stack(self, output):

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/metric.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/metric.py
@@ -21,7 +21,9 @@ from torchmetrics import Metric
 
 class PytorchOpenVINOMetric(BaseOpenVINOMetric):
     def __init__(self, metric, higher_better=True):
-        invalidInputError(isinstance(metric, Metric),
+        forecast_metric = hasattr(metric, '__name__') and\
+                          metric.__name__ in ['mae', 'mse', 'rmse', 'mape', 'smape', 'r2']
+        invalidInputError(isinstance(metric, Metric) or forecast_metric,
                           "Please provide an instance of torchmetrics.Metric.")
         super().__init__(metric, higher_better)
 

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/metric.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/metric.py
@@ -23,7 +23,7 @@ import inspect
 class PytorchOpenVINOMetric(BaseOpenVINOMetric):
     def __init__(self, metric, higher_better=True):
         if not isinstance(metric, Metric):
-            invalidInputError(len(inspect.signature(metric).parameters)==2,
+            invalidInputError(len(inspect.signature(metric).parameters) == 2,
                               "Please provide an instance of torchmetrics.Metric or"
                               "a metric function with input (preds, targets).")
         super().__init__(metric, higher_better)

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/metric.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/metric.py
@@ -26,8 +26,6 @@ class PytorchOpenVINOMetric(BaseOpenVINOMetric):
             invalidInputError(len(inspect.signature(metric).parameters)==2,
                               "Please provide an instance of torchmetrics.Metric or"
                               "a metric function with input (preds, targets).")
-        # invalidInputError(isinstance(metric, Metric),
-        #                   "Please provide an instance of torchmetrics.Metric.")
         super().__init__(metric, higher_better)
 
     def stack(self, output):


### PR DESCRIPTION
## Description

There exists error when run:
```python
forecaster.quantize(calib_data=train_loader, val_data=val_loader, metric="mae", framework='openvino')
```
In this PR, fix it.

### 2. User API changes

None

### 3. Summary of the change 

- modify check of `metric` in `PytorchOpenVINOMetric`
- remove `_str2metric` and use `_str2optimizer_metric` of which parameter order is (pred, target)
- add openvino quantization related uts

### 4. How to test?
- [x] Unit test
