### PR TITLE
Support save model checkpoint by step frequency

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/base.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/base.py
@@ -70,3 +70,6 @@ class Callback(object):
 
     def after_pred_iter(self, runner):
         self.after_iter(runner)
+
+    def every_n_iter(self, runner, n):
+        return (runner.global_step + 1) % n == 0 if n > 0 else False

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/base.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/base.py
@@ -73,3 +73,6 @@ class Callback(object):
 
     def every_n_iter(self, runner, n):
         return (runner.global_step + 1) % n == 0 if n > 0 else False
+
+    def every_n_epoch(self, runner, n):
+        return runner.epochs % n == 0 if n > 0 else False

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
@@ -28,10 +28,10 @@ class ModelCheckpoint(Callback):
     FILE_EXTENSION = ".ckpt"
 
     def __init__(self,
-                 filepath=None,
-                 save_weights_only=False,
-                 by_epoch=True,
-                 interval=-1,
+                 filepath: str = "",
+                 save_weights_only: bool = False,
+                 by_epoch: bool = True,
+                 interval: int = -1,
                  ):
         """
         ModelCheckpoint callback is used in conjunction with training using estimator.fit() to save
@@ -66,13 +66,22 @@ class ModelCheckpoint(Callback):
         """
         if not self.by_epoch:
             return
-        stats = {"epoch": runner.epochs}
-        last_ckpt_path = self._format_checkpoint_name(dirname=self.dirname,
-                                                      filename=self.filename,
-                                                      stats=stats)
-        runner.save_checkpoint(last_ckpt_path, self.save_weights_only)
+        # if user do not specify the interval, save checkpoint after every epoch
+        if self.interval < 0:
+            self.interval = 1
+        if self.every_n_epoch(runner, self.interval):
+            stats = {"epoch": runner.epochs}
+            last_ckpt_path = self._format_checkpoint_name(dirname=self.dirname,
+                                                          filename=self.filename,
+                                                          stats=stats)
+            runner.save_checkpoint(last_ckpt_path, self.save_weights_only)
 
     def after_train_iter(self, runner):
+        """
+        Called at the end of an iteration.
+        Subclasses should override for any actions to run. This function should only
+        be called during TRAIN mode.
+        """
         if self.by_epoch:
             return
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
@@ -117,10 +117,8 @@ class ModelCheckpoint(Callback):
         Called at the end of training.
         Subclasses should override for any actions to run.
         """
-        stats = {"epoch": runner.epochs}
         last_ckpt_path = self._format_checkpoint_name(dirname=self.dirname,
-                                                      filename=self.CHECKPOINT_NAME_LAST,
-                                                      stats=stats)
+                                                      filename=self.CHECKPOINT_NAME_LAST)
         previous, self.last_ckpt_path = self.last_ckpt_path, last_ckpt_path
         runner.save_checkpoint(last_ckpt_path, self.save_weights_only)
         if previous and previous != last_ckpt_path:

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/model_checkpoint.py
@@ -31,7 +31,7 @@ class ModelCheckpoint(Callback):
                  filepath=None,
                  save_weights_only=False,
                  by_epoch=True,
-                 interval=1,
+                 interval=-1,
                  ):
         """
         ModelCheckpoint callback is used in conjunction with training using estimator.fit() to save
@@ -44,6 +44,9 @@ class ModelCheckpoint(Callback):
         And checkpoints will be saved as file with path like 'my/path/sample-mnist-epoch=1.ckpt'
         with different epoch values.
         :param filepath: path to save the model file.
+        :param by_epoch: save chekpoint by epoch or by iteration
+        :param interval: The saving period. If ``by_epoch=True``, interval
+            indicates epochs, otherwise it indicates iterations. Default: -1, which means "never".
         """
         super().__init__()
         self.filepath = filepath

--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
@@ -646,6 +646,48 @@ class TestPyTorchEstimator(TestCase):
         with pytest.raises(RuntimeError):
             Estimator.latest_checkpoint(temp_dir)
 
+    def test_checkpoint_callback_by_iter(self):
+        from bigdl.orca.learn.pytorch.callbacks.model_checkpoint import ModelCheckpoint
+        sc = OrcaContext.get_spark_context()
+        spark = SparkSession.builder.getOrCreate()
+        rdd = sc.range(0, 100)
+        epochs = 1
+        data = rdd.map(lambda x: (np.random.randn(50).astype(np.float32).tolist(),
+                                  [float(np.random.randint(0, 2, size=()))])
+                       )
+        schema = StructType([
+            StructField("feature", ArrayType(FloatType()), True),
+            StructField("label", ArrayType(FloatType()), True)
+        ])
+        df = spark.createDataFrame(data=data, schema=schema)
+        df = df.cache()
+
+        size = df.count()
+        batch_size = 4
+        interval = 5
+
+        estimator = get_estimator(workers_per_node=2, log_level=logging.DEBUG)
+
+        try:
+            temp_dir = tempfile.mkdtemp()
+            callbacks = [
+                ModelCheckpoint(filepath=os.path.join(temp_dir, "test-{iter}"),
+                                save_weights_only=True,
+                                by_epoch=False,
+                                interval=interval)
+            ]
+            estimator.fit(df, batch_size=batch_size, epochs=epochs,
+                          callbacks=callbacks,
+                          feature_cols=["feature"],
+                          label_cols=["label"])
+
+            for i in range(interval, int(size / batch_size) + 1, interval):
+                assert os.path.isfile(os.path.join(temp_dir, f"test-iter={i}.ckpt"))
+
+            estimator.shutdown()
+        finally:
+            shutil.rmtree(temp_dir)
+
     def test_manual_ckpt(self):
         sc = OrcaContext.get_spark_context()
         spark = SparkSession.builder.getOrCreate()


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
Implement `after_train_iter`  method in ModelCheckpoint callback to support saving model checkpoint by step frequency. 
### 1. Why the change?
related issue: https://github.com/intel-analytics/BigDL/issues/7105#issuecomment-1419996858
<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
Add two parameters when creating the ModelCheckpoint callback.
- **by_epoch**: save chekpoint by epoch or by iteration, default is True
- **interval**: The saving period. If `by_epoch=True`, interval indicates epochs, otherwise it indicates iterations. Default is -1, which means "never".

To save model checkpoint by step frequency, we can create a ModelCheckpoint callback as below:
```python
# create estimator
estimator = ...

# create callbacks
callbacks = [
    ModelCheckpoint(filepath=ckpt_save_path, # filepath should contains 'epoch' or 'iter' like this 'my/path/test-{iter:02d}'
    save_weights_only=True,
    by_epoch=False,
    interval=5)
]

# use callbacks when training
estimator.fit(data, batch_size=batch_size, epochs=epochs,
    callbacks=callbacks,
    feature_cols=["feature"],
    label_cols=["label"])
```

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
Implement `after_train_iter`  method in ModelCheckpoint callback to support saving model checkpoint by step frequency. 

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
