### PR TITLE
[cicd] make nightly python build can only be triggered by schedule event

### DIFF
--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -17,7 +17,6 @@ on:
         options:
         - all
         - scala-build
-        - python-build
         - python-sourceforge-build
         - docker-bigdl-build
       tag:
@@ -272,7 +271,7 @@ jobs:
   
     
   python-build:
-    if: ${{ github.event.schedule || github.event.inputs.artifact == 'python-build' || github.event.inputs.artifact == 'all' }} 
+    if: ${{ github.event.schedule }} 
     runs-on: [self-hosted, ubuntu-20.04-lts, Bree]
 
     steps:

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -269,8 +269,8 @@ jobs:
         job-name: docker-build-bigdl
         runner-hosted-on: 'America'
   
-    
   python-build:
+    # python build can only be published once a day, please do not publish it manually
     if: ${{ github.event.schedule }} 
     runs-on: [self-hosted, ubuntu-20.04-lts, Bree]
 


### PR DESCRIPTION
## Description

This submission is to make nightly python build only triggered by scheduled events. Since python build can only be published once a day, if developers manually publish the python build, the nightly build will fail to publish which might affect other nightly tests.
