### PR TITLE
Nano: add invalidInputError for unexpected behaviours

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -101,6 +101,12 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         checkpoint_path = path / status['checkpoint']
         if status["use_jit"]:
             if status['compression'] == "bf16":
+                invalidInputError(model is not None,
+                                  "You must pass model when loading a PytorchIPEXJITModel "
+                                  "which is saving with compression precision.")
+                invalidInputError(input_sample is not None,
+                                  "You must pass model when loading a PytorchIPEXJITModel "
+                                  "which is saving with compression precision.")
                 state_dict = torch.load(checkpoint_path, map_location='cpu')
                 if status['compression'] == "bf16":
                     state_dict = transform_state_dict_to_dtype(state_dict, dtype="fp32")

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -105,7 +105,7 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                                   "You must pass model when loading a PytorchIPEXJITModel "
                                   "which is saving with compression precision.")
                 invalidInputError(input_sample is not None,
-                                  "You must pass model when loading a PytorchIPEXJITModel "
+                                  "You must pass input_sample when loading a PytorchIPEXJITModel "
                                   "which is saving with compression precision.")
                 state_dict = torch.load(checkpoint_path, map_location='cpu')
                 if status['compression'] == "bf16":

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -102,11 +102,11 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
         if status["use_jit"]:
             if status['compression'] == "bf16":
                 invalidInputError(model is not None,
-                                  "You must pass model when loading a PytorchIPEXJITModel "
-                                  "which is saving with compression precision.")
+                                  "You must pass model when loading this model "
+                                  "which was saved with compression precision.")
                 invalidInputError(input_sample is not None,
-                                  "You must pass input_sample when loading a PytorchIPEXJITModel "
-                                  "which is saving with compression precision.")
+                                  "You must pass input_sample when loading this model "
+                                  "which was saved with compression precision.")
                 state_dict = torch.load(checkpoint_path, map_location='cpu')
                 if status['compression'] == "bf16":
                     state_dict = transform_state_dict_to_dtype(state_dict, dtype="fp32")

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -215,7 +215,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                                   "You must pass model when loading a PytorchIPEXJITModel "
                                   "which is saving with compression precision.")
                 invalidInputError(input_sample is not None,
-                                  "You must pass model when loading a PytorchIPEXJITModel "
+                                  "You must pass input_sample when loading a PytorchIPEXJITModel "
                                   "which is saving with compression precision.")
                 state_dict = torch.load(checkpoint_path, map_location='cpu')
                 if status['compression'] == "bf16":

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -212,7 +212,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         if status["use_jit"]:
             if status['compression'] == "bf16":
                 invalidInputError(model is not None,
-                                  "You must pass input_sample when loading this model "
+                                  "You must pass model when loading this model "
                                   "which was saved with compression precision.")
                 invalidInputError(input_sample is not None,
                                   "You must pass input_sample when loading this model "

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -211,6 +211,12 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         checkpoint_path = path / status['checkpoint']
         if status["use_jit"]:
             if status['compression'] == "bf16":
+                invalidInputError(model is not None,
+                                  "You must pass model when loading a PytorchIPEXJITModel "
+                                  "which is saving with compression precision.")
+                invalidInputError(input_sample is not None,
+                                  "You must pass model when loading a PytorchIPEXJITModel "
+                                  "which is saving with compression precision.")
                 state_dict = torch.load(checkpoint_path, map_location='cpu')
                 if status['compression'] == "bf16":
                     state_dict = transform_state_dict_to_dtype(state_dict, dtype="fp32")

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -212,11 +212,11 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
         if status["use_jit"]:
             if status['compression'] == "bf16":
                 invalidInputError(model is not None,
-                                  "You must pass model when loading a PytorchIPEXJITModel "
-                                  "which is saving with compression precision.")
+                                  "You must pass input_sample when loading this model "
+                                  "which was saved with compression precision.")
                 invalidInputError(input_sample is not None,
-                                  "You must pass input_sample when loading a PytorchIPEXJITModel "
-                                  "which is saving with compression precision.")
+                                  "You must pass input_sample when loading this model "
+                                  "which was saved with compression precision.")
                 state_dict = torch.load(checkpoint_path, map_location='cpu')
                 if status['compression'] == "bf16":
                     state_dict = transform_state_dict_to_dtype(state_dict, dtype="fp32")

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
@@ -55,7 +55,7 @@ class PytorchQuantizedModel(AcceleratedLightningModule):
         )
         ipex_quantization = False
         # only ipex quantization saves this file
