### PR TITLE
Chronos: fix ImportError of `TSPipeline`

### DIFF
--- a/python/chronos/src/bigdl/chronos/autots/__init__.py
+++ b/python/chronos/src/bigdl/chronos/autots/__init__.py
@@ -23,9 +23,8 @@ if os.getenv("LD_PRELOAD", "null") != "null":
                   "Please run `source bigdl-nano-unset-env` "
                   "in your bash terminal")
 
-try:
-    # TODO: make this a LazyImport
-    from .autotsestimator import AutoTSEstimator
-    from .tspipeline import TSPipeline
-except ImportError:
-    pass
+# to avoid ImportError of TSPipeline, make this a LazyImport
+from bigdl.chronos.utils import LazyImport
+AutoTSEstimator = LazyImport('bigdl.chronos.autots.autotsestimator.AutoTSEstimator')
+
+from .tspipeline import TSPipeline


### PR DESCRIPTION
## Description

If users only install bigdl-chronos[pytorch], there exists ImportError of `TSPipeline`.
Make `AutoTSEstimator` a LazyImport.

### 4. How to test?
- [x] Unit test
