### PR TITLE
Nano: TF customized training loop multi-process training

### DIFF
--- a/python/nano/src/bigdl/nano/tf/keras/__init__.py
+++ b/python/nano/src/bigdl/nano/tf/keras/__init__.py
@@ -19,4 +19,4 @@ import tensorflow as tf
 from .Sequential import Sequential
 from .Model import V2Model as Model
 from .inference.optimizer import InferenceOptimizer
-from .customized_training_utils import nano_bf16
+from .customized_training_utils import nano_bf16, nano_multiprocessing, nano

--- a/python/nano/src/bigdl/nano/tf/keras/customized_training_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/customized_training_utils.py
@@ -102,8 +102,6 @@ class _Nano_Customized_Training(object):
                 # serialize the dataset
                 if isinstance(arg, tf.data.Dataset):
                     from tensorflow.python.distribute.coordinator.values import serialize_dataset_to_graph
-                    from tensorflow.python.ops.numpy_ops import np_config
-                    np_config.enable_numpy_behavior()
 
                     train_ds_def = serialize_dataset_to_graph(arg).numpy()
                     train_elem_spec = arg.element_spec

--- a/python/nano/src/bigdl/nano/tf/keras/customized_training_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/customized_training_utils.py
@@ -102,6 +102,8 @@ class _Nano_Customized_Training(object):
                 # serialize the dataset
                 if isinstance(arg, tf.data.Dataset):
                     from tensorflow.python.distribute.coordinator.values import serialize_dataset_to_graph
+                    from tensorflow.python.ops.numpy_ops import np_config
+                    np_config.enable_numpy_behavior()
 
                     train_ds_def = serialize_dataset_to_graph(arg).numpy()
                     train_elem_spec = arg.element_spec

--- a/python/nano/src/bigdl/nano/tf/keras/customized_training_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/customized_training_utils.py
@@ -43,10 +43,13 @@ def nano_bf16(func):
 
 class nano_multiprocessing(object):
     """A decorator to realize nano_multiprocessing training on customized training step."""
+
     def __init__(self, func):
+        """Initialize the training step function."""
         self.func = func
 
     def __call__(self, *args, mirrored_strategy=None, **kwargs):