-        if os.path.exists(os.path.join(path, "best_configure.jason")):
+        if os.path.exists(os.path.join(path, "best_configure.json")):
             ipex_quantization = True
         if ipex_quantization:
             invalidInputError(example_inputs is not None,

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -1038,6 +1038,10 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         # device name might be: CPU, GPU, GPU.0 ...
         invalidInputError(device == 'CPU' or 'GPU' in device,
                           "Now we only support fp32 for CPU and GPU, not {}".format(device))
+        # can't set precision for trace
+        invalidInputError("precision" not in kwargs,
+                          "Don't pass precision when call InferenceOptimizer.trace, otherwise you"
+                          "should call InferenceOptimizer.quantize(precision=...)")
         if device != 'CPU' and accelerator != 'openvino':
             invalidInputError(False,
                               "Now we only support {} device when accelerator "

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -1040,7 +1040,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                           "Now we only support fp32 for CPU and GPU, not {}".format(device))
         # can't set precision for trace
         invalidInputError("precision" not in kwargs,
-                          "Don't pass precision when call InferenceOptimizer.trace, otherwise you"
+                          "Don't pass precision when call InferenceOptimizer.trace, otherwise you "
                           "should call InferenceOptimizer.quantize(precision=...)")
         if device != 'CPU' and accelerator != 'openvino':
             invalidInputError(False,

--- a/python/nano/test/inc/pytorch/test_quantize.py
+++ b/python/nano/test/inc/pytorch/test_quantize.py
@@ -26,6 +26,7 @@ from pytorch_lightning import LightningModule
 from torch import nn
 from test.pytorch.utils._train_torch_lightning import create_data_loader, data_transform
 import torchmetrics
+from torchvision.models import resnet18
 
 from bigdl.nano.pytorch import Trainer
 from bigdl.nano.pytorch import InferenceOptimizer
@@ -330,3 +331,38 @@ class TestINC(TestCase):
                                              max_trials=10,
                                              thread_num=8)
         assert qmodel
+
+    def test_quantize_loading_behavior(self):
+        # test nn.Module
+        model = resnet18()
+        input_sample = torch.randn(1, 3, 224, 224)
+        # test pytorch_fx
+        qmodel = InferenceOptimizer.quantize(model,
+                                             calib_data=input_sample)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(qmodel, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
+        with InferenceOptimizer.get_context(load_model):
+            load_model(input_sample)
+        
+        # test pytorch_ipex with wrong input
+        qmodel = InferenceOptimizer.quantize(model,
+                                             calib_data=input_sample,
+                                             method='ipex')
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(qmodel, tmp_dir_name)
+            with pytest.raises(
+                RuntimeError,
+                match="For INC ipex quantizated model, you need to set input_sample when loading model."
+                ):
+                load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
+
+        # test pytorch_ipex with right input
+        qmodel = InferenceOptimizer.quantize(model,
+                                             calib_data=input_sample,
+                                             method='ipex')
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(qmodel, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name, model=model, input_sample=input_sample)
+        with InferenceOptimizer.get_context(load_model):
+            load_model(input_sample)

--- a/python/nano/test/inc/pytorch/test_quantize.py
+++ b/python/nano/test/inc/pytorch/test_quantize.py
@@ -345,24 +345,26 @@ class TestINC(TestCase):
         with InferenceOptimizer.get_context(load_model):
             load_model(input_sample)
         
-        # test pytorch_ipex with wrong input
-        qmodel = InferenceOptimizer.quantize(model,
-                                             calib_data=input_sample,
-                                             method='ipex')
-        with tempfile.TemporaryDirectory() as tmp_dir_name:
-            InferenceOptimizer.save(qmodel, tmp_dir_name)
-            with pytest.raises(
-                RuntimeError,
-                match="For INC ipex quantizated model, you need to set input_sample when loading model."
-                ):
-                load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
+        if compare_version("neural_compressor", operator.ge, "2.0"):
+            # save & load of INC ipex quantized model only works when inc version >= 2.0
+            # test pytorch_ipex with wrong input
+            qmodel = InferenceOptimizer.quantize(model,
+                                                calib_data=input_sample,
+                                                method='ipex')
+            with tempfile.TemporaryDirectory() as tmp_dir_name:
+                InferenceOptimizer.save(qmodel, tmp_dir_name)
+                with pytest.raises(
+                    RuntimeError,
+                    match="For INC ipex quantizated model, you need to set input_sample when loading model."
+                    ):
+                    load_model = InferenceOptimizer.load(tmp_dir_name, model=model)
 
-        # test pytorch_ipex with right input
-        qmodel = InferenceOptimizer.quantize(model,
-                                             calib_data=input_sample,
-                                             method='ipex')
-        with tempfile.TemporaryDirectory() as tmp_dir_name:
-            InferenceOptimizer.save(qmodel, tmp_dir_name)
-            load_model = InferenceOptimizer.load(tmp_dir_name, model=model, input_sample=input_sample)
-        with InferenceOptimizer.get_context(load_model):
-            load_model(input_sample)
+            # test pytorch_ipex with right input
+            qmodel = InferenceOptimizer.quantize(model,
+                                                calib_data=input_sample,
+                                                method='ipex')
+            with tempfile.TemporaryDirectory() as tmp_dir_name:
+                InferenceOptimizer.save(qmodel, tmp_dir_name)
+                load_model = InferenceOptimizer.load(tmp_dir_name, model=model, input_sample=input_sample)
+            with InferenceOptimizer.get_context(load_model):
+                load_model(input_sample)

--- a/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
@@ -785,12 +785,12 @@ class TestInferencePipeline(TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             InferenceOptimizer.save(opt_model, tmpdir, compression="bf16")
             with pytest.raises(RuntimeError,
-                               match="You must pass model when loading a PytorchIPEXJITModel "
-                                     "which is saving with compression precision."):
+                               match="You must pass model when loading this model "
+                                     "which was saved with compression precision."):
                 InferenceOptimizer.load(tmpdir)
             with pytest.raises(RuntimeError,
-                               match="You must pass input_sample when loading a PytorchIPEXJITModel "
-                                     "which is saving with compression precision."):
+                               match="You must pass input_sample when loading this model "
+                                     "which was saved with compression precision."):
                 InferenceOptimizer.load(tmpdir, model=self.model)
             opt_model_load = InferenceOptimizer.load(tmpdir, model=self.model,
                                                      input_sample=input_sample)


### PR DESCRIPTION
## Description

Provide more clear error message to remind user about some tricky paramters.

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/300

### 2. User API changes

None, just add some invalidInputError for unexpected behaviours

### 3. Summary of the change 

add some invalidInputError for unexpected behaviours like:

- forget to pass input_sample for INC ipex quantizated model
- forget to pass input_sample for JIT compressed model
- forget to pass model for JIT compressed model
- pass precision for `InferenceOptimizer.trace`

### 4. How to test?
- [x] Unit test