### PR TITLE
[Nano] Make methods from `BaseInferenceOptimizer` shown in api doc of TF `InferenceOptimizer`

### DIFF
--- a/docs/readthedocs/source/doc/PythonAPI/Nano/tensorflow.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/Nano/tensorflow.rst
@@ -29,6 +29,7 @@ bigdl.nano.tf.keras.InferenceOptimizer
     :members:
     :undoc-members:
     :exclude-members: ALL_INFERENCE_ACCELERATION_METHOD
+    :inherited-members:
 
 Patch API
 ---------------------------


### PR DESCRIPTION
## Description

Make methods from `BaseInferenceOptimizer` shown in api doc of TF `InferenceOptimizer`

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/308

### 2. How to test?
- [x] Document test: https://yuwentestdocs.readthedocs.io/en/nano-tf-api-fix/doc/PythonAPI/Nano/tensorflow.html#bigdl.nano.tf.keras.InferenceOptimizer.get_best_model
