### PR TITLE
Nano: allow pipeline to specify CPU cores for each stage

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/pipeline.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/pipeline.py
@@ -52,8 +52,9 @@ class Pipeline():
             ])
         ```
         will create a pipeline which has stage "preprocess" and "inference",
-        and the "preprocess" stage will call `preprocess(input)` with 4 CPU cores,
-        while the "inference" stage will call `model(input)` with 8 CPU cores.
+        and the "preprocess" stage will call `preprocess(input)` with 4 CPU cores
+        for openmp worload, while the "inference" stage will call `model(input)`
+        with 8 CPU cores for openmp workload.
 
         :param stages: A list of configurations for each stage, each stage should consist of
             a 'name'(str), a 'function'(Callable), and a 'config'(dict).

--- a/python/nano/src/bigdl/nano/utils/common/__init__.py
+++ b/python/nano/src/bigdl/nano/utils/common/__init__.py
@@ -48,5 +48,6 @@ from .affinity import get_affinity_core_num
 
 from .env import _env_variable_is_set
 from .env import _find_library
+from .env import EnvContext
 
 from .optimizer import *

--- a/python/nano/src/bigdl/nano/utils/common/env.py
+++ b/python/nano/src/bigdl/nano/utils/common/env.py
@@ -91,8 +91,5 @@ class EnvContext(object):
 
     def __exit__(self, exc_type, exc_value, exc_tb):
         # it seems `os.environ = self.env_backup` will cause bug
-        for k, v in self.env_backup.items():
-            if k not in os.environ:
-                os.environ.pop(k)
-            else:
-                os.environ[k] = v
+        os.environ.clear()
+        os.environ.update(self.env_backup)

--- a/python/nano/src/bigdl/nano/utils/common/env.py
+++ b/python/nano/src/bigdl/nano/utils/common/env.py
@@ -18,7 +18,7 @@
 import os
 import subprocess
 import warnings
-from typing import Union, Dict
+from typing import Union, Dict, Optional
 
 
 def _env_variable_is_set(variable: str,
@@ -62,3 +62,37 @@ def _find_library(library_name: str, priority_dir: Union[str, None] = None) -> U
         warnings.warn(
             "Some errors occurred while trying to find " + library_name)
     return res[0].decode("utf-8") if len(res) > 0 else None
+
+
+class EnvContext(object):
+    """
+    A helper context for changing environment variables temporarily.
+
+    Usage:
+    ```
+    with EnvContext():
+        os.environ["KMP_AFFINITY"] = "x"
+        ...
+    ```
+    or
+    ```
+    with EnvContext({"KMP_AFFINITY": "x"}):
+        ...
+    ```
+    After exiting this context, `os.environ` will be restored to initial state.
+    """
+    def __init__(self, env: Optional[Dict[str, str]] = None) -> None:
+        self.env_backup = os.environ.copy()
+        self.new_env = env
+
+    def __enter__(self):
+        if self.new_env is not None:
+            os.environ.update(self.new_env)
+
+    def __exit__(self, exc_type, exc_value, exc_tb):
+        # it seems `os.environ = self.env_backup` will cause bug
+        for k, v in self.env_backup.items():
+            if k not in os.environ:
+                os.environ.pop(k)
+            else:
+                os.environ[k] = v

--- a/python/nano/test/pytorch/tests/inference/test_pipeline.py
+++ b/python/nano/test/pytorch/tests/inference/test_pipeline.py
@@ -22,18 +22,22 @@ from torchvision.models import resnet18
 from bigdl.nano.pytorch import Pipeline
 
 
+def empty_stage():
+    pass
+
+
+def preprocess(_i):
+    return torch.rand((1, 3, 224, 224))
+
+
 class TestPipeline(TestCase):
     def test_pipeline_create(self):
-        def stage1():
-            pass
         _pipeline = Pipeline([
-            ("preprocess", stage1, {}),
-            ("inference", stage1, {}),
+            ("preprocess", empty_stage, {}),
+            ("inference", empty_stage, {}),
         ])
 
     def test_pipeline_inference(self):
-        def preprocess(_i):
-            return torch.rand((1, 3, 224, 224))
         model = resnet18(num_classes=10)
         pipeline = Pipeline([
             ("preprocess", preprocess, {}),
@@ -44,7 +48,8 @@ class TestPipeline(TestCase):
         assert len(outputs) == 10 and all(map(lambda o: o.shape == (1, 10), outputs))
 
     @pytest.mark.skipif(platform.system() == "Windows",
-                        reason="os.sched_getaffinity() is unavaiable on Windows.")
+                        reason=("os.sched_getaffinity() is unavaiable on Windows, "
+                                "and Windows doesn't support pickle local function"))
     def test_pipeline_core_control(self):
         def preprocess(_i):
             import os


### PR DESCRIPTION
## Description

Improve pipeline: Allow pipeline to specify CPU cores for each stage.
And fix nano nightly test: windows doesn't support pickle local object

### 1. Why the change?

For better performance

### 2. User API changes

```python
from bigdl.nano.pytorch import Pipeline

pipeline = Pipeline([
    ("preprocess", preprocess, {"core_num": 4}),
    ("inference", inference, {"core_num": 8})
])
```

### 3. Summary of the change 

- Allow pipeline to specify CPU cores for each stage.
- Add a new utils `EnvContext` to simplify setting environment variables temporarily.

### 4. How to test?

- [ ] Unit test