### PR TITLE
Fix unknown size dataset for tf quantize

### DIFF
--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -170,6 +170,7 @@ def setup_package():
                         "py-cpuinfo",
                         "pyyaml",
                         "packaging",
+                        "sigfig",
                         "setuptools<66"]
 
     package_data = [

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
@@ -116,8 +116,13 @@ def _quantize(
         else:
             # `dataloader` is tensorflow (x,y)
             # we should construct a INC DataLoader from tf.Dataset or numpy ndarray
-            from .onnx.tensorflow.quantization import KerasNumpyDataset
-            dataloader = KerasNumpyDataset(dataloader[0], dataloader[1])
+            import tensorflow as tf
+            if isinstance(dataloader[0], tf.data.Dataset):
+                dataloader = DataLoader("tensorflow", dataloader[0])
+            else:
+                from .onnx.tensorflow.quantization import KerasNumpyDataset
+                dataloader = KerasNumpyDataset(dataloader[0], dataloader[1])
+
     elif not hasattr(dataloader, "batch_size") and not hasattr(dataloader, "_batch_size"):
         # INC requires a batched dataloader,
         # A torch.Dataset doesn't have `batch_size` attribute,

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -17,6 +17,7 @@
 import torch
 from torch import nn
 import time
+import sigfig
 import multiprocessing as mp
 from typing import Dict, Callable, Tuple, Optional, List, Union, Sequence
 from torch.utils.data import DataLoader
@@ -470,7 +471,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                             _accuracy = result_map["original"]["accuracy"]
                             if isinstance(_accuracy, torch.Tensor):
                                 _accuracy = _accuracy.item()
-                            _accuracy = round(_accuracy, 3)
+                            _accuracy = sigfig.round(_accuracy, sigfigs=5)
                             result_map[method]["accuracy"] = str(_accuracy) + '*'
                         else:
                             if method == "original":

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -838,4 +838,4 @@ def _accuracy_calculate_helper(model, metric, data):
             results.append(result)
         return np.average(results)
     else:
-        raise ValueError("metric should be a tf.keras.metrics.Metric or a Callable")
+        invalidInputError(False, "metric should be a tf.keras.metrics.Metric or a Callable")

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -25,6 +25,7 @@ from pathlib import Path
 import numpy as np
 import traceback
 import inspect
+import sigfig
 import tensorflow as tf
 import keras
 from typing import Dict, Optional, List, Union, Callable
@@ -298,7 +299,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                     # so we jump it to reduce time cost of optimize
                     if precision == "fp32" and method != "original":
                         _accuracy = result_map["original"]["accuracy"]
-                        _accuracy = round(_accuracy, 3)
+                        _accuracy = sigfig.round(_accuracy, sigfigs=5)
                         result_map[method]["accuracy"] = str(_accuracy) + '*'
                     else:
                         if method == "original":
@@ -620,6 +621,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 y = range(len(x))    # type: ignore
                 y = tf.data.Dataset.from_tensor_slices(y)
                 x = tf.data.Dataset.zip((x, y))
+
         if accelerator is None:
             if isinstance(x, tf.data.Dataset):
                 calib_dataset = x
@@ -824,6 +826,16 @@ def _accuracy_calculate_helper(model, metric, data):
     '''
     A quick helper to calculate accuracy
     '''
-    for data_input, target in data:
-        metric.update_state(y_true=target, y_pred=model(data_input))
-    return metric.result().numpy()
+    if isinstance(metric, tf.keras.metrics.Metric):
+        metric.reset_states()
+        for data_input, target in data:
+            metric.update_state(y_true=target, y_pred=model(data_input))
+        return metric.result().numpy()
+    elif isinstance(metric, Callable):
+        results = []
+        for data_input, target in data:
+            result = metric(y_true=target, y_pred=model(data_input))
+            results.append(result)
+        return np.average(results)
+    else:
+        raise ValueError("metric should be a tf.keras.metrics.Metric or a Callable")

--- a/python/nano/src/bigdl/nano/utils/common/optimizer/format.py
+++ b/python/nano/src/bigdl/nano/utils/common/optimizer/format.py
@@ -17,6 +17,7 @@
 
 import numbers
 from typing import Dict
+import sigfig
 
 from .acceleration_option import AccelerationOption
 
@@ -61,21 +62,21 @@ def format_optimize_result(optimize_result_dict: dict,
             status = result["status"]
             latency = result.get("latency", "None")
             if latency != "None":
-                latency = round(latency, 3)
+                latency = sigfig.round(latency, sigfigs=5)
             accuracy = result.get("accuracy", "None")
             if accuracy != "None" and isinstance(accuracy, float):
-                accuracy = round(accuracy, 3)
+                accuracy = sigfig.round(accuracy, sigfigs=5)
             elif isinstance(accuracy, numbers.Real):
                 # support more types
                 accuracy = float(accuracy)
-                accuracy = round(accuracy, 3)
+                accuracy = sigfig.round(accuracy, sigfigs=5)
             else:
                 try:
                     import torch
                     # turn Tensor into float
                     if isinstance(accuracy, torch.Tensor):
                         accuracy = accuracy.item()
-                        accuracy = round(accuracy, 3)
+                        accuracy = sigfig.round(accuracy, sigfigs=5)
                 except ImportError:
                     pass
             method_str = f"| {method:^30} | {status:^20} | " \
@@ -93,7 +94,7 @@ def format_optimize_result(optimize_result_dict: dict,
             status = result["status"]
             latency = result.get("latency", "None")
             if latency != "None":
-                latency = round(latency, 3)
+                latency = sigfig.round(latency, sigfigs=5)
             method_str = f"| {method:^30} | {status:^20} | {latency:^12} |\n"
             repr_str += method_str
         repr_str += horizontal_line

--- a/python/nano/test/onnx/tf/test_inc_onnx.py
+++ b/python/nano/test/onnx/tf/test_inc_onnx.py
@@ -28,7 +28,7 @@ class TestONNX(TestCase):
     def test_model_quantize_onnx(self):
         model = EfficientNetB0(weights=None, input_shape=[224, 224, 3], classes=10)
         model = Model(inputs=model.inputs, outputs=model.outputs)
-        input_examples = np.random.random((100, 224, 224, 3))
+        input_examples = np.random.random((100, 224, 224, 3)).astype(np.float32)
         input_features = np.random.randint(0, 10, size=100)
         
         train_dataset = tf.data.Dataset.from_tensor_slices((input_examples,
@@ -55,7 +55,7 @@ class TestONNX(TestCase):
     def test_model_quantize_onnx_without_dataset(self):
         model = EfficientNetB0(weights=None, input_shape=[224, 224, 3], classes=10)
         model = Model(inputs=model.inputs, outputs=model.outputs)
-        input_examples = np.random.random((100, 224, 224, 3))
+        input_examples = np.random.random((100, 224, 224, 3)).astype(np.float32)
         input_features = np.random.randint(0, 10, size=100)
 
         # quantize a Keras model
@@ -74,7 +74,7 @@ class TestONNX(TestCase):
     def test_model_quantize_onnx_with_only_x(self):
         model = EfficientNetB0(weights=None, input_shape=[224, 224, 3], classes=10)
         model = Model(inputs=model.inputs, outputs=model.outputs)
-        input_examples = np.random.random((100, 224, 224, 3))
+        input_examples = np.random.random((100, 224, 224, 3)).astype(np.float32)
         preds = model.predict(input_examples, batch_size=5)
 
         # quantize a Keras model based on numpy array
@@ -115,7 +115,7 @@ class TestONNX(TestCase):
     def test_model_quantize_onnx_save_load(self):
         model = EfficientNetB0(weights=None, input_shape=[224, 224, 3], classes=10)
         model = Model(inputs=model.inputs, outputs=model.outputs)
-        input_examples = np.random.random((100, 224, 224, 3))
+        input_examples = np.random.random((100, 224, 224, 3)).astype(np.float32)
         input_features = np.random.randint(0, 10, size=100)
         
         train_dataset = tf.data.Dataset.from_tensor_slices((input_examples,


### PR DESCRIPTION
## Description

1. fix tf quantize when dataset size is unknowm
2. support metric function in addition to `tf.keras.metrics.Metric` object
3. print result rounding to 5 significant figures instead of 3 decimals

### 4. How to test?
- [ ] N/A
- [x] hot fix, existing Unit test, additional unit tests will be added later
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [x] New Python dependencies
       - sigfig (rounding to significant figures)
