### PR TITLE
[ORCA] Reduce Training Time Cost with PyTorch Pyspark Estimator

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -141,6 +141,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
 
         self.model_creator = model_creator
         self.optimizer_creator = optimizer_creator
+        self.state_dict = None
 
         num_nodes, cores_per_node = get_node_and_core_number()
         self.num_workers = num_nodes * workers_per_node

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -363,11 +363,13 @@ class PyTorchPySparkEstimator(BaseEstimator):
             worker_stats = res
         else:
             # state dicts of all runners would be the same
-            state_list = [item for item in res if isinstance(item, dict)]
+            for item in res:
+                if isinstance(item, dict):
+                    self.state_dict = item
+                    break
             # Each runner would return a list of worker stats for different epochs
             worker_stats = [item for item in res if isinstance(item, list)]
 
-        self.state_dict = state_list[0]
         epoch_stats = list(map(list, zip(*worker_stats)))
         if reduce_results:
             for i in range(len(epoch_stats)):

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -183,7 +183,6 @@ class PyTorchPySparkEstimator(BaseEstimator):
             cluster_info=self._get_cluster_info(sc),
             **local_init_params)
 
-
     def create_tcpstore_server(self) -> 'TCPStore':
         import torch.distributed as dist
         server_store = dist.TCPStore(self.ip, self.tcp_store_port, -1, True,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -362,7 +362,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
             self.state_dict = PyTorchPySparkEstimator._get_state_dict_from_remote(self.model_dir)
             worker_stats = res
         else:
-            # state dicts of all runners would be the same
+            # Only the state_dict of the rank 0 worker would be returned
             for item in res:
                 if isinstance(item, dict):
                     self.state_dict = item

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -362,7 +362,9 @@ class PyTorchPySparkEstimator(BaseEstimator):
             self.state_dict = PyTorchPySparkEstimator._get_state_dict_from_remote(self.model_dir)
             worker_stats = res
         else:
-            self.state_dict = res[0]  # state dicts of all runners would be the same
+            # state dicts of all runners would be the same
+            self.state_dict = [item[0] for item in res if isinstance(item, list)
+                               and isinstance(item[0], dict)]
             # Each runner would return a list of worker stats for different epochs
             worker_stats = [item for item in res if isinstance(item, list)]
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -183,8 +183,6 @@ class PyTorchPySparkEstimator(BaseEstimator):
             cluster_info=self._get_cluster_info(sc),
             **local_init_params)
 
-        if self.model_creator:
-            self.state_dict = self.driver_runner.get_state_dict()
 
     def create_tcpstore_server(self) -> 'TCPStore':
         import torch.distributed as dist

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -363,11 +363,11 @@ class PyTorchPySparkEstimator(BaseEstimator):
             worker_stats = res
         else:
             # state dicts of all runners would be the same
-            self.state_dict = [item[0] for item in res if isinstance(item, list)
-                               and isinstance(item[0], dict)]
+            state_list = [item for item in res if isinstance(item, dict)]
             # Each runner would return a list of worker stats for different epochs
             worker_stats = [item for item in res if isinstance(item, list)]
 
+        self.state_dict = state_list[0]
         epoch_stats = list(map(list, zip(*worker_stats)))
         if reduce_results:
             for i in range(len(epoch_stats)):

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -153,7 +153,8 @@ class PytorchPysparkWorker(TorchRunner):
     def validate(self, data_creator, batch_size=32, num_steps=None, profile=False,
                  wrap_dataloader=None, callbacks=None):
         """Evaluates the model on the validation data set."""
-        self.load_state_dict(self.state_dict.value)
+        if self.state_dict:
+            self.load_state_dict(self.state_dict.value)
         validation_stats = super().validate(data_creator, batch_size, num_steps, profile,
                                             wrap_dataloader, callbacks)
         if self.log_to_driver:
@@ -166,7 +167,8 @@ class PytorchPysparkWorker(TorchRunner):
         self._toggle_profiling(profile=profile)
 
         partition = data_creator(config, batch_size)
-        self.load_state_dict(self.state_dict.value)
+        if self.state_dict:
+            self.load_state_dict(self.state_dict.value)
         result = super().predict(partition=partition, batch_size=batch_size,
                                  profile=profile, callbacks=callbacks)
         if self.log_to_driver:

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -135,17 +135,20 @@ class PytorchPysparkWorker(TorchRunner):
                                           wrap_dataloader=wrap_dataloader,
                                           callbacks=callbacks,
                                           validation_data_creator=validation_data_creator)
