### PR TITLE
[PPML] refine ppml context scala and python backend

### DIFF
--- a/python/ppml/src/bigdl/ppml/api/simple_query_example.py
+++ b/python/ppml/src/bigdl/ppml/api/simple_query_example.py
@@ -17,7 +17,7 @@
 import argparse
 
 from bigdl.ppml.ppml_context import *
-from bigdl.ppml.kms.utils import KmsArgumentParser
+from bigdl.ppml.kms.utils.kms_argument_parser import KmsArgumentParser
 
 """
 execute the following command to run this example on local

--- a/python/ppml/src/bigdl/ppml/api/simple_query_example.py
+++ b/python/ppml/src/bigdl/ppml/api/simple_query_example.py
@@ -24,7 +24,7 @@ execute the following command to run this example on local
 
 python simple_query_example.py \
 --app_id your_simple_kms_app_id \
---app_key your_simple_kms_app_key \
+--api_key your_simple_kms_app_key \
 --primary_key_material /your/primary/key/path/primaryKey \
 --input_path /your/file/input/path \
 --output_path /your/file/output/path \

--- a/python/ppml/src/bigdl/ppml/api/simple_query_example.py
+++ b/python/ppml/src/bigdl/ppml/api/simple_query_example.py
@@ -17,15 +17,15 @@
 import argparse
 
 from bigdl.ppml.ppml_context import *
+from bigdl.ppml.kms.utils import KmsArgumentParser
 
 """
 execute the following command to run this example on local
 
 python simple_query_example.py \
---simple_app_id your_app_id \
---simple_app_key your_app_key \
---primary_key_path /your/primary/key/path/primaryKey \
---data_key_path /your/data/key/path/dataKey \
+--app_id your_simple_kms_app_id \
+--app_key your_simple_kms_app_key \
+--primary_key_material /your/primary/key/path/primaryKey \
 --input_path /your/file/input/path \
 --output_path /your/file/output/path \
 --input_encrypt_mode AES/CBC/PKCS5Padding \
