### PR TITLE
Nano: add output_tensors parameter for `quantize` and `optimize`

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -629,6 +629,7 @@ class BasePytorchForecaster(Forecaster):
                      metric=metric,
                      direction="min",
                      thread_num=thread_num,
+                     output_tensors=False,
                      excludes=excludes,
                      input_sample=dummy_input)
         try:
@@ -641,6 +642,7 @@ class BasePytorchForecaster(Forecaster):
         except Exception:
             invalidInputError(False, "Unable to find an optimized model that meets your conditions."
                               "Maybe you can relax your search limit.")
+        self.optimized_model_output_tensor = False
         self.optimized_model_thread_num = thread_num
 
     def get_context(self, thread_num=None, optimize=True):
@@ -1977,14 +1979,13 @@ class BasePytorchForecaster(Forecaster):
                                               timeout=timeout,
                                               max_trials=max_trials,
                                               onnxruntime_session_options=sess_options,
-                                              thread_num=thread_num)
+                                              thread_num=thread_num,
+                                              output_tensors=False)
         if accelerator == 'onnxruntime':
-            q_model.output_tensors = False
             self.accelerated_model = q_model
             self.optimized_model_output_tensor = False
             self.accelerate_method = "onnxruntime_int8"
         if accelerator == 'openvino':
-            q_model.output_tensors = False
             self.accelerated_model = q_model
             self.optimized_model_output_tensor = False
             self.accelerate_method = "openvino_int8"

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -2073,8 +2073,10 @@ def _str2optimizer_metric(metric):
         metric_func = REGRESSION_MAP[metric_name]
 
         def metric(pred, target):
-            pred = pred.numpy()
-            target = target.numpy()
+            if isinstance(pred, torch.Tensor):
+                pred = pred.numpy()
+            if isinstance(target, torch.Tensor):
+                target = target.numpy()
             return metric_func(target, pred)
         metric.__name__ = metric_name
     return metric

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -175,7 +175,8 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                       device=self.ov_model._device,
                       thread_num=thread_num,
                       precision='int8',
-                      config=config)
+                      config=config,
+                      output_tensors=self.output_tensors)
         return self
 
     def _save_model(self, path, compression="fp32"):

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -859,7 +859,11 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                           "max_trials": max_trials,
                                           "onnxruntime_session_options": onnxruntime_session_options
                                           }
-                if framework != 'pytorch_ipex':
+                if accelerator == "onnxruntime":
+                    q_model = inc_quantize(**inc_quantize_arguments)
+                    q_model.output_tensors = output_tensors
+                    return q_model
+                elif framework != 'pytorch_ipex':
                     return inc_quantize(**inc_quantize_arguments)
                 else:
                     try:

--- a/python/nano/test/onnx/pytorch/test_inc_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_inc_onnx.py
@@ -432,6 +432,27 @@ class TestOnnx(TestCase):
         result_m = accmodel(x1,x2,x3,x4, np.array([2]))
         assert abs(torch.sum(result_m).item()) < 1e-5 + 6
 
+    def test_onnx_quantize_output_tensors(self):
+        model = ResNet18(10, pretrained=True, include_top=False, freeze=True)
+        loss = nn.CrossEntropyLoss()
+        optimizer = torch.optim.Adam(model.parameters(), lr=0.01)
+
+        pl_model = Trainer.compile(model, loss, optimizer)
+        x = torch.rand((10, 3, 256, 256))
+        y = torch.ones((10, ), dtype=torch.long)
+        ds = TensorDataset(x, y)
+        train_loader = DataLoader(ds, batch_size=2)
+
+        onnx_model = InferenceOptimizer.quantize(pl_model, accelerator='onnxruntime',
+                                                 method='qlinear', calib_data=train_loader)
+        test_onnx_model = InferenceOptimizer.quantize(pl_model, accelerator="onnxruntime",
+                                                      method='qlinear', calib_data=train_loader,
+                                                      output_tensors=False)
+        for x, y in train_loader:
+            model.eval()
+            forward_res_tensor = onnx_model(x).numpy()
+            forward_res_numpy = test_onnx_model(x)
+            np.testing.assert_almost_equal(forward_res_tensor, forward_res_numpy, decimal=5)
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/python/nano/test/onnx/pytorch/test_inc_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_inc_onnx.py
@@ -449,9 +449,9 @@ class TestOnnx(TestCase):
                                                       method='qlinear', calib_data=train_loader,
                                                       output_tensors=False)
         for x, y in train_loader:
