### PR TITLE
Nano: Add more options for InferenceOptimizer and Fix JIT BF16 ut

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -129,6 +129,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                                                    ipex=True,
                                                                    channels_last=True),
             "openvino_fp32": TorchAccelerationOption(openvino=True),
+            "openvino_bf16": TorchAccelerationOption(openvino=True, bf16=True),
+            "openvino_fp16": TorchAccelerationOption(openvino=True, fp16=True),
             "openvino_int8": TorchAccelerationOption(openvino=True, pot=True),
             "onnxruntime_fp32": TorchAccelerationOption(onnxruntime=True),
             "onnxruntime_int8_qlinear": TorchAccelerationOption(onnxruntime=True, inc=True,

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -87,7 +87,10 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         {  # type: ignore
             "original": TFAccelerationOption(),
             "static_int8": TFAccelerationOption(inc=True),
+            "bf16": TFAccelerationOption(bf16=True),
             "openvino_fp32": TFAccelerationOption(openvino=True),
+            "openvino_bf16": TFAccelerationOption(openvino=True, bf16=True),
+            "openvino_fp16": TFAccelerationOption(openvino=True, fp16=True),
             "openvino_int8": TFAccelerationOption(openvino=True, pot=True),
             "onnxruntime_fp32": TFAccelerationOption(onnxruntime=True),
             "onnxruntime_int8_qlinear": TFAccelerationOption(onnxruntime=True, inc=True,

--- a/python/nano/src/bigdl/nano/utils/common/optimizer/acceleration_option.py
+++ b/python/nano/src/bigdl/nano/utils/common/optimizer/acceleration_option.py
@@ -23,7 +23,7 @@ from bigdl.nano.utils.common import _inc_checker, _ipex_checker,\
 
 
 _whole_acceleration_options = ["inc", "ipex", "onnxruntime", "openvino", "pot",
-                               "bf16", "jit", "channels_last"]
+                               "bf16", "fp16", "jit", "channels_last"]
 
 
 class AccelerationOption(object):
@@ -42,6 +42,8 @@ class AccelerationOption(object):
             return "int8"
         if self.bf16:
             return "bf16"
+        if self.fp16:
+            return "fp16"
         return "fp32"
 
     def get_accelerator(self):


### PR DESCRIPTION
## Description

Fix `RuntimeError: could not create a primitive descriptor iterator` of JIT BF16 ut, and relax the limit of `torch.allclose`.
Add more options in InferenceOptimizer.

### 1. Why the change?

Fix occasional `RuntimeError: could not create a primitive descriptor iterator` of JIT BF16 ut

### 2. User API changes

No, just add more options in `InferenceOptimizer.optimize`

### 3. Summary of the change 

- Fix `RuntimeError: could not create a primitive descriptor iterator` of JIT BF16 ut by adding avx512 checker, and relax the limit of `torch.allclose`.
- Add more options in `InferenceOptimizer.optimize`.
add `openvino_bf16` / `openvino_fp16` in Torch all combinations.
add `openvino_bf16` / `openvino_fp16` / `bf16` in Keras all combinations.

### 4. How to test?
- [x] Unit test
