### PR TITLE
Add tritonserver to DL-Serving Image.

### DIFF
--- a/ppml/trusted-dl-serving/base/Dockerfile
+++ b/ppml/trusted-dl-serving/base/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE_NAME
 ARG BASE_IMAGE_TAG
 ARG JDK_VERSION=11
 
-#Stage.1 Torchserve Frontend
+# Stage.1 Torchserve Frontend
 FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG as temp
 ARG http_proxy
 ARG https_proxy
@@ -12,7 +12,8 @@ ARG JDK_VERSION
 ENV JDK_HOME                /opt/jdk${JDK_VERSION}
 ENV JAVA_HOME                           /opt/jdk${JDK_VERSION}
 
-RUN apt-get install -y openjdk-${JDK_VERSION}-jdk && \
+RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -y openjdk-${JDK_VERSION}-jdk && \
     mkdir -p ${JAVA_HOME} && \
     cp -r /usr/lib/jvm/java-${JDK_VERSION}-openjdk-amd64/* ${JAVA_HOME} && \
     git clone https://github.com/analytics-zoo/pytorch-serve.git && \
@@ -21,7 +22,7 @@ RUN apt-get install -y openjdk-${JDK_VERSION}-jdk && \
     mkdir -p /ppml/torchserve && \
     mv server/build/libs/server-1.0.jar /ppml/torchserve/frontend.jar
 
-#Stage.2 Tritonserver
+# Stage.2 Tritonserver
 From ubuntu:20.04 as tritonserver
 ARG http_proxy
 ARG https_proxy
@@ -51,6 +52,13 @@ RUN cd / &&\
     ./build.py -v --no-container-build --build-dir=`pwd`/build --backend=python --repoagent=checksum --filesystem=gcs --filesystem=s3 --filesystem=azure_storage --endpoint=http --endpoint=grpc --endpoint=sagemaker --endpoint=vertex-ai --enable-logging --enable-stats --enable-tracing
 
 FROM nvcr.io/nvidia/tritonserver:23.01-py3-min AS min_container
+
+# Stage.3 TF-Serving
+FROM tensorflow/serving:latest-devel as tf-serving
+ARG http_proxy
+ARG https_proxy
+ARG no_proxy
+RUN bazel build -c opt tensorflow_serving/...
 
 # DL-Serving
 FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG
@@ -84,6 +92,7 @@ ENV TCMALLOC_RELEASE_RATE 200
 RUN mkdir /ppml/examples && \
     mkdir /ppml/torchserve && \
     mkdir /ppml/tritonserver && \
+    mkdir /ppml/tf-serving && \
     mkdir -p /usr/local/cuda/lib64/stubs && \
     mkdir -p /usr/local/cuda/targets/x86_64-linux/lib && \
     mkdir /opt/tritonserver && \
@@ -102,11 +111,12 @@ ADD ./filelock.patch /filelock.patch
 
 # COPY frontend.jar
 COPY --from=temp /ppml/torchserve/frontend.jar /ppml/torchserve/frontend.jar
-# Start Script for Torchserve
+# Start Script for Torchserve, Tritonserver and TF-Serving
 ADD ./start-backend-sgx.sh      /ppml/torchserve/start-backend-sgx.sh
 ADD ./start-frontend-sgx.sh     /ppml/torchserve/start-frontend-sgx.sh
 ADD ./start-torchserve-sgx.sh   /ppml/torchserve/start-torchserve-sgx.sh
 ADD ./start-tritonserver-sgx.sh /ppml/tritonserver/start-tritonserver-sgx.sh
+ADD ./start-tf-serving-sgx.sh   /ppml/tf-serving/start-tf-serving-sgx.sh
 
 
 #For Tritonserver python backend
@@ -130,6 +140,9 @@ COPY --from=tritonserver /server/docker/entrypoint.d/ /opt/nvidia/entrypoint.d/
 COPY --from=tritonserver /server/docker/cpu_only/ /opt/nvidia/
 COPY --from=min_container /opt/tritonserver/backends/pytorch /opt/tritonserver/backends
 COPY --from=min_container /opt/tritonserver/backends/tensorflow2 /opt/tritonserver/backends
+
+#TF-Serving
+COPY --from=tf-serving /tensorflow-serving/bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server /usr/bin/tensorflow_model_server
 
 # PyTorch Dependencies
 RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \

--- a/ppml/trusted-dl-serving/base/Dockerfile
+++ b/ppml/trusted-dl-serving/base/Dockerfile
@@ -4,61 +4,12 @@ ARG BASE_IMAGE_NAME
 ARG BASE_IMAGE_TAG
 ARG JDK_VERSION=11
 
-# Stage.1 Torchserve Frontend
-FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG as temp
-ARG http_proxy
-ARG https_proxy
-ARG JDK_VERSION
-ENV JDK_HOME                /opt/jdk${JDK_VERSION}
-ENV JAVA_HOME                           /opt/jdk${JDK_VERSION}
-
-RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y openjdk-${JDK_VERSION}-jdk && \
-    mkdir -p ${JAVA_HOME} && \
-    cp -r /usr/lib/jvm/java-${JDK_VERSION}-openjdk-amd64/* ${JAVA_HOME} && \
-    git clone https://github.com/analytics-zoo/pytorch-serve.git && \
-    cd pytorch-serve/frontend && \
-    ./gradlew clean assemble && \
-    mkdir -p /ppml/torchserve && \
-    mv server/build/libs/server-1.0.jar /ppml/torchserve/frontend.jar
-
-# Stage.2 Tritonserver
-From ubuntu:20.04 as tritonserver
-ARG http_proxy
-ARG https_proxy
-ARG TRITON_VERSION=2.31.0dev
-ARG TRITON_CONTAINER_VERSION=23.02dev
-ENV DEBIAN_FRONTEND=noninteractive
-ENV TRITON_SERVER_VERSION ${TRITON_VERSION}
-ENV NVIDIA_TRITON_SERVER_VERSION ${TRITON_CONTAINER_VERSION}
-
-RUN cd / &&\
-    apt-get update &&\
-    apt-get install -y --no-install-recommends ca-certificates autoconf automake build-essential docker.io git gperf libre2-dev libssl-dev libtool libboost-dev libcurl4-openssl-dev libb64-dev libgoogle-perftools-dev patchelf python3-dev python3-pip python3-setuptools rapidjson-dev scons software-properties-common unzip wget zlib1g-dev libarchive-dev pkg-config uuid-dev libnuma-dev &&\
-    rm -rf /var/lib/apt/lists/* &&\
-    pip3 install --upgrade pip &&\
-    pip3 install --upgrade wheel setuptools docker &&\
-    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null &&\
-    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' &&\
-    apt-get update &&\
-    apt-get install -y --no-install-recommends cmake-data=3.21.1-0kitware1ubuntu20.04.1 cmake=3.21.1-0kitware1ubuntu20.04.1 &&\
-    wget https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz &&\
-    tar -zxvf boost_1_78_0.tar.gz &&\
-    rm -rf /usr/include/boost &&\
-    cp -r boost_1_78_0/boost /usr/include &&\
-
-    git clone --branch v2.31.0 https://github.com/triton-inference-server/server.git &&\
-    cd server &&\
-    ./build.py -v --no-container-build --build-dir=`pwd`/build --backend=python --repoagent=checksum --filesystem=gcs --filesystem=s3 --filesystem=azure_storage --endpoint=http --endpoint=grpc --endpoint=sagemaker --endpoint=vertex-ai --enable-logging --enable-stats --enable-tracing
-
-FROM nvcr.io/nvidia/tritonserver:23.01-py3-min AS min_container
-
 # Stage.3 TF-Serving
 FROM tensorflow/serving:latest-devel as tf-serving
 ARG http_proxy
 ARG https_proxy
 ARG no_proxy
-RUN bazel build -c opt tensorflow_serving/...
+RUN bazel build -c opt tensorflow_serving/... || true
 
 # DL-Serving
 FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG
@@ -118,35 +69,12 @@ ADD ./start-torchserve-sgx.sh   /ppml/torchserve/start-torchserve-sgx.sh
 ADD ./start-tritonserver-sgx.sh /ppml/tritonserver/start-tritonserver-sgx.sh
 ADD ./start-tf-serving-sgx.sh   /ppml/tf-serving/start-tf-serving-sgx.sh
 
-
-#For Tritonserver python backend
-COPY --from=min_container /usr/local/cuda/lib64/stubs/libcusparse.so /usr/local/cuda/lib64/stubs/libcusparse.so.12
-COPY --from=min_container /usr/local/cuda/lib64/stubs/libcusolver.so /usr/local/cuda/lib64/stubs/libcusolver.so.11
-COPY --from=min_container /usr/local/cuda/lib64/stubs/libcurand.so /usr/local/cuda/lib64/stubs/libcurand.so.10
-COPY --from=min_container /usr/local/cuda/lib64/stubs/libcufft.so /usr/local/cuda/lib64/stubs/libcufft.so.11
-COPY --from=min_container /usr/local/cuda/lib64/stubs/libcublas.so /usr/local/cuda/lib64/stubs/libcublas.so.12
-COPY --from=min_container /usr/local/cuda/lib64/stubs/libcublasLt.so /usr/local/cuda/lib64/stubs/libcublasLt.so.12
-COPY --from=min_container /usr/local/cuda/lib64/stubs/libcublasLt.so /usr/local/cuda/lib64/stubs/libcublasLt.so.11
-COPY --from=min_container /usr/local/cuda-12.0/targets/x86_64-linux/lib/libcudart.so.12 /usr/local/cuda/targets/x86_64-linux/lib/.
-COPY --from=min_container /usr/local/cuda-12.0/targets/x86_64-linux/lib/libcupti.so.12 /usr/local/cuda/targets/x86_64-linux/lib/.
-COPY --from=min_container /usr/local/cuda-12.0/targets/x86_64-linux/lib/libnvToolsExt.so.1 /usr/local/cuda/targets/x86_64-linux/lib/.
-COPY --from=min_container /usr/local/cuda-12.0/targets/x86_64-linux/lib/libnvJitLink.so.12 /usr/local/cuda/targets/x86_64-linux/lib/.
-COPY --from=min_container /usr/lib/x86_64-linux-gnu/libcudnn.so.8 /usr/lib/x86_64-linux-gnu/libcudnn.so.8
-COPY --from=min_container /usr/lib/x86_64-linux-gnu/libnccl.so.2 /usr/lib/x86_64-linux-gnu/libnccl.so.2
-
-#Tritonserver
-COPY --from=tritonserver /server/build/opt/tritonserver /opt/tritonserver
-COPY --from=tritonserver /server/docker/entrypoint.d/ /opt/nvidia/entrypoint.d/
-COPY --from=tritonserver /server/docker/cpu_only/ /opt/nvidia/
-COPY --from=min_container /opt/tritonserver/backends/pytorch /opt/tritonserver/backends
-COPY --from=min_container /opt/tritonserver/backends/tensorflow2 /opt/tritonserver/backends
-
 #TF-Serving
 COPY --from=tf-serving /tensorflow-serving/bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server /usr/bin/tensorflow_model_server
 
 # PyTorch Dependencies
 RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y --no-install-recommends software-properties-common libb64-0d             libcurl4-openssl-dev libre2-5 git gperf dirmngr libgoogle-perftools-dev libnuma-dev curl libgomp1 openmpi-bin patchelf python3 libarchive-dev python3-pip libpython3-dev && \
+    apt-get install -y --no-install-recommends software-properties-common libb64-0d libcurl4-openssl-dev libre2-5 git gperf dirmngr libgoogle-perftools-dev libnuma-dev curl libgomp1 openmpi-bin patchelf python3 libarchive-dev python3-pip libpython3-dev && \
     rm -rf /var/lib/apt/lists/* &&\
     apt-get install -y libssl-dev && \
     pip install --no-cache-dir astunparse numpy ninja pyyaml setuptools cmake cffi typing_extensions future six requests dataclasses mkl mkl-include intel-openmp && \

--- a/ppml/trusted-dl-serving/base/Dockerfile
+++ b/ppml/trusted-dl-serving/base/Dockerfile
@@ -51,7 +51,7 @@ RUN cd / &&\
     cd server &&\
     ./build.py -v --no-container-build --build-dir=`pwd`/build --backend=python --repoagent=checksum --filesystem=gcs --filesystem=s3 --filesystem=azure_storage --endpoint=http --endpoint=grpc --endpoint=sagemaker --endpoint=vertex-ai --enable-logging --enable-stats --enable-tracing
 
-FROM nvcr.io/nvidia/tritonserver:23.01-py3-min AS min_container
+FROM nvcr.io/nvidia/tritonserver:23.01-py3 AS min_container
 
 # Stage.3 TF-Serving
 FROM tensorflow/serving:latest-devel as tf-serving
@@ -97,22 +97,15 @@ RUN mkdir /ppml/examples && \
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
 ADD ./entrypoint.sh /opt/entrypoint.sh
 
-# Small examples for PyTorch
-ADD ./mnist.py                   /ppml/examples/mnist.py
-ADD ./pert.py                    /ppml/examples/pert.py
-ADD ./pert_ipex.py               /ppml/examples/pert_ipex.py
-ADD ./load_save_encryption_ex.py /ppml/examples/load_save_encryption_ex.py
-# Patch for datasets
-ADD ./filelock.patch /filelock.patch
-
 # COPY frontend.jar
 COPY --from=temp /ppml/torchserve/frontend.jar /ppml/torchserve/frontend.jar
 # Start Script for Torchserve, Tritonserver and TF-Serving
-ADD ./start-backend-sgx.sh      /ppml/torchserve/start-backend-sgx.sh
-ADD ./start-frontend-sgx.sh     /ppml/torchserve/start-frontend-sgx.sh
-ADD ./start-torchserve-sgx.sh   /ppml/torchserve/start-torchserve-sgx.sh
-ADD ./start-tritonserver-sgx.sh /ppml/tritonserver/start-tritonserver-sgx.sh
-ADD ./start-tf-serving-sgx.sh   /ppml/tf-serving/start-tf-serving-sgx.sh
+# Start Script for Torchserve
+ADD ./start-torchserve-backend.sh       /ppml/torchserve/start-torchserve-backend.sh
+ADD ./start-torchserve-frontend.sh      /ppml/torchserve/start-torchserve-frontend.sh
+ADD ./start-torchserve.sh               /ppml/torchserve/start-torchserve.sh
+ADD ./start-tritonserver-sgx.sh         /ppml/tritonserver/start-tritonserver-sgx.sh
+ADD ./start-tf-serving-sgx.sh           /ppml/tf-serving/start-tf-serving-sgx.sh
 
 
 #For Tritonserver python backend
@@ -134,31 +127,22 @@ COPY --from=min_container /usr/lib/x86_64-linux-gnu/libnccl.so.2 /usr/lib/x86_64
 COPY --from=tritonserver /server/build/opt/tritonserver /opt/tritonserver
 COPY --from=tritonserver /server/docker/entrypoint.d/ /opt/nvidia/entrypoint.d/
 COPY --from=tritonserver /server/docker/cpu_only/ /opt/nvidia/
-COPY --from=min_container /opt/tritonserver/backends/pytorch /opt/tritonserver/backends
-COPY --from=min_container /opt/tritonserver/backends/tensorflow2 /opt/tritonserver/backends
+COPY --from=min_container /opt/tritonserver/backends/pytorch /opt/tritonserver/backends/pytorch
+COPY --from=min_container /opt/tritonserver/backends/tensorflow2 /opt/tritonserver/backends/tensorflow
 
 #TF-Serving
-COPY --from=tf-serving /tensorflow-serving/bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server /usr/bin/tensorflow_model_server
+COPY --from=tf-serving /usr/local/bin/tensorflow_model_server /usr/bin/tensorflow_model_server
 
-# PyTorch Dependencies
+# Dependencies
 RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt-get install -y --no-install-recommends software-properties-common libb64-0d             libcurl4-openssl-dev libre2-5 git gperf dirmngr libgoogle-perftools-dev libnuma-dev curl libgomp1 openmpi-bin patchelf python3 libarchive-dev python3-pip libpython3-dev && \
-    rm -rf /var/lib/apt/lists/* &&\
     apt-get install -y libssl-dev && \
-    pip install --no-cache-dir astunparse numpy ninja pyyaml setuptools cmake cffi typing_extensions future six requests dataclasses mkl mkl-include intel-openmp && \
-    pip install --no-cache-dir torchvision==0.13.1 && \
-    cd /usr/local/lib && \
-    ln -s libmkl_gnu_thread.so.2 libmkl_gnu_thread.so && \
-    ln -s libmkl_intel_lp64.so.2 libmkl_intel_lp64.so && \
-    ln -s libmkl_core.so.2 libmkl_core.so && \
-# huggingface related
-    pip3 install --no-cache datasets==2.6.1 transformers intel_extension_for_pytorch && \
 # Optimization related
-    pip3 install --pre --no-cache --upgrade bigdl-nano[pytorch] && \
+    pip3 install --pre --no-cache --upgrade bigdl-nano[pytorch,inference]==2.2.0b20221226 vit_pytorch && \
 # Torchserve
-    pip install --no-cache-dir torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu && \
-    pip install --no-cache-dir cython pillow==9.0.1 captum packaging nvgpu && \
-    pip install --no-cache-dir torchserve==0.6.1 torch-model-archiver==0.6.1 torch-workflow-archiver==0.2.5 && \
+    pip3 install --no-cache-dir torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu && \
+    pip3 install --no-cache-dir cython pillow==9.0.1 captum packaging nvgpu && \
+    pip3 install --no-cache-dir torchserve==0.6.1 torch-model-archiver==0.6.1 torch-workflow-archiver==0.2.5 && \
     apt-get install -y openjdk-${JDK_VERSION}-jdk && \
     mkdir -p ${JAVA_HOME} && \
     cp -r /usr/lib/jvm/java-${JDK_VERSION}-openjdk-amd64/* ${JAVA_HOME} && \
@@ -169,21 +153,9 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     sed -i '/os.path.join/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.8/dist-packages/ts/model_loader.py && \
     sed -i '/import json/iimport sys' /usr/local/lib/python3.8/dist-packages/ts/model_loader.py && \
     cp /usr/local/lib/python3.8/dist-packages/ts/configs/metrics.yaml /ppml && \
-    chmod +x /ppml/torchserve/start-backend-sgx.sh && \
-    chmod +x /ppml/torchserve/start-frontend-sgx.sh && \
-    chmod +x /ppml/torchserve/start-torchserve-sgx.sh && \
-# PyTorch
-    rm -rf /usr/local/lib/python3.8/dist-packages/torch && \
-    git clone https://github.com/analytics-zoo/pytorch /pytorch && \
-    cd /pytorch && git checkout devel-v1.13.0-2022-11-16 && \
-    git submodule sync && git submodule update --init --recursive --jobs 0 && \
-    rm -rf ./third_party/gloo && \
-    cd third_party && git clone https://github.com/analytics-zoo/gloo.git && \
-    cd gloo && git checkout  devel-pt-v1.13.0-2022-11-16 && \
-    cd /pytorch && \
-    python3 setup.py install && \
-    cd /ppml/ && \
-    rm -rf /pytorch && \
+    chmod +x /ppml/torchserve/start-torchserve-backend.sh && \
+    chmod +x /ppml/torchserve/start-torchserve-frontend.sh && \
+    chmod +x /ppml/torchserve/start-torchserve.sh && \
 # generate secured_argvs
     gramine-argv-serializer bash -c 'export TF_MKL_ALLOC_MAX_BYTES=10737418240 && $sgx_command' > /ppml/secured_argvs && \
     chmod +x /sbin/tini && \
@@ -191,8 +163,8 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     cp /sbin/tini /usr/bin/tini && \
 # We need to downgrade markupsafe, the markupsafe required by bigdl-nano removed `soft_unicode`
 # which is then required by our third-layer gramine make command
-    patch /usr/local/lib/python3.8/dist-packages/datasets/utils/filelock.py /filelock.patch && \
     pip3 install --no-cache markupsafe==2.0.1 pyarrow==6.0.1 && \
-    patchelf --add-needed /usr/local/cuda/lib64/stubs/libcublasLt.so.12 backends/pytorch/libtorch_cuda.so
+    ls /opt/tritonserver/backends/pytorch && \
+    patchelf --add-needed /usr/local/cuda/lib64/stubs/libcublasLt.so.12 /opt/tritonserver/backends/pytorch/libtorch_cuda.so
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/ppml/trusted-dl-serving/base/Dockerfile
+++ b/ppml/trusted-dl-serving/base/Dockerfile
@@ -55,10 +55,6 @@ FROM nvcr.io/nvidia/tritonserver:23.01-py3-min AS min_container
 
 # Stage.3 TF-Serving
 FROM tensorflow/serving:latest-devel as tf-serving
-ARG http_proxy
-ARG https_proxy
-ARG no_proxy
-RUN bazel build -c opt tensorflow_serving/... || true
 
 # DL-Serving
 FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG

--- a/ppml/trusted-dl-serving/base/Dockerfile
+++ b/ppml/trusted-dl-serving/base/Dockerfile
@@ -10,10 +10,9 @@ ARG http_proxy
 ARG https_proxy
 ARG JDK_VERSION
 ENV JDK_HOME                /opt/jdk${JDK_VERSION}
-ENV JAVA_HOME               /opt/jdk${JDK_VERSION}
+ENV JAVA_HOME                           /opt/jdk${JDK_VERSION}
 
-RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y openjdk-${JDK_VERSION}-jdk && \
+RUN apt-get install -y openjdk-${JDK_VERSION}-jdk && \
     mkdir -p ${JAVA_HOME} && \
     cp -r /usr/lib/jvm/java-${JDK_VERSION}-openjdk-amd64/* ${JAVA_HOME} && \
     git clone https://github.com/analytics-zoo/pytorch-serve.git && \
@@ -22,6 +21,38 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     mkdir -p /ppml/torchserve && \
     mv server/build/libs/server-1.0.jar /ppml/torchserve/frontend.jar
 
+#Stage.2 Tritonserver
+From ubuntu:20.04 as tritonserver
+ARG http_proxy
+ARG https_proxy
+ARG TRITON_VERSION=2.31.0dev
+ARG TRITON_CONTAINER_VERSION=23.02dev
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TRITON_SERVER_VERSION ${TRITON_VERSION}
+ENV NVIDIA_TRITON_SERVER_VERSION ${TRITON_CONTAINER_VERSION}
+
+RUN cd / &&\
+    apt-get update &&\
+    apt-get install -y --no-install-recommends ca-certificates autoconf automake build-essential docker.io git gperf libre2-dev libssl-dev libtool libboost-dev libcurl4-openssl-dev libb64-dev libgoogle-perftools-dev patchelf python3-dev python3-pip python3-setuptools rapidjson-dev scons software-properties-common unzip wget zlib1g-dev libarchive-dev pkg-config uuid-dev libnuma-dev &&\
+    rm -rf /var/lib/apt/lists/* &&\
+    pip3 install --upgrade pip &&\
+    pip3 install --upgrade wheel setuptools docker &&\
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null &&\
+    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' &&\
+    apt-get update &&\
+    apt-get install -y --no-install-recommends cmake-data=3.21.1-0kitware1ubuntu20.04.1 cmake=3.21.1-0kitware1ubuntu20.04.1 &&\
+    wget https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz &&\
+    tar -zxvf boost_1_78_0.tar.gz &&\
+    rm -rf /usr/include/boost &&\
+    cp -r boost_1_78_0/boost /usr/include &&\
+
+    git clone --branch v2.31.0 https://github.com/triton-inference-server/server.git &&\
+    cd server &&\
+    ./build.py -v --no-container-build --build-dir=`pwd`/build --backend=python --repoagent=checksum --filesystem=gcs --filesystem=s3 --filesystem=azure_storage --endpoint=http --endpoint=grpc --endpoint=sagemaker --endpoint=vertex-ai --enable-logging --enable-stats --enable-tracing
+
+FROM nvcr.io/nvidia/tritonserver:23.01-py3-min AS min_container
+
+# DL-Serving
 FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG
 ARG http_proxy
 ARG https_proxy
@@ -32,29 +63,93 @@ ARG JDK_VERSION
 ENV JDK_HOME                            /opt/jdk${JDK_VERSION}
 ENV JAVA_HOME                           /opt/jdk${JDK_VERSION}
 # Environment used for build pytorch
+ARG USE_CUDA=0 USE_CUDNN=0 USE_MKLDNN=1 USE_DISTRIBUTED=1 USE_GLOO=1 USE_GLOO_WITH_OPENSSL=1 USE_MKL=1 BUILD_TEST=0 BLAS=MKL
+ARG CMAKE_PREFIX_PATH="/usr/local/lib/python3.8/dist-packages/:/usr/local/lib/"
+ARG TRITON_VERSION=2.31.0dev
+ARG TRITON_CONTAINER_VERSION=23.02dev
+ENV TRITON_SERVER_VERSION ${TRITON_VERSION}
+ENV NVIDIA_TRITON_SERVER_VERSION ${TRITON_CONTAINER_VERSION}
+
+ENV PATH /opt/tritonserver/bin:${PATH}
+ENV LD_LIBRARY_PATH /usr/local/cuda/targets/x86_64-linux/lib:/usr/local/cuda/lib64/stubs:${LD_LIBRARY_PATH}
+
+ENV TF_ADJUST_HUE_FUSED         1
+ENV TF_ADJUST_SATURATION_FUSED  1
+ENV TF_ENABLE_WINOGRAD_NONFUSED 1
+ENV TF_AUTOTUNE_THRESHOLD       2
+ENV TRITON_SERVER_GPU_ENABLED    0
+
+ENV TCMALLOC_RELEASE_RATE 200
+
 RUN mkdir /ppml/examples && \
-    mkdir /ppml/torchserve
+    mkdir /ppml/torchserve && \
+    mkdir /ppml/tritonserver && \
+    mkdir -p /usr/local/cuda/lib64/stubs && \
+    mkdir -p /usr/local/cuda/targets/x86_64-linux/lib && \
+    mkdir /opt/tritonserver && \
+    mkdir /opt/nvidia
 
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
 ADD ./entrypoint.sh /opt/entrypoint.sh
 
+# Small examples for PyTorch
+ADD ./mnist.py                   /ppml/examples/mnist.py
+ADD ./pert.py                    /ppml/examples/pert.py
+ADD ./pert_ipex.py               /ppml/examples/pert_ipex.py
+ADD ./load_save_encryption_ex.py /ppml/examples/load_save_encryption_ex.py
+# Patch for datasets
+ADD ./filelock.patch /filelock.patch
+
 # COPY frontend.jar
 COPY --from=temp /ppml/torchserve/frontend.jar /ppml/torchserve/frontend.jar
 # Start Script for Torchserve
-ADD ./start-torchserve-backend.sh      /ppml/torchserve/start-torchserve-backend.sh
-ADD ./start-torchserve-frontend.sh     /ppml/torchserve/start-torchserve-frontend.sh
-ADD ./start-torchserve.sh              /ppml/torchserve/start-torchserve.sh
+ADD ./start-backend-sgx.sh      /ppml/torchserve/start-backend-sgx.sh
+ADD ./start-frontend-sgx.sh     /ppml/torchserve/start-frontend-sgx.sh
+ADD ./start-torchserve-sgx.sh   /ppml/torchserve/start-torchserve-sgx.sh
+ADD ./start-tritonserver-sgx.sh /ppml/tritonserver/start-tritonserver-sgx.sh
 
 
-# Dependencies
+#For Tritonserver python backend
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcusparse.so /usr/local/cuda/lib64/stubs/libcusparse.so.12
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcusolver.so /usr/local/cuda/lib64/stubs/libcusolver.so.11
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcurand.so /usr/local/cuda/lib64/stubs/libcurand.so.10
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcufft.so /usr/local/cuda/lib64/stubs/libcufft.so.11
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcublas.so /usr/local/cuda/lib64/stubs/libcublas.so.12
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcublasLt.so /usr/local/cuda/lib64/stubs/libcublasLt.so.12
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcublasLt.so /usr/local/cuda/lib64/stubs/libcublasLt.so.11
+COPY --from=min_container /usr/local/cuda-12.0/targets/x86_64-linux/lib/libcudart.so.12 /usr/local/cuda/targets/x86_64-linux/lib/.
+COPY --from=min_container /usr/local/cuda-12.0/targets/x86_64-linux/lib/libcupti.so.12 /usr/local/cuda/targets/x86_64-linux/lib/.
+COPY --from=min_container /usr/local/cuda-12.0/targets/x86_64-linux/lib/libnvToolsExt.so.1 /usr/local/cuda/targets/x86_64-linux/lib/.
+COPY --from=min_container /usr/local/cuda-12.0/targets/x86_64-linux/lib/libnvJitLink.so.12 /usr/local/cuda/targets/x86_64-linux/lib/.
+COPY --from=min_container /usr/lib/x86_64-linux-gnu/libcudnn.so.8 /usr/lib/x86_64-linux-gnu/libcudnn.so.8
+COPY --from=min_container /usr/lib/x86_64-linux-gnu/libnccl.so.2 /usr/lib/x86_64-linux-gnu/libnccl.so.2
+
+#Tritonserver
+COPY --from=tritonserver /server/build/opt/tritonserver /opt/tritonserver
+COPY --from=tritonserver /server/docker/entrypoint.d/ /opt/nvidia/entrypoint.d/
+COPY --from=tritonserver /server/docker/cpu_only/ /opt/nvidia/
+COPY --from=min_container /opt/tritonserver/backends/pytorch /opt/tritonserver/backends
+COPY --from=min_container /opt/tritonserver/backends/tensorflow2 /opt/tritonserver/backends
+
+# PyTorch Dependencies
 RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -y --no-install-recommends software-properties-common libb64-0d             libcurl4-openssl-dev libre2-5 git gperf dirmngr libgoogle-perftools-dev libnuma-dev curl libgomp1 openmpi-bin patchelf python3 libarchive-dev python3-pip libpython3-dev && \
+    rm -rf /var/lib/apt/lists/* &&\
     apt-get install -y libssl-dev && \
+    pip install --no-cache-dir astunparse numpy ninja pyyaml setuptools cmake cffi typing_extensions future six requests dataclasses mkl mkl-include intel-openmp && \
+    pip install --no-cache-dir torchvision==0.13.1 && \
+    cd /usr/local/lib && \
+    ln -s libmkl_gnu_thread.so.2 libmkl_gnu_thread.so && \
+    ln -s libmkl_intel_lp64.so.2 libmkl_intel_lp64.so && \
+    ln -s libmkl_core.so.2 libmkl_core.so && \
+# huggingface related
+    pip3 install --no-cache datasets==2.6.1 transformers intel_extension_for_pytorch && \
 # Optimization related
-    pip3 install --pre --no-cache --upgrade bigdl-nano[pytorch,inference]==2.2.0b20221226 && \
+    pip3 install --pre --no-cache --upgrade bigdl-nano[pytorch] && \
 # Torchserve
-    pip3 install --no-cache-dir torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu && \
-    pip3 install --no-cache-dir cython pillow==9.0.1 captum packaging nvgpu && \
-    pip3 install --no-cache-dir torchserve==0.6.1 torch-model-archiver==0.6.1 torch-workflow-archiver==0.2.5 && \
+    pip install --no-cache-dir torch torchvision torchaudio --extra-index-url https://download.pytorch.org/whl/cpu && \
+    pip install --no-cache-dir cython pillow==9.0.1 captum packaging nvgpu && \
+    pip install --no-cache-dir torchserve==0.6.1 torch-model-archiver==0.6.1 torch-workflow-archiver==0.2.5 && \
     apt-get install -y openjdk-${JDK_VERSION}-jdk && \
     mkdir -p ${JAVA_HOME} && \
     cp -r /usr/lib/jvm/java-${JDK_VERSION}-openjdk-amd64/* ${JAVA_HOME} && \
@@ -65,16 +160,30 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     sed -i '/os.path.join/i\ \ \ \ \ \ \ \ sys.path.append(model_dir)' /usr/local/lib/python3.8/dist-packages/ts/model_loader.py && \
     sed -i '/import json/iimport sys' /usr/local/lib/python3.8/dist-packages/ts/model_loader.py && \
     cp /usr/local/lib/python3.8/dist-packages/ts/configs/metrics.yaml /ppml && \
-    chmod +x /ppml/torchserve/start-torchserve-backend.sh && \
-    chmod +x /ppml/torchserve/start-torchserve-frontend.sh && \
-    chmod +x /ppml/torchserve/start-torchserve.sh && \
-#generate secured_argvs
+    chmod +x /ppml/torchserve/start-backend-sgx.sh && \
+    chmod +x /ppml/torchserve/start-frontend-sgx.sh && \
+    chmod +x /ppml/torchserve/start-torchserve-sgx.sh && \
+# PyTorch
+    rm -rf /usr/local/lib/python3.8/dist-packages/torch && \
+    git clone https://github.com/analytics-zoo/pytorch /pytorch && \
+    cd /pytorch && git checkout devel-v1.13.0-2022-11-16 && \
+    git submodule sync && git submodule update --init --recursive --jobs 0 && \
+    rm -rf ./third_party/gloo && \
+    cd third_party && git clone https://github.com/analytics-zoo/gloo.git && \
+    cd gloo && git checkout  devel-pt-v1.13.0-2022-11-16 && \
+    cd /pytorch && \
+    python3 setup.py install && \
+    cd /ppml/ && \
+    rm -rf /pytorch && \
+# generate secured_argvs
     gramine-argv-serializer bash -c 'export TF_MKL_ALLOC_MAX_BYTES=10737418240 && $sgx_command' > /ppml/secured_argvs && \
     chmod +x /sbin/tini && \
     chmod +x /opt/entrypoint.sh && \
     cp /sbin/tini /usr/bin/tini && \
 # We need to downgrade markupsafe, the markupsafe required by bigdl-nano removed `soft_unicode`
 # which is then required by our third-layer gramine make command
-    pip3 install --no-cache markupsafe==2.0.1 pyarrow==6.0.1
+    patch /usr/local/lib/python3.8/dist-packages/datasets/utils/filelock.py /filelock.patch && \
+    pip3 install --no-cache markupsafe==2.0.1 pyarrow==6.0.1 && \
+    patchelf --add-needed /usr/local/cuda/lib64/stubs/libcublasLt.so.12 backends/pytorch/libtorch_cuda.so
 
 ENTRYPOINT [ "/opt/entrypoint.sh" ]

--- a/ppml/trusted-dl-serving/base/Dockerfile
+++ b/ppml/trusted-dl-serving/base/Dockerfile
@@ -4,6 +4,55 @@ ARG BASE_IMAGE_NAME
 ARG BASE_IMAGE_TAG
 ARG JDK_VERSION=11
 
+# Stage.1 Torchserve Frontend
+FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG as temp
+ARG http_proxy
+ARG https_proxy
+ARG JDK_VERSION
+ENV JDK_HOME                /opt/jdk${JDK_VERSION}
+ENV JAVA_HOME                           /opt/jdk${JDK_VERSION}
+
+RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt-get install -y openjdk-${JDK_VERSION}-jdk && \
+    mkdir -p ${JAVA_HOME} && \
+    cp -r /usr/lib/jvm/java-${JDK_VERSION}-openjdk-amd64/* ${JAVA_HOME} && \
+    git clone https://github.com/analytics-zoo/pytorch-serve.git && \
+    cd pytorch-serve/frontend && \
+    ./gradlew clean assemble && \
+    mkdir -p /ppml/torchserve && \
+    mv server/build/libs/server-1.0.jar /ppml/torchserve/frontend.jar
+
+# Stage.2 Tritonserver
+From ubuntu:20.04 as tritonserver
+ARG http_proxy
+ARG https_proxy
+ARG TRITON_VERSION=2.31.0dev
+ARG TRITON_CONTAINER_VERSION=23.02dev
+ENV DEBIAN_FRONTEND=noninteractive
+ENV TRITON_SERVER_VERSION ${TRITON_VERSION}
+ENV NVIDIA_TRITON_SERVER_VERSION ${TRITON_CONTAINER_VERSION}
+
+RUN cd / &&\
+    apt-get update &&\
+    apt-get install -y --no-install-recommends ca-certificates autoconf automake build-essential docker.io git gperf libre2-dev libssl-dev libtool libboost-dev libcurl4-openssl-dev libb64-dev libgoogle-perftools-dev patchelf python3-dev python3-pip python3-setuptools rapidjson-dev scons software-properties-common unzip wget zlib1g-dev libarchive-dev pkg-config uuid-dev libnuma-dev &&\
+    rm -rf /var/lib/apt/lists/* &&\
+    pip3 install --upgrade pip &&\
+    pip3 install --upgrade wheel setuptools docker &&\
+    wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | tee /etc/apt/trusted.gpg.d/kitware.gpg >/dev/null &&\
+    apt-add-repository 'deb https://apt.kitware.com/ubuntu/ focal main' &&\
+    apt-get update &&\
+    apt-get install -y --no-install-recommends cmake-data=3.21.1-0kitware1ubuntu20.04.1 cmake=3.21.1-0kitware1ubuntu20.04.1 &&\
+    wget https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.tar.gz &&\
+    tar -zxvf boost_1_78_0.tar.gz &&\
+    rm -rf /usr/include/boost &&\
+    cp -r boost_1_78_0/boost /usr/include &&\
+
+    git clone --branch v2.31.0 https://github.com/triton-inference-server/server.git &&\
+    cd server &&\
+    ./build.py -v --no-container-build --build-dir=`pwd`/build --backend=python --repoagent=checksum --filesystem=gcs --filesystem=s3 --filesystem=azure_storage --endpoint=http --endpoint=grpc --endpoint=sagemaker --endpoint=vertex-ai --enable-logging --enable-stats --enable-tracing
+
+FROM nvcr.io/nvidia/tritonserver:23.01-py3-min AS min_container
+
 # Stage.3 TF-Serving
 FROM tensorflow/serving:latest-devel as tf-serving
 ARG http_proxy
@@ -69,12 +118,35 @@ ADD ./start-torchserve-sgx.sh   /ppml/torchserve/start-torchserve-sgx.sh
 ADD ./start-tritonserver-sgx.sh /ppml/tritonserver/start-tritonserver-sgx.sh
 ADD ./start-tf-serving-sgx.sh   /ppml/tf-serving/start-tf-serving-sgx.sh
 
+
+#For Tritonserver python backend
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcusparse.so /usr/local/cuda/lib64/stubs/libcusparse.so.12
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcusolver.so /usr/local/cuda/lib64/stubs/libcusolver.so.11
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcurand.so /usr/local/cuda/lib64/stubs/libcurand.so.10
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcufft.so /usr/local/cuda/lib64/stubs/libcufft.so.11
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcublas.so /usr/local/cuda/lib64/stubs/libcublas.so.12
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcublasLt.so /usr/local/cuda/lib64/stubs/libcublasLt.so.12
+COPY --from=min_container /usr/local/cuda/lib64/stubs/libcublasLt.so /usr/local/cuda/lib64/stubs/libcublasLt.so.11
+COPY --from=min_container /usr/local/cuda-12.0/targets/x86_64-linux/lib/libcudart.so.12 /usr/local/cuda/targets/x86_64-linux/lib/.
+COPY --from=min_container /usr/local/cuda-12.0/targets/x86_64-linux/lib/libcupti.so.12 /usr/local/cuda/targets/x86_64-linux/lib/.
+COPY --from=min_container /usr/local/cuda-12.0/targets/x86_64-linux/lib/libnvToolsExt.so.1 /usr/local/cuda/targets/x86_64-linux/lib/.
+COPY --from=min_container /usr/local/cuda-12.0/targets/x86_64-linux/lib/libnvJitLink.so.12 /usr/local/cuda/targets/x86_64-linux/lib/.
+COPY --from=min_container /usr/lib/x86_64-linux-gnu/libcudnn.so.8 /usr/lib/x86_64-linux-gnu/libcudnn.so.8
+COPY --from=min_container /usr/lib/x86_64-linux-gnu/libnccl.so.2 /usr/lib/x86_64-linux-gnu/libnccl.so.2
+
+#Tritonserver
+COPY --from=tritonserver /server/build/opt/tritonserver /opt/tritonserver
+COPY --from=tritonserver /server/docker/entrypoint.d/ /opt/nvidia/entrypoint.d/
+COPY --from=tritonserver /server/docker/cpu_only/ /opt/nvidia/
+COPY --from=min_container /opt/tritonserver/backends/pytorch /opt/tritonserver/backends
+COPY --from=min_container /opt/tritonserver/backends/tensorflow2 /opt/tritonserver/backends
+
 #TF-Serving
 COPY --from=tf-serving /tensorflow-serving/bazel-bin/tensorflow_serving/model_servers/tensorflow_model_server /usr/bin/tensorflow_model_server
 
 # PyTorch Dependencies
 RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y --no-install-recommends software-properties-common libb64-0d libcurl4-openssl-dev libre2-5 git gperf dirmngr libgoogle-perftools-dev libnuma-dev curl libgomp1 openmpi-bin patchelf python3 libarchive-dev python3-pip libpython3-dev && \
+    apt-get install -y --no-install-recommends software-properties-common libb64-0d             libcurl4-openssl-dev libre2-5 git gperf dirmngr libgoogle-perftools-dev libnuma-dev curl libgomp1 openmpi-bin patchelf python3 libarchive-dev python3-pip libpython3-dev && \
     rm -rf /var/lib/apt/lists/* &&\
     apt-get install -y libssl-dev && \
     pip install --no-cache-dir astunparse numpy ninja pyyaml setuptools cmake cffi typing_extensions future six requests dataclasses mkl mkl-include intel-openmp && \

--- a/ppml/trusted-dl-serving/base/build-docker-image.sh
+++ b/ppml/trusted-dl-serving/base/build-docker-image.sh
@@ -8,6 +8,8 @@ export BASE_IMAGE_TAG=your_base_image_tag
 Proxy_Modified="sudo docker build \
     --build-arg http_proxy=http://${HTTP_PROXY_HOST}:${HTTP_PROXY_PORT} \
     --build-arg https_proxy=http://${HTTPS_PROXY_HOST}:${HTTPS_PROXY_PORT} \
+    --build-arg BASE_IMAGE_NAME=$BASE_IMAGE_NAME \
+    --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG \
     --build-arg no_proxy=x.x.x.x \
     -t intelanalytics/bigdl-ppml-trusted-dl-serving-gramine-base:2.3.0-SNAPSHOT -f ./Dockerfile ."
 

--- a/ppml/trusted-dl-serving/base/start-tf-serving-sgx.sh
+++ b/ppml/trusted-dl-serving/base/start-tf-serving-sgx.sh
@@ -1,0 +1,6 @@
+cd /ppml
+./init.sh
+export sgx_command="./tensorflow_model_server --model_base_path=path_to_model --model_name=name_of_model --rest_api_port=rest_port --tensorflow_inter_op_parallelism=2 --tensorflow_intra_op_parallelism=5"
+
+gramine-sgx bash 2>&1 | tee tfserving-sgx.log
+

--- a/ppml/trusted-dl-serving/base/start-tf-serving-sgx.sh
+++ b/ppml/trusted-dl-serving/base/start-tf-serving-sgx.sh
@@ -1,6 +1,6 @@
 cd /ppml
 ./init.sh
-export sgx_command="./tensorflow_model_server --model_base_path=path_to_model --model_name=name_of_model --rest_api_port=rest_port --tensorflow_inter_op_parallelism=2 --tensorflow_intra_op_parallelism=5"
+export sgx_command="/usr/bin/tensorflow_model_server --model_base_path=path_to_model --model_name=name_of_model --rest_api_port=rest_port --tensorflow_inter_op_parallelism=2 --tensorflow_intra_op_parallelism=5"
 
 gramine-sgx bash 2>&1 | tee tfserving-sgx.log
 

--- a/ppml/trusted-dl-serving/base/start-tritonserver-sgx.sh
+++ b/ppml/trusted-dl-serving/base/start-tritonserver-sgx.sh
@@ -1,0 +1,5 @@
+cd /ppml
+./init.sh
+export sgx_command="/opt/tritonserver/bin/tritonserver --model-repository=/ppml/work/data/model/tritonserver/ --model-load-thread-count 5"
+gramine-sgx bash 2>&1 | tee tritonserver-sgx.log
+

--- a/ppml/trusted-dl-serving/base/start-tritonserver-sgx.sh
+++ b/ppml/trusted-dl-serving/base/start-tritonserver-sgx.sh
@@ -1,5 +1,5 @@
 cd /ppml
 ./init.sh
-export sgx_command="/opt/tritonserver/bin/tritonserver --model-repository=/ppml/work/data/model/tritonserver/ --model-load-thread-count 5"
+export sgx_command="/opt/tritonserver/bin/tritonserver --model-repository=path_to_model --model-load-thread-count 5"
 gramine-sgx bash 2>&1 | tee tritonserver-sgx.log
 

--- a/ppml/trusted-dl-serving/ref/build-custom-image.sh
+++ b/ppml/trusted-dl-serving/ref/build-custom-image.sh
@@ -8,6 +8,10 @@ export BASE_IMAGE_TAG=your_base_image_tag
 Proxy_Modified="sudo docker build \
     --build-arg http_proxy=http://${HTTP_PROXY_HOST}:${HTTP_PROXY_PORT} \
     --build-arg https_proxy=http://${HTTPS_PROXY_HOST}:${HTTPS_PROXY_PORT} \
+    --build-arg BASE_IMAGE_NAME=$BASE_IMAGE_NAME \
+    --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG \
+    --build-arg SGX_MEM_SIZE=MEM_SIZE_OF_SGX \
+    --build-arg SGX_LOG_LEVEL=LOG_LEVEL_OF_SGX \
     --build-arg no_proxy=x.x.x.x \
     -t intelanalytics/bigdl-ppml-trusted-dl-serving-gramine-ref:2.3.0-SNAPSHOT -f ./Dockerfile ."
 


### PR DESCRIPTION
## Description

Add tritonserver to DL-Serving Image.

### 1. Why the change?

Run tritonserver natively and on SGX in DL-Serving Image.

### 2. User API changes

To run tritonserver natively:
tritonserver --model-store=path_of_tritonserver_model
To run tritonserver on SGX:
bash start-tritonserver-sgx.sh