-            model.eval()
             forward_res_tensor = onnx_model(x).numpy()
             forward_res_numpy = test_onnx_model(x)
+            assert isinstance(forward_res_numpy, np.ndarray)
             np.testing.assert_almost_equal(forward_res_tensor, forward_res_numpy, decimal=5)
 
 if __name__ == '__main__':

--- a/python/nano/test/onnx/pytorch/test_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_onnx.py
@@ -350,9 +350,9 @@ class TestOnnx(TestCase):
                                                    input_sample=train_loader, output_tensors=False)
 
         for x, y in train_loader:
-            model.eval()
             forward_res_tensor = onnx_model(x).numpy()
             forward_res_numpy = test_onnx_model(x)
+            assert isinstance(forward_res_numpy, np.ndarray)
             np.testing.assert_almost_equal(forward_res_tensor, forward_res_numpy, decimal=5)
 
 if __name__ == '__main__':

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -381,7 +381,7 @@ class TestOpenVINO(TestCase):
                                                        input_sample=dataloader, output_tensors=False)
 
         for x, y in dataloader:
-            model.eval()
             forward_model_tensor = openvino_model(x).numpy()
             forward_model_numpy = test_openvino_model(x)
+            assert isinstance(forward_model_numpy, np.ndarray)
             np.testing.assert_almost_equal(forward_model_tensor, forward_model_numpy, decimal=5)

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -385,3 +385,23 @@ class TestOpenVINO(TestCase):
             preds2 = load_model(x).numpy()
 
         np.testing.assert_almost_equal(preds1, preds2, decimal=5)
+
+    def test_openvino_quantize_output_tensors(self):
+        model = mobilenet_v3_small(num_classes=10)
+
+        x = torch.rand((10, 3, 256, 256))
+        y = torch.ones((10, ), dtype=torch.long)
+
+        ds = TensorDataset(x, y)
+        dataloader = DataLoader(ds, batch_size=2)
+
+        openvino_model = InferenceOptimizer.quantize(model, accelerator='openvino',
+                                                     calib_data=dataloader)
+        test_openvino_model = InferenceOptimizer.quantize(model, accelerator='openvino',
+                                                          calib_data=dataloader,
+                                                          output_tensors=False)
+        for x, y in dataloader:
+            model.eval()
+            forward_model_tensor = openvino_model(x).numpy()
+            forward_model_numpy = test_openvino_model(x)
+            np.testing.assert_almost_equal(forward_model_tensor, forward_model_numpy, decimal=5)

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -401,7 +401,7 @@ class TestOpenVINO(TestCase):
                                                           calib_data=dataloader,
                                                           output_tensors=False)
         for x, y in dataloader:
-            model.eval()
             forward_model_tensor = openvino_model(x).numpy()
             forward_model_numpy = test_openvino_model(x)
+            assert isinstance(forward_model_numpy, np.ndarray)
             np.testing.assert_almost_equal(forward_model_tensor, forward_model_numpy, decimal=5)


### PR DESCRIPTION
## Description

Add `output_tensors` parameter for `quantize` and `optimize`, so users can specify the output is numpy.ndarray. (avoid some unnecessary type conversion)

### 1. Why the change?

follow up https://github.com/intel-analytics/BigDL/pull/7638.

### 2. User API changes

add new param `output_tensors` in `InferenceOptimizer.quantize` and `InferenceOptimizer.optimize`
```bash
def optimize(..., output_tensors: bool = True, ...)
def quantize(..., output_tensors: bool = True, ...)
# output_tensors: boolean, default to True and output of the model will be Tensors, only valid when accelerator='onnxruntime' or accelerator='openvino', otherwise will be ignored. If output_tensors=False, output of the export model will be ndarray.
```

### 3. Summary of the change 

- add new param `output_tensors` in `InferenceOptimizer.quantize` and `InferenceOptimizer.optimize`
- add related uts
- modify internal implementation in Chronos

### 4. How to test?
- [x] Unit test
