### PR TITLE
Orca: Make optimizer_creator optional and discuss optimizers when fit and eval in pytorch estimator

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -103,7 +103,8 @@ class PyTorchRayEstimator(BaseRayEstimator):
 
         # todo remove ray_ctx to run on workers
         ray_ctx = OrcaRayContext.get()
-        if not isinstance(model_creator, types.FunctionType):  # Torch model is also callable.
+        if model_creator and not isinstance(model_creator, types.FunctionType):
+            # Torch model is also callable.
             invalidInputError(False,
                               "Must provide a function for model_creator.")
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -103,7 +103,7 @@ class PyTorchRayEstimator(BaseRayEstimator):
 
         # todo remove ray_ctx to run on workers
         ray_ctx = OrcaRayContext.get()
-        if model_creator and not isinstance(model_creator, types.FunctionType):
+        if not isinstance(model_creator, types.FunctionType):
             # Torch model is also callable.
             invalidInputError(False,
                               "Must provide a function for model_creator.")

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -103,8 +103,7 @@ class PyTorchRayEstimator(BaseRayEstimator):
 
         # todo remove ray_ctx to run on workers
         ray_ctx = OrcaRayContext.get()
-        if not isinstance(model_creator, types.FunctionType):
-            # Torch model is also callable.
+        if not isinstance(model_creator, types.FunctionType):  # Torch model is also callable.
             invalidInputError(False,
                               "Must provide a function for model_creator.")
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -103,11 +103,9 @@ class PyTorchRayEstimator(BaseRayEstimator):
 
         # todo remove ray_ctx to run on workers
         ray_ctx = OrcaRayContext.get()
-        if not (isinstance(model_creator, types.FunctionType) and
-                isinstance(optimizer_creator, types.FunctionType)):  # Torch model is also callable.
+        if not isinstance(model_creator, types.FunctionType):  # Torch model is also callable.
             invalidInputError(False,
-                              "Must provide a function for both model_creator and"
-                              " optimizer_creator")
+                              "Must provide a function for model_creator.")
 
         self.model_creator = model_creator
         self.optimizer_creator = optimizer_creator

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -280,11 +280,11 @@ class TorchRunner(BaseRunner):
 
         if not self.models:
             invalidInputError(False,
-                              "You must provide a model for train.")
+                              "You must provide a model for train and evaluate.")
 
         if not self.criterion:
             invalidInputError(False,
-                              "You must provide a loss for train.")
+                              "You must provide a loss for train and evaluate.")
 
         if not self.optimizers:
             invalidInputError(False,

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -453,9 +453,6 @@ class TorchRunner(BaseRunner):
         if not self.criterion:
             invalidInputError(False,
                               "You must provide a loss for train and evaluate.")
-        if not self.optimizers:
-            invalidInputError(False,
-                              "You must provide the optimizer for train and evaluate.")
 
         config = copy.copy(self.config)
         self._toggle_profiling(profile=profile)

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -288,7 +288,7 @@ class TorchRunner(BaseRunner):
 
         if not self.optimizers:
             invalidInputError(False,
-                              "You must provide the optimizer for train and evaluate.")
+                              "You must provide the optimizer for train.")
 
         self._toggle_profiling(profile=profile)
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -280,15 +280,15 @@ class TorchRunner(BaseRunner):
 
         if not self.models:
             invalidInputError(False,
-                              "You must provide a model for train and evaluate.")
+                              "You must provide a model for train.")
 
         if not self.criterion:
             invalidInputError(False,
-                              "You must provide a loss for train and evaluate.")
+                              "You must provide a loss for train.")
 
         if not self.optimizers:
             invalidInputError(False,
-                              "You must provide the optimizer for train and evaluate.")
+                              "You must provide the optimizer for train.")
 
         self._toggle_profiling(profile=profile)
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -282,6 +282,10 @@ class TorchRunner(BaseRunner):
             invalidInputError(False,
                               "You must provide a loss for train and evaluate.")
 
+        if not self.optimizers:
+            invalidInputError(False,
+                              "You must provide the optimizer for train and evaluate.")
+
         self._toggle_profiling(profile=profile)
 
         with self.timers.record("train_epoch"):
@@ -449,6 +453,9 @@ class TorchRunner(BaseRunner):
         if not self.criterion:
             invalidInputError(False,
                               "You must provide a loss for train and evaluate.")
+        if not self.optimizers:
+            invalidInputError(False,
+                              "You must provide the optimizer for train and evaluate.")
 
         config = copy.copy(self.config)
         self._toggle_profiling(profile=profile)

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -288,7 +288,7 @@ class TorchRunner(BaseRunner):
 
         if not self.optimizers:
             invalidInputError(False,
-                              "You must provide the optimizer for train.")
+                              "You must provide the optimizer for train and evaluate.")
 
         self._toggle_profiling(profile=profile)
 