-        state_dict = self.get_state_dict()
 
         if self.log_to_driver:
             LogMonitor.stop_log_monitor(self.log_path, self.logger_thread, self.thread_stop)
 
         if self.rank == 0:
             if self.model_dir is not None:
+                state_dict = self.get_state_dict()
                 save_pkl(state_dict, os.path.join(self.model_dir, "state.pkl"))
+
+        if self.model_dir is not None:
             return [stats_list]
         else:
             if self.rank == 0:
+                state_dict = self.get_state_dict()
                 return [state_dict, stats_list]
             else:
                 return [stats_list]

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -140,14 +140,15 @@ class PytorchPysparkWorker(TorchRunner):
         if self.log_to_driver:
             LogMonitor.stop_log_monitor(self.log_path, self.logger_thread, self.thread_stop)
 
-        if self.rank == 0:
-            if self.model_dir is not None:
-                save_pkl(state_dict, os.path.join(self.model_dir, "state.pkl"))
-
         if self.model_dir is not None:
+            if self.rank == 0:
+                save_pkl(state_dict, os.path.join(self.model_dir, "state.pkl"))
             return [stats_list]
         else:
-            return [state_dict, stats_list]
+            if self.rank == 0:
+                return [state_dict, stats_list]
+            else:
+                return [stats_list]
 
     def validate(self, data_creator, batch_size=32, num_steps=None, profile=False,
                  wrap_dataloader=None, callbacks=None):

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -139,12 +139,10 @@ class PytorchPysparkWorker(TorchRunner):
         if self.log_to_driver:
             LogMonitor.stop_log_monitor(self.log_path, self.logger_thread, self.thread_stop)
 
-        if self.rank == 0:
-            if self.model_dir is not None:
+        if self.model_dir is not None:
+            if self.rank == 0:
                 state_dict = self.get_state_dict()
                 save_pkl(state_dict, os.path.join(self.model_dir, "state.pkl"))
-
-        if self.model_dir is not None:
             return [stats_list]
         else:
             if self.rank == 0:

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -140,8 +140,8 @@ class PytorchPysparkWorker(TorchRunner):
         if self.log_to_driver:
             LogMonitor.stop_log_monitor(self.log_path, self.logger_thread, self.thread_stop)
 
-        if self.model_dir is not None:
-            if self.rank == 0:
+        if self.rank == 0:
+            if self.model_dir is not None:
                 save_pkl(state_dict, os.path.join(self.model_dir, "state.pkl"))
             return [stats_list]
         else:

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -126,7 +126,8 @@ class PytorchPysparkWorker(TorchRunner):
     def train_epochs(self, data_creator, epochs=1, batch_size=32, profile=False,
                      wrap_dataloader=None, callbacks=None,
                      validation_data_creator=None):
-        self.load_state_dict(self.state_dict.value)
+        if self.state_dict:
+            self.load_state_dict(self.state_dict.value)
         stats_list = super().train_epochs(data_creator=data_creator,
                                           epochs=epochs,
                                           batch_size=batch_size,

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -154,8 +154,7 @@ class PytorchPysparkWorker(TorchRunner):
     def validate(self, data_creator, batch_size=32, num_steps=None, profile=False,
                  wrap_dataloader=None, callbacks=None):
         """Evaluates the model on the validation data set."""
-        if self.state_dict:
-            self.load_state_dict(self.state_dict.value)
+        self.load_state_dict(self.state_dict.value)
         validation_stats = super().validate(data_creator, batch_size, num_steps, profile,
                                             wrap_dataloader, callbacks)
         if self.log_to_driver:
@@ -168,8 +167,7 @@ class PytorchPysparkWorker(TorchRunner):
         self._toggle_profiling(profile=profile)
 
         partition = data_creator(config, batch_size)
-        if self.state_dict:
-            self.load_state_dict(self.state_dict.value)
+        self.load_state_dict(self.state_dict.value)
         result = super().predict(partition=partition, batch_size=batch_size,
                                  profile=profile, callbacks=callbacks)
         if self.log_to_driver:


### PR DESCRIPTION
## Description
For https://github.com/intel-analytics/BigDL/issues/7626 to improve pytorch pyspark backend training performance.

### 1. Why the change?
To minimize the overhead during training with pytorch pyspark backend.

### 2. User API changes
N/A

### 3. Summary of the change 
Disable broadcast for first training and setup only rank 0 worker will return model states to reduce spark overhead. 

### 4. How to test?
- [x] Unit test
- [x] Application test