+        """Run distribution strategy for multi-process training."""
         # TODO: to validate if we really could support kwargs
         per_replica_losses = mirrored_strategy.run(self.func, args=args, kwargs=kwargs)
         return mirrored_strategy.reduce(tf.distribute.ReduceOp.SUM, per_replica_losses,
@@ -54,11 +57,11 @@ class nano_multiprocessing(object):
 
 
 def nano(num_processes):
-    '''
-    A decorator to run customized training loop on multiple processes
+    """
+    A decorator to run customized training loop on multiple processes.
 
     :param num_processes: int, number of processes.
-    '''
+    """
     def decorator(func):
         return _Nano_Customized_Training(func, num_processes)
     return decorator

--- a/python/nano/src/bigdl/nano/tf/keras/customized_training_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/customized_training_utils.py
@@ -15,9 +15,16 @@
 #
 
 
+import cloudpickle
 import tensorflow as tf
 import numpy as np
-from functools import wraps
+from functools import wraps, partial
+from tempfile import TemporaryDirectory
+import os
+import json
+
+from bigdl.nano.utils.common import schedule_processors
+from bigdl.nano.tf.keras.distributed_utils import _find_free_port
 
 
 def nano_bf16(func):
@@ -32,3 +39,169 @@ def nano_bf16(func):
             new_args.append(arg)
         return func(*new_args)
     return wrapper
+
+
+class nano_multiprocessing(object):
+    """A decorator to realize nano_multiprocessing training on customized training step."""
+    def __init__(self, func):
+        self.func = func
+
+    def __call__(self, *args, mirrored_strategy=None, **kwargs):
+        # TODO: to validate if we really could support kwargs
+        per_replica_losses = mirrored_strategy.run(self.func, args=args, kwargs=kwargs)
+        return mirrored_strategy.reduce(tf.distribute.ReduceOp.SUM, per_replica_losses,
+                                axis=None)
+
+
+def nano(num_processes):
+    '''
+    A decorator to run customized training loop on multiple processes
+
+    :param num_processes: int, number of processes.
+    '''
+    def decorator(func):
+        return _Nano_Customized_Training(func, num_processes)
+    return decorator
+
+
+class _Nano_Customized_Training(object):
+    def __init__(self, func, nproc):
+        self.func = func
+        self.nproc = nproc
+
+    def __call__(self, *args, **kwargs):
+        new_args = []
+        from bigdl.nano.utils.tf import MultiprocessingBackend
+        backend = MultiprocessingBackend()
+
+        main_model = None
+
+        with TemporaryDirectory() as temp_dir:
+            for i, arg in enumerate(args):
+                # save the model
+                if isinstance(arg, tf.Module):
+                    arg.save(os.path.join(temp_dir, f'args_{i}'))
+                    new_args.append(("model", os.path.join(temp_dir, f'args_{i}')))
+                    main_model = arg
+                    continue
+
+                # save the optimizer
+                if isinstance(arg, tf.keras.optimizers.Optimizer):
+                    with open(os.path.join(temp_dir, f"args_{i}.pkl"), 'wb') as f:
+                        cloudpickle.dump(arg, f)
+                    new_args.append(("optimizer", os.path.join(temp_dir, f'args_{i}.pkl')))
+                    continue
+
+                # save the loss
+                if isinstance(arg, tf.keras.losses.Loss):
+                    with open(os.path.join(temp_dir, f"args_{i}.pkl"), 'wb') as f:
+                        cloudpickle.dump(arg, f)
+                    new_args.append(("loss", os.path.join(temp_dir, f'args_{i}.pkl')))
+                    continue
+
+                # serialize the dataset
+                if isinstance(arg, tf.data.Dataset):
+                    from tensorflow.python.distribute.coordinator.values import serialize_dataset_to_graph
+
+                    train_ds_def = serialize_dataset_to_graph(arg).numpy()
+                    train_elem_spec = arg.element_spec
+                    new_args.append(("dataset", train_ds_def, train_elem_spec))
+                    continue
+
+                with open(os.path.join(temp_dir, f"args_{i}.pkl"), 'wb') as f:
+                    cloudpickle.dump(arg, f)
+                    new_args.append(("others", os.path.join(temp_dir, f"args_{i}.pkl")))
+
+            target_path = os.path.join(temp_dir, "target.pkl")
+            with open(target_path, 'wb') as f:
+                cloudpickle.dump(self.func, f)
+
+            ports = set()
+            while len(ports) < self.nproc:
+                ports.add(_find_free_port())
+            ports = list(ports)
+            worker_list = [f"localhost:{p}" for p in ports]
+
+            # TODO: this env mainly for core affinity and allocation limit
+            # while does not work for stock TF
+            envs = schedule_processors(self.nproc)
+
+            for i, env in enumerate(envs):
+                env.update({
+                    "TF_CONFIG": json.dumps(
+                        {
+                            'cluster': {
+                                'worker': worker_list
+                            },
+                            'task': {'type': 'worker', 'index': i}
+                        }),
+                    'no_proxy': "localhost"
+                })
+
+            # TODO: validation needs to be done on non-NoneType histories
+            histrories = backend.run(target=_train_func,
+                                     args=(target_path, *new_args),
+                                     nprocs=self.nproc,
+                                     envs=envs)
+
+            main_model.load_weights('trained_model_weights')
+
+
+def _train_func(target_path, *args):
+    mirrored_strategy = tf.distribute.MultiWorkerMirroredStrategy()
+
+    actrual_args = [None] * len(args)
+    new_model = None
+
+    for i, arg in enumerate(args):
+        with mirrored_strategy.scope():
+            # deserialize model
+            if arg[0] == "model":
+                actrual_args[i] = tf.keras.models.load_model(arg[1])
+                new_model = actrual_args[i]
+                continue
+            # deserialize optimizer
+            if arg[0] == "optimizer":
+                with open(arg[1], 'rb') as f:
+                    actrual_args[i] = cloudpickle.load(f)
+                continue
+        # deserialize dataset
+        if arg[0] == "dataset":
+            # TODO: only dataset is supported here
+            # data generator is needed to be supported
+            # Dataset.from_generator could not be used due to a known limitation
+            # https://www.tensorflow.org/api_docs/python/tf/data/Dataset#from_generator
+            from tensorflow.python.distribute.coordinator.values import deserialize_dataset_from_graph
+            original_dataset = deserialize_dataset_from_graph(arg[1], arg[2])
+            actrual_args[i] = mirrored_strategy.experimental_distribute_dataset(original_dataset)
+            continue
+        # deserialize loss
+        if arg[0] == "loss":
+            with open(arg[1], 'rb') as f:
+                original_loss_object = cloudpickle.load(f)
+                original_loss_object.reduction = tf.keras.losses.Reduction.NONE
+            def loss_object(*args, **kwargs):
+                per_example_loss = original_loss_object(*args, **kwargs)
+                return tf.nn.compute_average_loss(per_example_loss, global_batch_size=32)
+            actrual_args[i] = loss_object
+            continue
+        # deserialize others
+        if arg[0] == "others":
+            with open(arg[1], 'rb') as f:
+                actrual_args[i] = cloudpickle.load(f)
+                if callable(actrual_args[i]) and isinstance(actrual_args[i], nano_multiprocessing):
+                    actrual_args[i] = partial(actrual_args[i], mirrored_strategy=mirrored_strategy)
+
+    with open(target_path, 'rb') as f:
+        target_func = cloudpickle.load(f)
+
+    res = target_func(*actrual_args)
+
+    task_id = mirrored_strategy.cluster_resolver.task_id
+    # TODO: only task 0's model weight is stored
+    # could not understand why we need other task's weight
+    if task_id == 0:
+        path = os.path.join('trained_model_weights')
+        new_model.save_weights(path, overwrite=True)
+
+    return res

--- a/python/nano/test/run-nano-tf-train-tests.sh
+++ b/python/nano/test/run-nano-tf-train-tests.sh
@@ -9,7 +9,8 @@ unset MALLOC_CONF
 set -e
 echo "# Start testing"
 start=$(date "+%s")
-python -m pytest -s ${TF_NANO_TEST_DIR}
+python -m pytest -s ${TF_NANO_TEST_DIR} -k "not test_fit_graph"
+python -m pytest -s ${TF_NANO_TEST_DIR}/test_fit_graph.py
 
 now=$(date "+%s")
 time=$((now-start))

--- a/python/nano/test/tf/train/test_tf_nano_decorator.py
+++ b/python/nano/test/tf/train/test_tf_nano_decorator.py
@@ -47,3 +47,36 @@ def test_tf_nano_bf16_decorator():
     # y = np.random.random(1000)
     # model.train(x, y)
     unpatch_tensorflow()
+
+
+def test_tf_nano_multiprocessing_customized_loop():
+    from bigdl.nano.tf.keras import nano_multiprocessing, nano
+
+    global_batch_size = 32
+    model = tf.keras.Sequential([tf.keras.layers.Dense(1, input_shape=(1,))])
+    optimizer = tf.keras.optimizers.SGD()
+
+    dataset = tf.data.Dataset.from_tensors(([1.], [1.])).repeat(128).batch(
+        global_batch_size)
+
+    loss_object = tf.keras.losses.BinaryCrossentropy(from_logits=True)
+
+    @nano_multiprocessing
+    @tf.function
+    def train_step(inputs, model, loss_object, optimizer):
+        features, labels = inputs
+
+        with tf.GradientTape() as tape:
+            predictions = model(features, training=True)
+            loss = loss_object(labels, predictions)
+
+        gradients = tape.gradient(loss, model.trainable_variables)
+        optimizer.apply_gradients(zip(gradients, model.trainable_variables))
+        return loss
+
+    @nano(num_processes=4)
+    def train_whole_data(model, dataset, loss_object, optimizer, train_step):
+        for inputs in dataset:
+            print(train_step(inputs, model, loss_object, optimizer))
+
+    train_whole_data(model, dataset, loss_object, optimizer, train_step)

--- a/python/nano/test/tf/train/test_tf_nano_decorator.py
+++ b/python/nano/test/tf/train/test_tf_nano_decorator.py
@@ -50,6 +50,9 @@ def test_tf_nano_bf16_decorator():
 
 
 def test_tf_nano_multiprocessing_customized_loop():
+    from tensorflow.python.framework.ops import enable_eager_execution
+    enable_eager_execution()
+
     from bigdl.nano.tf.keras import nano_multiprocessing, nano
 
     global_batch_size = 32

--- a/python/nano/test/tf/train/test_tf_nano_decorator.py
+++ b/python/nano/test/tf/train/test_tf_nano_decorator.py
@@ -74,7 +74,7 @@ def test_tf_nano_multiprocessing_customized_loop():
         optimizer.apply_gradients(zip(gradients, model.trainable_variables))
         return loss
 
-    @nano(num_processes=4)
+    @nano(num_processes=2)
     def train_whole_data(model, dataset, loss_object, optimizer, train_step):
         for inputs in dataset:
             print(train_step(inputs, model, loss_object, optimizer))

--- a/python/nano/test/tf/train/test_tf_nano_decorator.py
+++ b/python/nano/test/tf/train/test_tf_nano_decorator.py
@@ -50,9 +50,6 @@ def test_tf_nano_bf16_decorator():
 
 
 def test_tf_nano_multiprocessing_customized_loop():
-    from tensorflow.python.framework.ops import enable_eager_execution
-    enable_eager_execution()
-
     from bigdl.nano.tf.keras import nano_multiprocessing, nano
 
     global_batch_size = 32


### PR DESCRIPTION
## Description

### 1. Why the change?

Currently we only support TF multiprocess training for keras model with default training loop (i.e., `model.fit`). While many of our users design their own training loop as shown in this [tensorflow document](https://www.tensorflow.org/guide/keras/writing_a_training_loop_from_scratch). 

This PR add the support for this kind of models with customized training loop with a **2-lines code change** for users.

Proof points has been carried out on 2 models, and it does speed-up the training process.

### 2. User API changes

Users will have 2 decorators.
```python
from bigdl.nano.tf.keras import nano_multiprocessing
from bigdl.nano.tf.keras import nano
```

- `nano_multiprocessing`: users need to add this decorator to their `train_step` (typically an tf function), should be OK to use together with `nano_bf16` (need validation)
- `nano(num_processes=...)`: users need to add this decorator to their customized training loop (typically a loop calling `train_step`)

Here is an easy example
```python
from bigdl.nano.tf.keras import nano_multiprocessing, nano
import tensorflow as tf

tf.random.set_seed(0)

global_batch_size = 32
model = tf.keras.Sequential([tf.keras.layers.Dense(1, input_shape=(1,))])
optimizer = tf.keras.optimizers.SGD()

dataset = tf.data.Dataset.from_tensors(([1.], [1.])).repeat(128).batch(
    global_batch_size)

loss_object = tf.keras.losses.BinaryCrossentropy(from_logits=True)

# @nano_bf16  <-- Users could use bf16 and multiple processing together
@nano_multiprocessing  # <-- Just remove this line to run on 1 process
@tf.function
def train_step(inputs, model, loss_object, optimizer):
    features, labels = inputs

    with tf.GradientTape() as tape:
        predictions = model(features, training=True)
        loss = loss_object(labels, predictions)

    gradients = tape.gradient(loss, model.trainable_variables)
    optimizer.apply_gradients(zip(gradients, model.trainable_variables))
    return loss

@nano(num_processes=4)  # <-- Just remove this line to run on 1 process
def train_whole_data(model, dataset, loss_object, optimizer, train_step):
    for inputs in dataset:
        print(train_step(inputs, model, loss_object, optimizer))

if __name__ == "__main__":
    train_whole_data(model, dataset, loss_object, optimizer, train_step)
    print(model.predict(next(dataset.as_numpy_iterator())[0])[0])  # <-- single process and multiple process will get same result
```

### 3. Summary of the change 
nothing special is implemented. `backend` and `subprocess_worker` is reused as in default training loop model.

Users' args put to the customized training loop is serialized and changed (different types, like model, dataset, loss, optimizer..., in different way)

### 4. How to test?
- [ ] Unit test

please @plusbang help me to complete some critical TODOs