@@ -33,25 +33,7 @@ python simple_query_example.py \
 
 """
 
-parser = argparse.ArgumentParser()
-parser.add_argument("--app_id", type=str, help="app id")
-parser.add_argument("--api_key", type=str, help="app key")
-parser.add_argument("--kms_server_ip", type=str, help="ehsm kms server ip")
-parser.add_argument("--kms_server_port", type=str, help="ehsm kms server port")
-parser.add_argument("--kms_user_name", type=str, help="ehsm kms server ip")
-parser.add_argument("--kms_user_token", type=str, help="ehsm kms server port")
-parser.add_argument("--vault", type=str, help="Azure Key Vault name")
-parser.add_argument("--client_id", type=str, default="", help="Azure client id")
-parser.add_argument("--primary_key", type=str, help="primary key path")
-parser.add_argument("--data_key", type=str, help="data key path")
-parser.add_argument("--input_encrypt_mode", type=str, required=True, help="input encrypt mode")
-parser.add_argument("--output_encrypt_mode", type=str, required=True, help="output encrypt mode")
-parser.add_argument("--input_path", type=str, required=True, help="input path")
-parser.add_argument("--output_path", type=str, required=True, help="output path")
-parser.add_argument("--kms_type", type=str, default="SimpleKeyManagementService",
-                    help="SimpleKeyManagementService, EHSMKeyManagementService or AzureKeyManagementService")
-args = parser.parse_args()
-arg_dict = vars(args)
+arg_dict = KmsArgumentParser.get_arg_dict()
 
 sc = PPMLContext('pyspark-simple-query', arg_dict)
 

--- a/python/ppml/src/bigdl/ppml/kms/__init__.py
+++ b/python/ppml/src/bigdl/ppml/kms/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/ppml/src/bigdl/ppml/kms/utils/__init__.py
+++ b/python/ppml/src/bigdl/ppml/kms/utils/__init__.py
@@ -1,0 +1,15 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/python/ppml/src/bigdl/ppml/kms/utils/kms_argument_parser.py
+++ b/python/ppml/src/bigdl/ppml/kms/utils/kms_argument_parser.py
@@ -1,0 +1,40 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class KmsArgumentParser:
+    import argparse
+    
+    def __init__(self):
+        self.parser = argparse.ArgumentParser()
+        self.parser.add_argument("--app_id", type=str, help="app id")
+        self.parser.add_argument("--api_key", type=str, help="app key")
+        self.parser.add_argument("--kms_server_ip", type=str, help="ehsm or azure etc. kms server ip")
+        self.parser.add_argument("--kms_server_port", type=str, help="ehsm or azure etc. kms server port")
+        self.parser.add_argument("--kms_user_name", type=str, help="bigdl kms user name")
+        self.parser.add_argument("--kms_user_token", type=str, help="bigdl kms user token")
+        self.parser.add_argument("--vault", type=str, help="azure key vault name")
+        self.parser.add_argument("--client_id", type=str, default="", help="azure client id")
+        self.parser.add_argument("--primary_key_material", type=str, help="primary key path or name")
+        self.parser.add_argument("--input_encrypt_mode", type=str, required=True, help="input encrypt mode")
+        self.parser.add_argument("--output_encrypt_mode", type=str, required=True, help="output encrypt mode")
+        self.parser.add_argument("--input_path", type=str, required=True, help="input path")
+        self.parser.add_argument("--output_path", type=str, required=True, help="output path")
+        self.parser.add_argument("--kms_type", type=str, default="SimpleKeyManagementService",
+                                 help="SimpleKeyManagementService, EHSMKeyManagementService or AzureKeyManagementService")
+   def get_arg_dict(self):
+       args = self.parser.parse_args()
+       arg_dict = vars(args)
+

--- a/python/ppml/src/bigdl/ppml/kms/utils/kms_argument_parser.py
+++ b/python/ppml/src/bigdl/ppml/kms/utils/kms_argument_parser.py
@@ -33,8 +33,9 @@ class KmsArgumentParser:
         self.parser.add_argument("--input_path", type=str, required=True, help="input path")
         self.parser.add_argument("--output_path", type=str, required=True, help="output path")
         self.parser.add_argument("--kms_type", type=str, default="SimpleKeyManagementService",
-                                 help="SimpleKeyManagementService, EHSMKeyManagementService or AzureKeyManagementService")
-   def get_arg_dict(self):
+                help="SimpleKeyManagementService, EHSMKeyManagementService or AzureKeyManagementService")
+
+    def get_arg_dict(self):
        args = self.parser.parse_args()
        arg_dict = vars(args)
 

--- a/python/ppml/src/bigdl/ppml/kms/utils/kms_argument_parser.py
+++ b/python/ppml/src/bigdl/ppml/kms/utils/kms_argument_parser.py
@@ -15,9 +15,8 @@
 #
 
 class KmsArgumentParser:
-    import argparse
-    
     def __init__(self):
+        import argparse
         self.parser = argparse.ArgumentParser()
         self.parser.add_argument("--app_id", type=str, help="app id")
         self.parser.add_argument("--api_key", type=str, help="app key")
@@ -38,4 +37,5 @@ class KmsArgumentParser:
     def get_arg_dict(self):
        args = self.parser.parse_args()
        arg_dict = vars(args)
+       return arg_dict
 

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/BigDLEncryptCompressor.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/BigDLEncryptCompressor.scala
@@ -140,8 +140,8 @@ object BigDLEncryptCompressor {
 
   def apply(conf: Configuration): BigDLEncryptCompressor = {
     val (dataKeyPlainText, dataKeyCipherText) = (
-      conf.get("bigdl.dataKey.plainText"),
-      conf.get("bigdl.dataKey.cipherText")
+      conf.get("bigdl.write.dataKey.plainText"),
+      conf.get("bigdl.write.dataKey.cipherText")
     )
     new BigDLEncryptCompressor(AES_CBC_PKCS5PADDING,
       dataKeyPlainText, dataKeyCipherText)

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/CryptoCodec.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/CryptoCodec.scala
@@ -119,7 +119,7 @@ object CryptoCodec {
 
       if (!headerVerified) {
         val (encryptedDataKey, initializationVector) = bigdlEncrypt.getHeader(in)
-        val dataKeyPlainText = conf.get(s"bigdl.dataKey.$encryptedDataKey.plainText")
+        val dataKeyPlainText = conf.get(s"bigdl.read.dataKey.$encryptedDataKey.plainText")
         bigdlEncrypt.init(cryptoMode, DECRYPT, dataKeyPlainText)
         bigdlEncrypt.verifyHeader(initializationVector)
         headerVerified = true

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/dataframe/EncryptedDataFrameWriter.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/dataframe/EncryptedDataFrameWriter.scala
@@ -74,9 +74,9 @@ class EncryptedDataFrameWriter(
         val (dataKeyPlainText, dataKeyCipherText) = keyLoaderManagement
           .retrieveKeyLoader(primaryKeyName).generateDataKeyPlainText
         sparkSession.sparkContext.hadoopConfiguration
-                    .set("bigdl.dataKey.plainText", dataKeyPlainText)
+                    .set("bigdl.write.dataKey.plainText", dataKeyPlainText)
         sparkSession.sparkContext.hadoopConfiguration
-                    .set("bigdl.dataKey.cipherText", dataKeyCipherText)
+                    .set("bigdl.write.dataKey.cipherText", dataKeyCipherText)
         sparkSession.sparkContext.hadoopConfiguration
                     .set("bigdl.cryptoMode", encryptMode.encryptionAlgorithm)
         option("compression", "com.intel.analytics.bigdl.ppml.crypto.CryptoCodec")

--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/kms/common/KeyLoader.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/kms/common/KeyLoader.scala
@@ -65,7 +65,7 @@ case class KeyLoader(val fromKms: Boolean,
         }
         val sparkSession: SparkSession = SparkSession.builder().getOrCreate()
         sparkSession.sparkContext.hadoopConfiguration
-          .set(s"bigdl.dataKey.$encryptedDataKey.plainText", dataKeyPlainText)
+          .set(s"bigdl.read.dataKey.$encryptedDataKey.plainText", dataKeyPlainText)
         dataKeyPlainText
     }
 


### PR DESCRIPTION
## Description

decouple arg parser from python example codes and rename scala key field for understandability.

### 1. Why the change?

as above

### 2. User API changes

python simple query primary key arg is renamed to `primary_key_material`

### 3. Summary of the change 

as above

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...
