### PR TITLE
Nano: remove usage of `py_function` when using inc

### DIFF
--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api.py
@@ -26,7 +26,7 @@ def load_inc_model(path, model, framework, input_sample=None):
         # only ipex quantization needs example_inputs
         return PytorchQuantizedModel._load(path, model, example_inputs=input_sample)
     elif framework == 'tensorflow':
-        from .tensorflow.model import KerasQuantizedModel
+        from .tensorflow.new_model import KerasQuantizedModel
         return KerasQuantizedModel._load(path, model)
     else:
         invalidInputError(False,

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/inc_api_2.py
@@ -43,7 +43,7 @@ def quantize(model, dataloader=None, eval_func=None, metric=None,
         return quantized_model
 
     elif 'tensorflow' in not_none_kwargs['framework']:
-        from .tensorflow.model import KerasQuantizedModel
+        from .tensorflow.new_model import KerasQuantizedModel
         return KerasQuantizedModel(q_model)
 
     elif 'onnx' in not_none_kwargs['framework']:

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/new_model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/new_model.py
@@ -1,0 +1,120 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import os
+import pickle
+import yaml
+from pathlib import Path
+from typing import Sequence, Any
+
+from neural_compressor.model.model import TensorflowModel
+
+from bigdl.nano.utils.common import invalidInputError
+from bigdl.nano.utils.tf import convert_all
+from bigdl.nano.tf.new_model import KerasOptimizedModel
+
+from ..core import version as inc_version
+
+
+class KerasQuantizedModel(KerasOptimizedModel):
+
+    def __init__(self, model):
+        super().__init__()
+        self.model = model
+        self._input = model.input_tensor
+        self._output = model.output_tensor
+        self._sess = model.sess
+
+    def preprocess(self, inputs: Sequence[Any]):
+        return convert_all(inputs, "numpy")
+
+    def forward(self, inputs: Sequence[Any]):
+        input_dict = dict(zip(self._input, inputs))
+        outputs = self._sess.run(self._output, feed_dict=input_dict)
+        return outputs
+
+    def postprocess(self, outputs: Sequence[Any]):
+        outputs = convert_all(outputs, "tf")
+        if len(outputs) == 1:
+            outputs = outputs[0]
+        return outputs
+
+    @property
+    def status(self):
+        status = super().status
+        status.update({"attr_path": "inc_saved_model_attr.pkl",
+                       "compile_path": "inc_saved_model_compile.pkl"})
+        return status
+
+    def _save(self, path, compression="fp32"):
+        path = Path(path)
+        path.mkdir(exist_ok=True)
+
+        self.model.save(path)
+        self._dump_status(path)
+
+        # save normal attrs
+        attrs = {"_output_shape": self._output_shape}
+        with open(path / self.status['attr_path'], "wb") as f:
+            pickle.dump(attrs, f)
+
+        # save compile attr
+        if self._is_compiled:
+            kwargs = {"run_eagerly": self._run_eagerly,
+                      "steps_per_execution": int(self._steps_per_execution)}
+            if self.compiled_loss is not None:
+                kwargs["loss"] = self.compiled_loss._user_losses
+                kwargs["loss_weights"] = self.compiled_loss._user_loss_weights
+            if self.compiled_metrics is not None:
+                user_metric = self.compiled_metrics._user_metrics
+                if user_metric is not None:
+                    if isinstance(user_metric, (list, tuple)):
+                        kwargs["metrics"] = [m._name for m in user_metric]
+                    else:
+                        kwargs["metrics"] = user_metric._name
+                weighted_metrics = self.compiled_metrics._user_weighted_metrics
+                if weighted_metrics is not None:
+                    if isinstance(weighted_metrics, (list, str)):
+                        kwargs["weighted_metrics"] = [m._name for m in weighted_metrics]
+                    else:
+                        kwargs["weighted_metrics"] = weighted_metrics._name
+            with open(path / self.status['compile_path'], "wb") as f:
+                pickle.dump(kwargs, f)
+
+    @staticmethod
+    def _load(path, model=None):
+        status = KerasQuantizedModel._load_status(path)
+        invalidInputError(
+            model is not None,
+            errMsg="FP32 model is required to create a quantized model."
+        )
+        qmodel = TensorflowModel("saved_model", str(path))
+        from packaging import version
+        if version.parse(inc_version) < version.parse("1.11"):
+            path = Path(path)
+            tune_cfg_file = path / 'best_configure.yaml'
+            with open(tune_cfg_file, 'r') as f:
+                tune_cfg = yaml.safe_load(f)
+                qmodel.tune_cfg = tune_cfg
+        model = KerasQuantizedModel(qmodel)
+        with open(Path(path) / status['attr_path'], "rb") as f:
+            attrs = pickle.load(f)
+        for attr_name, attr_value in attrs.items():
+            setattr(model, attr_name, attr_value)
+        if os.path.exists(Path(path) / status['compile_path']):
+            with open(Path(path) / status['compile_path'], "rb") as f:
+                kwargs = pickle.load(f)
+                model.compile(**kwargs)
+        return model

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/quantization.py
@@ -16,7 +16,7 @@
 from bigdl.nano.utils.common import invalidInputError
 from ..core import BaseQuantization
 from .metric import TensorflowINCMetric
-from .model import KerasQuantizedModel
+from .new_model import KerasQuantizedModel
 from .utils import Dataloader
 from bigdl.nano.utils.common import compare_version
 import operator


### PR DESCRIPTION
## Description

Remove usage of `py_function` when using inc

### 1. Why the change?

The usage of `py_function` causes inc optimized tf bert model fails to convert,
and it also causes lots of other bugs, so this PR removes it.

### 2. User API changes

N/A

### 3. Summary of the change 

change inc optimization to use new base model

### 4. How to test?
- [ ] Unit test
