### PR TITLE
support ndarray of tensors in torch_runner

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -426,7 +426,7 @@ class TorchRunner(BaseRunner):
         # and restore batch to what it should be.
         features, target = batch
         if torch.is_tensor(features) or \
-            (isinstance(features, np.ndarray) and torch.is_tensor(features[0])):
+                (isinstance(features, np.ndarray) and torch.is_tensor(features[0])):
             self.batch = features, target
         elif isinstance(features, (tuple, list)):
             self.batch = *features, target

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -425,7 +425,8 @@ class TorchRunner(BaseRunner):
         # unpack features into list to support multiple inputs model
         # and restore batch to what it should be.
         features, target = batch
-        if torch.is_tensor(features):
+        if torch.is_tensor(features) or \
+            (isinstance(features, np.ndarray) and torch.is_tensor(features[0])):
             self.batch = features, target
         elif isinstance(features, (tuple, list)):
             self.batch = *features, target

--- a/python/orca/src/bigdl/orca/learn/pytorch/utils.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/utils.py
@@ -289,7 +289,7 @@ def get_batchsize(input):
     elif isinstance(input, dict):
         return get_batchsize(list(input.values())[0])
     else:
-        return input.size(0)
+        return input.shape[0]
 
 
 def process_stats(worker_stats):


### PR DESCRIPTION
## Description
Current torch_runner accepts a torch tensor as a feature if only one input is needed, a list or tuple of tensors is unpacked when a couple of inputs when needed.  
When users often have self-defined collate_fn, an array of tensors is needed. 

