### PR TITLE
Nano: remove the usage of `py_function` when using openvino

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -109,7 +109,7 @@ def KerasOpenVINOModel(model, input_spec=None, precision='fp32',
     :param **kwargs: will be passed to model optimizer function.
     :return: KerasOpenVINOModel model for OpenVINO inference.
     """
-    from .tf.model import KerasOpenVINOModel
+    from .tf.new_model import KerasOpenVINOModel
     return KerasOpenVINOModel(model=model,
                               input_spec=input_spec,
                               precision=precision,

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/new_model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/new_model.py
@@ -120,7 +120,10 @@ class KerasOpenVINOModel(KerasOptimizedModel):
             thread_num=None):
         if metric:
             metric = KerasOpenVINOMetric(metric=metric, higher_better=higher_better)
-        dataloader = KerasOpenVINODataLoader(x, y, collate_fn=self.tensors_to_numpy)
+        # todo: replace `KerasOpenVINODataLoader` and `tensors_to_numpy`
+        from bigdl.nano.tf.model import AcceleratedKerasModel
+        dataloader = KerasOpenVINODataLoader(x, y,
+                                             collate_fn=AcceleratedKerasModel.tensors_to_numpy)
         model = self.ov_model.pot(dataloader, metric=metric, drop_type=drop_type,
                                   maximal_drop=maximal_drop, max_iter_num=max_iter_num,
                                   n_requests=n_requests, sample_size=sample_size)

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/new_model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/new_model.py
@@ -1,0 +1,205 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import os
+import pickle
+from pathlib import Path
+from typing import Sequence, Any
+from tempfile import TemporaryDirectory
+
+import numpy as np
+import tensorflow as tf
+
+from bigdl.nano.utils.common import invalidInputError
+from bigdl.nano.utils.tf import try_compute_output_shape
+from bigdl.nano.utils.tf import convert_all
+from bigdl.nano.tf.new_model import KerasOptimizedModel
+
+from ..core.model import OpenVINOModel
+from ..core.utils import save
+from .utils import export
+from .dataloader import KerasOpenVINODataLoader
+from .metric import KerasOpenVINOMetric
+
+
+class KerasOpenVINOModel(KerasOptimizedModel):
+    def __init__(self, model, input_spec=None, precision='fp32',
+                 thread_num=None, device='CPU', config=None,
+                 logging=True, **kwargs):
+        """
+        Create a OpenVINO model from Keras.
+
+        :param model: Keras model to be converted to OpenVINO for inference or
+                      path to Openvino saved model.
+        :param input_spec: A (tuple or list of) tf.TensorSpec or numpy array defining
+                           the shape/dtype of the input
+        :param precision: Global precision of model, supported type: 'fp32', 'fp16',
+                          defaults to 'fp32'.
+        :param thread_num: a int represents how many threads(cores) is needed for
+                    inference. default: None.
+        :param device: A string represents the device of the inference. Default to 'CPU'.
+                       'CPU', 'GPU' and 'VPUX' are supported for now.
+        :param config: The config to be inputted in core.compile_model.
+                       inference. default: None.
+        :param logging: whether to log detailed information of model conversion.
+                        default: True.
+        :param **kwargs: will be passed to model optimizer function.
+        """
+        super().__init__()
+        ov_model_path = model
+        with TemporaryDirectory() as tmp_dir:
+            tmp_dir = Path(tmp_dir)
+            if isinstance(model, tf.keras.Model):
+                self._output_shape = try_compute_output_shape(model, input_spec,
+                                                              try_fake_inference=not model.built)
+                export(model, str(tmp_dir / 'tmp.xml'),
+                       precision=precision,
+                       logging=logging,
+                       **kwargs)
+                ov_model_path = tmp_dir / 'tmp.xml'
+            self.ov_model = OpenVINOModel(ov_model_path,
+                                          device=device,
+                                          precision=precision,
+                                          thread_num=thread_num,
+                                          config=config)
+
+    def preprocess(self, inputs: Sequence[Any]):
+        self.ov_model._model_exists_or_err()
+        # todo: We should perform dtype conversion based on the
+        # dtype of the arguments that the model expects
+        inputs = convert_all(inputs, types="numpy", dtypes=np.float32)
+        return inputs
+
+    def forward(self, inputs: Sequence[Any]):
+        return self.ov_model.forward_step(*inputs)
+
+    def postprocess(self, outputs: Sequence[Any]):
+        outputs = tuple(outputs.values())
+        # todo: we should perform dtype conversion based on the
+        # dtype of the outputs of the original keras model
+        outputs = convert_all(outputs, types="tf", dtypes=tf.float32)
+        if len(outputs) == 1:
+            outputs = outputs[0]
+        return outputs
+
+    @property
+    def status(self):
+        status = super().status
+        status.update({"xml_path": 'ov_saved_model.xml',
+                       "attr_path": "ov_saved_model_attr.pkl",
+                       "compile_path": "ov_saved_model_compile.pkl",
+                       "weight_path": 'ov_saved_model.bin',
+                       "config": self.ov_model.final_config,
+                       "device": self.ov_model._device})
+        return status
+
+    def pot(self,
+            x,
+            y,
+            metric=None,
+            higher_better=True,
+            drop_type="relative",
+            maximal_drop=0.999,
+            max_iter_num=1,
+            n_requests=None,
+            config=None,
+            sample_size=300,
+            thread_num=None):
+        if metric:
+            metric = KerasOpenVINOMetric(metric=metric, higher_better=higher_better)
+        dataloader = KerasOpenVINODataLoader(x, y, collate_fn=self.tensors_to_numpy)
+        model = self.ov_model.pot(dataloader, metric=metric, drop_type=drop_type,
+                                  maximal_drop=maximal_drop, max_iter_num=max_iter_num,
+                                  n_requests=n_requests, sample_size=sample_size)
+        q_model = KerasOpenVINOModel(model, precision='int8',
+                                     config=config, thread_num=thread_num,
+                                     device=self.ov_model._device)
+        q_model._output_shape = self._output_shape
+        return q_model
+
+    @staticmethod
+    def _load(path, device=None):
+        """
+        Load an OpenVINO model for inference from directory.
+
+        :param path: Path to model to be loaded.
+        :param device: A string represents the device of the inference.
+        :return: KerasOpenVINOModel model for OpenVINO inference.
+        """
+        status = KerasOpenVINOModel._load_status(path)
+        if status.get('xml_path', None):
+            xml_path = Path(status['xml_path'])
+            invalidInputError(xml_path.suffix == '.xml',
+                              "Path of openvino model must be with '.xml' suffix.")
+        else:
+            invalidInputError(False, "nano_model_meta.yml must specify 'xml_path' for loading.")
+        xml_path = Path(path) / status['xml_path']
+        thread_num = None
+        config = status.get('config', {})
+        if "CPU_THREADS_NUM" in config:
+            thread_num = int(config["CPU_THREADS_NUM"])
+        if device is None:
+            device = status.get('device', 'CPU')
+        model = KerasOpenVINOModel(xml_path,
+                                   config=status['config'],
+                                   thread_num=thread_num,
+                                   device=device)
+        with open(Path(path) / status['attr_path'], "rb") as f:
+            attrs = pickle.load(f)
+        for attr_name, attr_value in attrs.items():
+            setattr(model, attr_name, attr_value)
+        if os.path.exists(Path(path) / status['compile_path']):
+            with open(Path(path) / status['compile_path'], "rb") as f:
+                kwargs = pickle.load(f)
+                model.compile(**kwargs)
+        return model
+
+    def _save(self, path, compression="fp32"):
+        """
+        Save KerasOpenVINOModel to local as xml and bin file
+
+        :param path: Directory to save the model.
+        """
+        self.ov_model._model_exists_or_err()
+        path = Path(path)
+        path.mkdir(exist_ok=True)
+        xml_path = path / self.status['xml_path']
+        save(self.ov_model.ie_network, xml_path)
+        # save normal attrs
+        attrs = {"_output_shape": self._output_shape}
+        with open(Path(path) / self.status['attr_path'], "wb") as f:
+            pickle.dump(attrs, f)
+        # save compile attr
+        if self._is_compiled:
+            kwargs = {"run_eagerly": self._run_eagerly,
+                      "steps_per_execution": int(self._steps_per_execution)}
+            if self.compiled_loss is not None:
+                kwargs["loss"] = self.compiled_loss._user_losses
+                kwargs["loss_weights"] = self.compiled_loss._user_loss_weights
+            if self.compiled_metrics is not None:
+                user_metric = self.compiled_metrics._user_metrics
+                if isinstance(user_metric, (list, tuple)):
+                    kwargs["metrics"] = [m._name for m in user_metric]
+                else:
+                    kwargs["metrics"] = user_metric._name
+                weighted_metrics = self.compiled_metrics._user_weighted_metrics
+                if weighted_metrics is not None:
+                    if isinstance(weighted_metrics, (list, str)):
+                        kwargs["weighted_metrics"] = [m._name for m in weighted_metrics]
+                    else:
+                        kwargs["weighted_metrics"] = weighted_metrics._name
+            with open(Path(path) / self.status['compile_path'], "wb") as f:
+                pickle.dump(kwargs, f)

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/new_model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/new_model.py
@@ -174,14 +174,19 @@ class KerasOpenVINOModel(KerasOptimizedModel):
         :param path: Directory to save the model.
         """
         self.ov_model._model_exists_or_err()
+
         path = Path(path)
         path.mkdir(exist_ok=True)
+        self._dump_status(path)
+
         xml_path = path / self.status['xml_path']
         save(self.ov_model.ie_network, xml_path)
+
         # save normal attrs
         attrs = {"_output_shape": self._output_shape}
         with open(Path(path) / self.status['attr_path'], "wb") as f:
             pickle.dump(attrs, f)
+
         # save compile attr
         if self._is_compiled:
             kwargs = {"run_eagerly": self._run_eagerly,

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -575,7 +575,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                   "VPUX device, you must specify mean_value for model optimizer "
                                   "function. For more details about model optimizer, you can "
                                   "see mo --help .")
-            from bigdl.nano.deps.openvino.tf.model import KerasOpenVINOModel    # type: ignore
+            from bigdl.nano.deps.openvino.tf.new_model import KerasOpenVINOModel    # type: ignore
             result = KerasOpenVINOModel(model,
                                         input_spec=input_spec,
                                         precision=precision,
@@ -595,7 +595,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 final_openvino_option = {"INFERENCE_PRECISION_HINT": "bf16"}
                 if openvino_config is not None:
                     final_openvino_option.update(openvino_config)
-                from bigdl.nano.deps.openvino.tf.model import KerasOpenVINOModel    # type: ignore
+                from bigdl.nano.deps.openvino.tf.new_model \
+                    import KerasOpenVINOModel  # type: ignore
                 result = KerasOpenVINOModel(model,
                                             input_spec=input_spec,
                                             precision=precision,
@@ -660,7 +661,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                   outputs=outputs)
             result._output_shape = _output_shape
         elif accelerator == 'openvino':
-            from bigdl.nano.deps.openvino.tf.model import KerasOpenVINOModel    # type: ignore
+            from bigdl.nano.deps.openvino.tf.new_model import KerasOpenVINOModel    # type: ignore
             if isinstance(model, KerasOpenVINOModel):    # type: ignore
                 openvino_model = model
             else:

--- a/python/nano/src/bigdl/nano/tf/new_model.py
+++ b/python/nano/src/bigdl/nano/tf/new_model.py
@@ -14,9 +14,11 @@
 # limitations under the License.
 #
 
+
+from pathlib import Path
 from typing import Sequence, Any
 
-import tensorflow as tf
+import yaml
 from keras import Model
 
 from bigdl.nano.utils.common import invalidInputError
@@ -104,6 +106,11 @@ class KerasOptimizedModel(Model):
     def status(self):
         """Return model's status."""
         return {"ModelType": type(self).__name__}
+
+    def _dump_status(self, path):
+        meta_path = Path(path) / "nano_model_meta.yml"
+        with open(meta_path, 'w') as f:
+            yaml.safe_dump(self.status, f)
 
     def _save(self, path, compression="fp32"):
         invalidInputError(False, "Saving function is not implemented.")

--- a/python/nano/src/bigdl/nano/tf/new_model.py
+++ b/python/nano/src/bigdl/nano/tf/new_model.py
@@ -1,0 +1,113 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import Sequence, Any
+
+import tensorflow as tf
+from keras import Model
+
+from bigdl.nano.utils.common import invalidInputError
+
+
+class KerasOptimizedModel(Model):
+    """A base class for keras optimized model."""
+
+    def __call__(self, *inputs, **kwargs):
+        """Run inference, automatically perform type and dtype conversion."""
+        # todo: we should parse the `kwargs` and add it into `inputs`
+        for k in kwargs.keys():
+            invalidInputError(k == 'training',
+                              "Now we do not support passing arguments with `key=value` format")
+        inputs = self.preprocess(inputs)
+        outputs = self.forward(inputs)
+        outputs = self.postprocess(outputs)
+        return outputs
+
+    def preprocess(self, inputs: Sequence[Any]):
+        """Preprocess inputs, such as convert inputs to numpy ndarray."""
+        return inputs
+
+    def forward(self, inputs: Sequence[Any]):
+        """Run inference."""
+        return self.model(*inputs)
+
+    def postprocess(self, outputs: Sequence[Any]):
+        """Postprocess outputs, such as convert outputs to tensorflow Tensor."""
+        return outputs
+
+    def predict(self,
+                x,
+                batch_size=None,
+                verbose='auto',
+                steps=None,
+                callbacks=None,
+                max_queue_size=10,
+                workers=1,
+                use_multiprocessing=False):
+        """Same to keras model's `predict` method, except that it runs in eager mode."""
+        # todo: we should implement our predict method, because tf's predict will convert
+        # numpy to tensor, then convert tensor to numpy when using ov/onnx optimized model
+        self.run_eagerly = True
+        return super().predict(x=x,
+                               batch_size=batch_size,
+                               verbose=verbose,
+                               steps=steps,
+                               callbacks=callbacks,
+                               max_queue_size=max_queue_size,
+                               workers=workers,
+                               use_multiprocessing=use_multiprocessing)
+
+    def evaluate(self,
+                 x=None,
+                 y=None,
+                 batch_size=None,
+                 verbose='auto',
+                 sample_weight=None,
+                 steps=None,
+                 callbacks=None,
+                 max_queue_size=10,
+                 workers=1,
+                 use_multiprocessing=False,
+                 return_dict=False,
+                 **kwargs):
+        """Same to keras model's `evaluate` method, except that it runs in eager mode."""
+        # todo: we should implement our evaluate method, because tf's predict will convert
+        # numpy to tensor, then convert tensor to numpy when using ov/onnx optimized model
+        self.run_eagerly = True
+        return super().evaluate(x=x,
+                                y=y,
+                                batch_size=batch_size,
+                                verbose=verbose,
+                                sample_weight=sample_weight,
+                                steps=steps,
+                                callbacks=callbacks,
+                                max_queue_size=max_queue_size,
+                                workers=workers,
+                                use_multiprocessing=use_multiprocessing,
+                                return_dict=return_dict,
+                                **kwargs)
+
+    @property
+    def status(self):
+        """Return model's status."""
+        return {"ModelType": type(self).__name__}
+
+    def _save(self, path, compression="fp32"):
+        invalidInputError(False, "Saving function is not implemented.")
+
+    @staticmethod
+    def _load(path, model=None):
+        invalidInputError(False, "Loading function is not implemented.")

--- a/python/nano/src/bigdl/nano/utils/tf/__init__.py
+++ b/python/nano/src/bigdl/nano/utils/tf/__init__.py
@@ -26,3 +26,6 @@ from .attributes import patch_compiled_and_attrs
 from .backend import MultiprocessingBackend
 
 from .preprocess import try_compute_output_shape
+
+from .data import convert
+from .data import convert_all

--- a/python/nano/src/bigdl/nano/utils/tf/data.py
+++ b/python/nano/src/bigdl/nano/utils/tf/data.py
@@ -27,8 +27,8 @@ DTYPE = Union[tf.DType, np.dtype]
 
 
 def convert_all(inputs: Sequence[Union[tf.Tensor, np.ndarray]],
-                types=Union[List[Optional[str]], Optional[str]],
-                dtypes=Union[List[Optional[DTYPE]], Optional[DTYPE]],
+                types: Union[List[str], str],
+                dtypes: Union[List[Optional[DTYPE]], Optional[DTYPE]] = None,
                 ):
     """
     Convert all input tf.Tensor/np.ndarray to specified format.
@@ -44,7 +44,7 @@ def convert_all(inputs: Sequence[Union[tf.Tensor, np.ndarray]],
     x, y = convert_all((x, y), types=["tf", "numpy"], dtypes=[tf.float32, np.float32])
     ```
 
-    :param input_: The tf.Tensor/np.ndarray to convert.
+    :param input_: A list of tf.Tensor/np.ndarray to convert.
     :param type_: (A list of) target type, "tf" means tf.Tensor, "numpy" means np.ndarray.
     :param dtype_: (A list of) target dtype.
     :return The convert result.
@@ -59,8 +59,8 @@ def convert_all(inputs: Sequence[Union[tf.Tensor, np.ndarray]],
 
 
 def convert(input_: Union[tf.Tensor, np.ndarray],
-            type_: Optional[str],
-            dtype_: Optional[DTYPE]):
+            type_: str,
+            dtype_: Optional[DTYPE] = None):
     """
     Convert tf.Tensor/np.ndarray to specified format.
 
@@ -76,7 +76,7 @@ def convert(input_: Union[tf.Tensor, np.ndarray],
     :param input_: The tf.Tensor/np.ndarray to convert.
     :param type_: The target type, "tf" means tf.Tensor, "numpy" means np.ndarray.
     :param dtype_: The target dtype.
-    :return The convert result.
+    :return The results of conversion.
     """
     # todo: we should also convert `int`, `float`, `bool` to scalar Tensor/numpy
     if type_ == "tf":

--- a/python/nano/src/bigdl/nano/utils/tf/data.py
+++ b/python/nano/src/bigdl/nano/utils/tf/data.py
@@ -1,0 +1,158 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+from typing import List, Union, Optional, Sequence
+
+import numpy as np
+import tensorflow as tf
+
+from bigdl.nano.utils.common import invalidInputError
+
+
+DTYPE = Union[tf.DType, np.dtype]
+
+
+def convert_all(inputs: Sequence[Union[tf.Tensor, np.ndarray]],
+                types=Union[List[Optional[str]], Optional[str]],
+                dtypes=Union[List[Optional[DTYPE]], Optional[DTYPE]],
+                ):
+    """
+    Convert all input tf.Tensor/np.ndarray to specified format.
+
+    Usage:
+    ```
+    x = np.random.random((10, 10))
+    y = np.random.random((10, 10))
+    x, y = convert_all((x, y), types="tf", dtypes=tf.float32)
+
+    x = np.random.random((10, 10))
+    y = tf.random.normal((10, 10))
+    x, y = convert_all((x, y), types=["tf", "numpy"], dtypes=[tf.float32, np.float32])
+    ```
+
+    :param input_: The tf.Tensor/np.ndarray to convert.
+    :param type_: (A list of) target type, "tf" means tf.Tensor, "numpy" means np.ndarray.
+    :param dtype_: (A list of) target dtype.
+    :return The convert result.
+    """
+    if not isinstance(types, list):
+        types = [types] * len(inputs)
+    if not isinstance(dtypes, list):
+        dtypes = [dtypes] * len(inputs)
+
+    return [convert(input_, type_, dtype_)
+            for input_, type_, dtype_ in zip(inputs, types, dtypes)]
+
+
+def convert(input_: Union[tf.Tensor, np.ndarray],
+            type_: Optional[str],
+            dtype_: Optional[DTYPE]):
+    """
+    Convert tf.Tensor/np.ndarray to specified format.
+
+    Usage:
+    ```
+    x = np.random.random((10, 10))
+    convert(x, type_="tf", dtype_=tf.float32)
+
+    x = tf.random.normal((10, 10))
+    convert(x, type_="numpy", dtype_=np.float32)
+    ```
+
+    :param input_: The tf.Tensor/np.ndarray to convert.
+    :param type_: The target type, "tf" means tf.Tensor, "numpy" means np.ndarray.
+    :param dtype_: The target dtype.
+    :return The convert result.
+    """
+    # todo: we should also convert `int`, `float`, `bool` to scalar Tensor/numpy
+    if type_ == "tf":
+        if isinstance(input_, np.ndarray):
+            return tf.convert_to_tensor(input_, dtype=dtype_)
+        elif isinstance(input_, tf.Tensor):
+            if dtype_ is not None and input_.dtype != dtype_:
+                return tf.cast(input_, dtype=dtype_)
+            else:
+                return input_
+        else:
+            invalidInputError(False, f"Unkonwn type: {type(input_)}")
+    elif type_ == "numpy":
+        if isinstance(input_, tf.Tensor):
+            input_ = input_.numpy()
+        if isinstance(input_, np.ndarray):
+            if dtype_ is not None and input_.dtype != dtype_:
+                return input_.astype(dtype_)
+            else:
+                return input_
+        else:
+            invalidInputError(False, f"Unkonwn type: {type(input_)}")
+    else:
+        invalidInputError(False, f"Invalid target type: {type_}")
+
+
+# todo: Add a common keras dataset
+# class KerasDataset():
+#     def __init__(self,
+#                  x,
+#                  y,
+#                  collate_fn=None,
+#                  dtype=tf.float32) -> None:
+#         self.x = x,
+#         self.y = y,
+#         self.collate_fn = collate_fn
+#         self.dtype=dtype
+
+#     def __getitem__(self, index):
+#         if index > len(self):
+#             invalidInputError(False, f"index out of bounds, index:{index}, length:{len(self)}")
+
+#         if index < self.next_index:
+#             self._reset()
+#         if index > self.next_index:
+#             for _ in range(index - self.next_index):
+#                 self._next()
+
+#         data = self._next()
+#         if self.collate_fn:
+#             data = self.collate_fn(data)
+#         return data
+
+#     def __len__(self):
+#         return len(self.x)
+
+#     def _reset(self):
+#         self.next_index = 0
+#         if isinstance(self.x, tf.data.Dataset):
+#             self.x_iter = iter(self.x)
+#         else:
+#             self.x_iter = iter(self.x)
+#             self.y_iter = iter(self.y)
+
+#     def _next(self):
+#         self.next_index += 1
+#         if isinstance(self.x, tf.data.Dataset):
+#             return next(self.x_iter)
+#         else:
+#             return next(self.x_iter), next(self.y_iter)
+
+#     def __iter__(self):
+#         if isinstance(self.x, tf.data.Dataset):
+#             for batch in self.x.batch(1):
+#                 yield AcceleratedKerasModel.tensors_to_numpy(batch, self.dtype)
+#         else:
+#             for x, y in zip(self.x, self.y):
+#                 x, y = AcceleratedKerasModel.tensors_to_numpy((x, y), self.dtype)
+#                 yield np.expand_dims(x, axis=0), np.expand_dims(y, axis=0)

--- a/python/nano/test/tf/inference/test_trace_and_quantize.py
+++ b/python/nano/test/tf/inference/test_trace_and_quantize.py
@@ -309,7 +309,7 @@ class TestTraceAndQuantize(TestCase):
             output = load_model(x)
             assert output.dtype == tf.bfloat16
 
-    def test_convert_custom_layer(self):
+    def test_model_cannot_compute_output_shape(self):
         model = MyModelCannotComputeOutputShape()
         x = np.random.random((100, 4))
         y = np.random.random((100, 4))


### PR DESCRIPTION
## Description

Remove the usage of `py_function` when using openvino.

### 1. Why the change?

The usage of `py_function` causes openvino optimized tf bert model only return half of the results,
and it also causes lots of other bugs, so this PR starts to remove it.

### 2. User API changes

N/A

### 3. Summary of the change 

Add a new base class without `py_function`, and change openvino optimization to it.

### 4. How to test?
- [ ] Unit test