@@ -600,7 +600,7 @@ class TorchRunner(BaseRunner):
 
         if not self.models:
             invalidInputError(False,
-                              "You must provide a model for predicting.")
+                              "You must provide a model for predict.")
 
         params = {"batch_size": batch_size, "shuffle": False}
         for arg in ["shuffle", "sampler", "batch_sampler", "num_workers", "collate_fn",

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -278,6 +278,10 @@ class TorchRunner(BaseRunner):
             data_loader.sampler.set_epoch(self.epochs)
         self.logger.debug("Begin Training Step {}".format(self.epochs + 1))
 
+        if not self.models:
+            invalidInputError(False,
+                              "You must provide a model for train and evaluate.")
+
         if not self.criterion:
             invalidInputError(False,
                               "You must provide a loss for train and evaluate.")
@@ -450,6 +454,10 @@ class TorchRunner(BaseRunner):
     def validate(self, data_creator, batch_size=32, num_steps=None, profile=False,
                  wrap_dataloader=None, callbacks=None):
         """Evaluates the model on the validation data set."""
+        if not self.models:
+            invalidInputError(False,
+                              "You must provide a model for train and evaluate.")
+
         if not self.criterion:
             invalidInputError(False,
                               "You must provide a loss for train and evaluate.")
@@ -585,10 +593,14 @@ class TorchRunner(BaseRunner):
         return output, target, loss
 
     def predict(self, partition, batch_size=32, profile=False, callbacks=None):
-        """Evaluates the model on the validation data set."""
+        """Predict the model."""
         config = copy.copy(self.config)
         self._toggle_profiling(profile=profile)
         callbacks = callbacks or []
+
+        if not self.models:
+            invalidInputError(False,
+                              "You must provide a model for predicting.")
 
         params = {"batch_size": batch_size, "shuffle": False}
         for arg in ["shuffle", "sampler", "batch_sampler", "num_workers", "collate_fn",

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
@@ -752,7 +752,7 @@ class TestPyTorchEstimator(TestCase):
 
         try:
             estimator = get_estimator(model_fn=lambda config: IdentityNet())
-            path = "/tmp/model"
+            path = "/tmp/optional_model"
             estimator.save(path)
             estimator.shutdown()
 

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
@@ -744,5 +744,63 @@ class TestPyTorchEstimator(TestCase):
 
         estimator.shutdown()
 
+    def test_optional_model_creator(self):
+        sc = OrcaContext.get_spark_context()
+        rdd = sc.range(0, 110).map(lambda x: np.array([x] * 50))
+        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(lambda x: {"x": np.stack(x)})
+        shards = SparkXShards(shards)
+
+        try:
+            estimator = get_estimator(model_fn=lambda config: IdentityNet())
+
+            result_shards = estimator.predict(shards, batch_size=4)
+            result_before = np.concatenate([shard["prediction"] for shard in result_shards.collect()])
+            expected_result = np.concatenate([shard["x"] for shard in result_shards.collect()])
+            assert np.array_equal(result_before, expected_result)
+
+            path = "/tmp/entire_model.pth"
+            estimator.save(path, entire=True)
+            estimator.shutdown()
+
+            trainer = Estimator.from_torch(optimizer=get_optimizer,
+                                           loss=nn.BCELoss(),
+                                           metrics=Accuracy(),
+                                           config={"lr": 1e-2},
+                                           workers_per_node=2,
+                                           backend="ray")
+            trainer.load(path)
+
+            result_shards = trainer.predict(shards, batch_size=4)
+            result_after = np.concatenate([shard["prediction"]
+                                           for shard in result_shards.collect()])
+        finally:
+            os.remove(path)
+
+        assert np.array_equal(expected_result, result_after)
+
+    def test_optional_optimizer(self):
+        sc = init_nncontext()
+        rdd = sc.range(0, 110).map(lambda x: np.array([x] * 50))
+        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(lambda x: {"x": np.stack(x)})
+        shards = SparkXShards(shards)
+
+        try:
+            trainer = get_estimator(model_fn=lambda config: IdentityNet())
+            path = "/tmp/optimizer_model.pth"
+            trainer.save(path)
+            trainer.shutdown()
+
+            estimator = Estimator.from_torch(model=lambda config: IdentityNet(),
+                                             workers_per_node=2,
+                                             backend="ray")
+            estimator.load(path)
+
+            result_shards = estimator.predict(shards, batch_size=4)
+            result_before = np.concatenate([shard["prediction"] for shard in result_shards.collect()])
+            expected_result = np.concatenate([shard["x"] for shard in result_shards.collect()])
+            assert np.array_equal(result_before, expected_result)
+        finally:
+            os.remove(path)
+
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
@@ -744,34 +744,6 @@ class TestPyTorchEstimator(TestCase):
 
         estimator.shutdown()
 
-    def test_optional_model_creator(self):
-        sc = OrcaContext.get_spark_context()
-        rdd = sc.range(0, 110).map(lambda x: np.array([x] * 50))
-        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(lambda x: {"x": np.stack(x)})
-        shards = SparkXShards(shards)
-
-        try:
-            estimator = get_estimator(model_fn=lambda config: IdentityNet())
-            path = "/tmp/optional_model"
-            estimator.save(path)
-            estimator.shutdown()
-
-            estimator = Estimator.from_torch(optimizer=get_optimizer,
-                                             loss=nn.BCELoss(),
-                                             metrics=Accuracy(),
-                                             config={"lr": 1e-2},
-                                             workers_per_node=2,
-                                             backend="ray")
-            estimator.load(path)
-
-            result = estimator.predict(shards, batch_size=4)
-            predicted_result = np.concatenate([shard["prediction"] for shard in result.collect()])
-            expected_result = np.concatenate([shard["x"] for shard in result.collect()])
-        finally:
-            os.remove(path)
-
-        assert np.array_equal(predicted_result, expected_result)
-
     def test_optional_optimizer(self):
         sc = OrcaContext.get_spark_context()
         rdd = sc.range(0, 110).map(lambda x: np.array([x] * 50))


### PR DESCRIPTION
## Description

When in predict mode, there should be no optimizer_creator. So we should require optimizer_creator when fiting or validating instead of init estimator.

[issue165](https://github.com/analytics-zoo/orca/issues/165#issuecomment-1439630520)