### PR TITLE
[PPML] Fix pert training script to add average statistics

### DIFF
--- a/ppml/trusted-deep-learning/base/pert.py
+++ b/ppml/trusted-deep-learning/base/pert.py
@@ -239,6 +239,8 @@ def main():
 
     total_loss = 0.
     best_acc = 0.
+    total_time = 0.
+    total_throughput = 0.
 
     for t in range(args.epochs):
         print(f"Epoch {t+1}/{args.epochs + 1}\n-------------------------------")
@@ -255,10 +257,17 @@ def main():
               total_dataset, flush=True)
         msg = "Epoch {}/{} Throughput: {: .4f}".format(
             t+1, args.epochs+1, 1.0 * total_dataset / (end-start))
+        total_time += (end - start)
+        total_throughput += total_dataset
         print(msg, flush=True)
         valid_acc = test_loop(valid_dataloader, model, mode='Valid')
 
     print("[INFO]Finish all test", flush=True)
+    msg = "[INFO]Average training time per epoch: {: .4f}".format(total_time / args.epochs)
+    print(msg, flush=True)
+
+    msg = "[INFO]Average throughput per epoch: {: .4f}".format(total_throughput / total_time)
+    print(msg, flush=True)
 
     if (args.save_model):
         torch.save(model.state_dict(), "pert.bin")


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

Add average statistics per epoch, so we do not need to calculate by hand.