### PR TITLE
Add new MMDDP implementation for mmcv runner

### DIFF
--- a/python/orca/dev/test/run-type-check.sh
+++ b/python/orca/dev/test/run-type-check.sh
@@ -23,7 +23,7 @@ mypy --install-types --non-interactive --config-file ${ORCA_DEVTEST_DIR}/mypy.in
                                                      $ORCA_HOME/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py \
                                                      $ORCA_HOME/src/bigdl/orca/learn/pytorch/estimator.py \
                                                      $ORCA_HOME/src/bigdl/orca/learn/pytorch/core/base_ray_estimator.py \
-                                                     $ORCA_HOME/src/bigdl/orca/learn/pytorch/experimential/mmcv \
+                                                     $ORCA_HOME/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_estimator.py \
                                                      $ORCA_HOME/src/bigdl/orca/automl/hp.py \
                                                      $ORCA_HOME/src/bigdl/orca/automl/auto_estimator.py \
                                                      $ORCA_HOME/src/bigdl/orca/automl/xgboost/auto_xgb.py

--- a/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
@@ -144,8 +144,8 @@ class Estimator(object):
         """
         Create an Estimator for MMCV.
 
-        :param mmcv_runner_creator: A runner creator function that takes the parameter "config" and returns a
-               MMCV runner.
+        :param mmcv_runner_creator: A runner creator function that takes the parameter
+               "config" and returns a MMCV runner.
         :param backend: The distributed backend for the Estimator.
                Default: "ray".
         :param config: A parameter config dict, CfgNode or any class instance that plays a role of
@@ -157,7 +157,8 @@ class Estimator(object):
         :return: A Estimator object for MMCV.
         """
         if backend == "ray":
-            from bigdl.orca.learn.pytorch.experimential.mmcv.mmcv_ray_estimator import MMCVRayEstimator
+            from bigdl.orca.learn.pytorch.experimential.mmcv.mmcv_ray_estimator \
+                import MMCVRayEstimator
             return MMCVRayEstimator(mmcv_runner_creator=mmcv_runner_creator,
                                     backend=backend,
                                     workers_per_node=workers_per_node,

--- a/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     from bigdl.orca.learn.pytorch.pytorch_ray_estimator import PyTorchRayEstimator
     from bigdl.orca.learn.pytorch.pytorch_spark_estimator import PyTorchSparkEstimator
     from bigdl.orca.learn.pytorch.pytorch_pyspark_estimator import PyTorchPySparkEstimator
+    from bigdl.orca.learn.pytorch.experimential.mmcv.mmcv_ray_estimator import MMCVRayEstimator
 
 
 class Estimator(object):
@@ -132,6 +133,25 @@ class Estimator(object):
             invalidInputError(False,
                               "Only horovod, ray, bigdl and spark backends are "
                               f"supported for now, got backend: {backend}")
+            return None
+
+    @staticmethod
+    def from_mmcv(*,
+                  mmcv_runner_creator: Callable,
+                  backend: str = "ray",
+                  workers_per_node: int = 1,
+                  config: Optional[Dict] = None) -> MMCVRayEstimator:
+        if backend == "ray":
+            from bigdl.orca.learn.pytorch.experimential.mmcv.mmcv_ray_estimator import MMCVRayEstimator
+            return MMCVRayEstimator(mmcv_runner_creator=mmcv_runner_creator,
+                                    backend=backend,
+                                    workers_per_node=workers_per_node,
+                                    config=config)
+        else:
+            from bigdl.dllib.utils.log4Error import invalidInputError
+            invalidInputError(False,
+                              "Only ray backend are supported for now, "
+                              f"got backend: {backend}")
             return None
 
     @staticmethod

--- a/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/estimator.py
@@ -140,7 +140,22 @@ class Estimator(object):
                   mmcv_runner_creator: Callable,
                   backend: str = "ray",
                   workers_per_node: int = 1,
-                  config: Optional[Dict] = None) -> MMCVRayEstimator:
+                  config: Optional[Dict] = None) -> Union['MMCVRayEstimator', None]:
+        """
+        Create an Estimator for MMCV.
+
+        :param mmcv_runner_creator: A runner creator function that takes the parameter "config" and returns a
+               MMCV runner.
+        :param backend: The distributed backend for the Estimator.
+               Default: "ray".
+        :param config: A parameter config dict, CfgNode or any class instance that plays a role of
+               configuration to create runner data.
+               Default: None if no config is needed.
+        :param workers_per_node: The number of MMCV workers on each node.
+               Default: 1.
+
+        :return: A Estimator object for MMCV.
+        """
         if backend == "ray":
             from bigdl.orca.learn.pytorch.experimential.mmcv.mmcv_ray_estimator import MMCVRayEstimator
             return MMCVRayEstimator(mmcv_runner_creator=mmcv_runner_creator,

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/distributed.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/distributed.py
@@ -1,0 +1,198 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from typing import Any, List, Tuple
+
+import torch
+from torch.nn.parallel.distributed import (DistributedDataParallel,
+                                           _find_tensors)
+
+from mmcv import print_log
+from mmcv.utils import TORCH_VERSION, digit_version
+from mmcv.parallel.scatter_gather import ScatterInputs, scatter_kwargs
+
+
+class MMDistributedDataParallel(DistributedDataParallel):
+    """The DDP module that supports DataContainer.
+
+    MMDDP has two main differences with PyTorch DDP:
+
+    - It supports a custom type :class:`DataContainer` which allows more
+      flexible control of input data.
+    - It implement two APIs ``train_step()`` and ``val_step()``.
+    """
+
+    def forward(self, *inputs, **kwargs):
+        """Override the original forward function.
+
+        The main difference lies in the CPU inference where the data in
+        :class:`DataContainers` will still be gathered.
+        """
+        if not self.device_ids:
+            # We add the following line thus the module could gather and
+            # convert data containers as those in GPU inference
+            inputs, kwargs = self.scatter(inputs, kwargs, [-1])
+            return self.module(*inputs[0], **kwargs[0])
+        else:
+            return super().forward(*inputs, **kwargs)
+
+    def to_kwargs(self, inputs: ScatterInputs, kwargs: ScatterInputs,
+                  device_id: int) -> Tuple[tuple, tuple]:
+        # Use `self.to_kwargs` instead of `self.scatter` in pytorch1.8
+        # to move all tensors to device_id
+        return scatter_kwargs(inputs, kwargs, [device_id], dim=self.dim)
+
+    def scatter(self, inputs: ScatterInputs, kwargs: ScatterInputs,
+                device_ids: List[int]) -> Tuple[tuple, tuple]:
+        return scatter_kwargs(inputs, kwargs, device_ids, dim=self.dim)
+
+    def train_step(self, *inputs, **kwargs):
+        """train_step() API for module wrapped by DistributedDataParallel.
+
+        This method is basically the same as
+        ``DistributedDataParallel.forward()``, while replacing
+        ``self.module.forward()`` with ``self.module.train_step()``.
+        It is compatible with PyTorch 1.1 - 1.5.
+        """
+
+        # In PyTorch >= 1.7, ``reducer._rebuild_buckets()`` is moved from the
+        # end of backward to the beginning of forward.
+        if ('parrots' not in TORCH_VERSION
+                and digit_version(TORCH_VERSION) >= digit_version('1.7')
+                and self.reducer._rebuild_buckets()):
+            print_log(
+                'Reducer buckets have been rebuilt in this iteration.',
+                logger='mmcv')
+
+        if ('parrots' not in TORCH_VERSION
+                and digit_version(TORCH_VERSION) >= digit_version('1.11.0a0')):
+            if self._check_sync_bufs_pre_fwd():
+                self._sync_buffers()
+        else:
+            if (getattr(self, 'require_forward_param_sync', False)
+                    and self.require_forward_param_sync):
+                self._sync_params()
+
+        if self.device_ids:
+            inputs, kwargs = self.scatter(inputs, kwargs, self.device_ids)
+            if len(self.device_ids) == 1:
+                output = self.module.train_step(*inputs[0], **kwargs[0])
+            else:
+                outputs = self.parallel_apply(
+                    self._module_copies[:len(inputs)], inputs, kwargs)
+                output = self.gather(outputs, self.output_device)
+        else:
+            # output = self.module.train_step(*inputs, **kwargs)
+            inputs, kwargs = self.scatter(inputs, kwargs, [-1])
+            output = self.module.train_step(*inputs[0], **kwargs[0])
+
+        if ('parrots' not in TORCH_VERSION
+                and digit_version(TORCH_VERSION) >= digit_version('1.11.0a0')):
+            if self._check_sync_bufs_post_fwd():
+                self._sync_buffers()
+
+        if (torch.is_grad_enabled()
+                and getattr(self, 'require_backward_grad_sync', False)
+                and self.require_backward_grad_sync):
+            if self.find_unused_parameters:
+                self.reducer.prepare_for_backward(list(_find_tensors(output)))
+            else:
+                self.reducer.prepare_for_backward([])
+        else:
+            if ('parrots' not in TORCH_VERSION
+                    and digit_version(TORCH_VERSION) > digit_version('1.2')):
+                self.require_forward_param_sync = False
+        return output
+
+    def val_step(self, *inputs, **kwargs):
+        """val_step() API for module wrapped by DistributedDataParallel.
+
+        This method is basically the same as
+        ``DistributedDataParallel.forward()``, while replacing
+        ``self.module.forward()`` with ``self.module.val_step()``.
+        It is compatible with PyTorch 1.1 - 1.5.
+        """
+        # In PyTorch >= 1.7, ``reducer._rebuild_buckets()`` is moved from the
+        # end of backward to the beginning of forward.
+        if ('parrots' not in TORCH_VERSION
+                and digit_version(TORCH_VERSION) >= digit_version('1.7')
+                and self.reducer._rebuild_buckets()):
+            print_log(
+                'Reducer buckets have been rebuilt in this iteration.',
+                logger='mmcv')
+
+        if ('parrots' not in TORCH_VERSION
+                and digit_version(TORCH_VERSION) >= digit_version('1.11.0a0')):
+            if self._check_sync_bufs_pre_fwd():
+                self._sync_buffers()
+        else:
+            if (getattr(self, 'require_forward_param_sync', False)
+                    and self.require_forward_param_sync):
+                self._sync_params()
+
+        if self.device_ids:
+            inputs, kwargs = self.scatter(inputs, kwargs, self.device_ids)
+            if len(self.device_ids) == 1:
+                output = self.module.val_step(*inputs[0], **kwargs[0])
+            else:
+                outputs = self.parallel_apply(
+                    self._module_copies[:len(inputs)], inputs, kwargs)
+                output = self.gather(outputs, self.output_device)
+        else:
+            # output = self.module.val_step(*inputs, **kwargs)
+            inputs, kwargs = self.scatter(inputs, kwargs, [-1])
+            output = self.module.val_step(*inputs[0], **kwargs[0])
+
+        if ('parrots' not in TORCH_VERSION
+                and digit_version(TORCH_VERSION) >= digit_version('1.11.0a0')):
+            if self._check_sync_bufs_post_fwd():
+                self._sync_buffers()
+
+        if (torch.is_grad_enabled()
+                and getattr(self, 'require_backward_grad_sync', False)
+                and self.require_backward_grad_sync):
+            if self.find_unused_parameters:
+                self.reducer.prepare_for_backward(list(_find_tensors(output)))
+            else:
+                self.reducer.prepare_for_backward([])
+        else:
+            if ('parrots' not in TORCH_VERSION
+                    and digit_version(TORCH_VERSION) > digit_version('1.2')):
+                self.require_forward_param_sync = False
+        return output
+
+    def _run_ddp_forward(self, *inputs, **kwargs) -> Any:
+        """Processes inputs and runs ``self.module.forward``.
+
+        Pytorch 1.12.0 performs ``self.module.forward`` in ``_run_ddp_forward``
+        and deprecates using ``DistributedDataParallel.to_kwargs`` to
+        process inputs, which leads to inputs cannot be processed by
+        :meth:`MMDistributedDataParallel.to_kwargs` anymore. Therefore,
+        ``MMDistributedDataParallel`` overrides this method to call
+        :meth:`to_kwargs` explicitly.
+
+        See more information in `<https://github.com/open-mmlab/mmsegmentation/issues/1742>`_.  # noqa: E501
+
+        Returns:
+            Any: Forward result of :attr:`module`.
+        """
+        module_to_run = self._replicated_tensor_module if \
+            self._use_replicated_tensor_module else self.module
+
+        device_id = self.device_ids[0] if self.device_ids else -1
+        inputs, kwargs = self.to_kwargs(  # type: ignore
+            inputs, kwargs, device_id)
+        return module_to_run(*inputs[0], **kwargs[0])  # type: ignore

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/distributed.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/distributed.py
@@ -95,7 +95,6 @@ class MMDistributedDataParallel(DistributedDataParallel):
                     self._module_copies[:len(inputs)], inputs, kwargs)
                 output = self.gather(outputs, self.output_device)
         else:
-            # output = self.module.train_step(*inputs, **kwargs)
             inputs, kwargs = self.scatter(inputs, kwargs, [-1])
             output = self.module.train_step(*inputs[0], **kwargs[0])
 
@@ -152,7 +151,6 @@ class MMDistributedDataParallel(DistributedDataParallel):
                     self._module_copies[:len(inputs)], inputs, kwargs)
                 output = self.gather(outputs, self.output_device)
         else:
-            # output = self.module.val_step(*inputs, **kwargs)
             inputs, kwargs = self.scatter(inputs, kwargs, [-1])
             output = self.module.val_step(*inputs[0], **kwargs[0])
 

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/distributed.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/distributed.py
@@ -14,6 +14,11 @@
 # limitations under the License.
 #
 
+# Copyright (c) OpenMMLab. All rights reserved.
+
+# This file is adapted from
+# https://github.com/open-mmlab/mmcv/blob/master/mmcv/parallel/distributed.py
+
 from typing import Any, List, Tuple
 
 import torch
@@ -28,11 +33,17 @@ from mmcv.parallel.scatter_gather import ScatterInputs, scatter_kwargs
 class MMDistributedDataParallel(DistributedDataParallel):
     """The DDP module that supports DataContainer.
 
-    MMDDP has two main differences with PyTorch DDP:
+    This MMDDP has some differences with the original MMDDP:
 
-    - It supports a custom type :class:`DataContainer` which allows more
-      flexible control of input data.
-    - It implement two APIs ``train_step()`` and ``val_step()``.
+    - It implements a ``forward()`` method
+    - It update the code in ``train_step()`` ``val_step()`` and ``_run_ddp_forward()``
+    when self.device_ids is None, which means training with CPU
+
+    related issues:
+    - https://github.com/open-mmlab/mmcv/issues/2524
+    - https://github.com/open-mmlab/mmcv/issues/2558
+    When the issues above is solved by mmcv, this file can be deleted, then directly
+    use the MMDDP implemented by mmcv in MMCVRayEpochRunner.
     """
 
     def forward(self, *inputs, **kwargs):

--- a/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/experimential/mmcv/mmcv_ray_runner.py
@@ -27,13 +27,13 @@ from torch.optim import Optimizer
 from mmcv.runner import EpochBasedRunner, DistEvalHook
 from mmcv.runner.utils import get_host_info
 from mmcv.parallel import is_module_wrapper
-from mmcv.parallel.distributed import MMDistributedDataParallel
 from mmcv.fileio.file_client import BaseStorageBackend
 from mmcv.utils.misc import is_list_of
 from mmcv.runner.checkpoint import CheckpointLoader
 from bigdl.orca.learn.pytorch.utils import get_batchsize
 from bigdl.dllib.utils.log4Error import invalidInputError
 from bigdl.orca.learn.pytorch.core.base_runner import BaseRunner
+from .distributed import MMDistributedDataParallel
 
 from typing import (TYPE_CHECKING, Union, Any, Dict, List, Optional, Tuple, Callable)
 

--- a/python/orca/test/bigdl/orca/learn/ray/experimental/test_mmcv_estimator_ray_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/experimental/test_mmcv_estimator_ray_backend.py
@@ -27,7 +27,7 @@ from torch.utils.data import DataLoader
 from mmcv.runner import EpochBasedRunner
 from mmcv.runner import DistEvalHook as BaseDistEvalHook
 from mmcv.utils import get_logger
-from bigdl.orca.learn.pytorch.experimential.mmcv.mmcv_ray_estimator import MMCVRayEstimator
+from bigdl.orca.learn.pytorch import Estimator
 
 resource_path = os.path.join(
     os.path.realpath(os.path.dirname(__file__)), "../../../resources")
@@ -182,7 +182,7 @@ def train_dataloader_creator(config):
 def get_estimator(creator, cfg=None, workers_per_node=1):
     if cfg is None:
         cfg = {}
-    estimator = MMCVRayEstimator(
+    estimator = Estimator.from_mmcv(
         mmcv_runner_creator=creator,
         config=cfg,
         workers_per_node=workers_per_node


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
- Implement a new MMDDP based on the original mmcv [MMDDP](https://github.com/open-mmlab/mmcv/blob/master/mmcv/parallel/distributed.py), fix the bug when do distributed training with CPU.
- Add a new static method `from_mmcv` for `Estimator` to create a new `MMCVRayEstimator`.

### 1. Why the change?

<!-- Provide the related github issue link if available -->
related issues:
- https://github.com/open-mmlab/mmcv/issues/2524
- https://github.com/open-mmlab/mmcv/issues/2558

The MMDDP implemented in this pr fix the two issues above

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
Now user can create a MMCVRayEstimator through
```python
from bigdl.orca.learn.pytorch import Estimator

estimator = Estimator.from_mmcv(
        mmcv_runner_creator=creator,
        backend='ray'
        config=cfg,
        workers_per_node=workers_per_node
    )
```
the default and only supported backend is 'ray' for now.
### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
- Implement a new MMDDP based on the original mmcv [MMDDP](https://github.com/open-mmlab/mmcv/blob/master/mmcv/parallel/distributed.py), fix the bug when do distributed training with CPU.
- Add a new static method `from_mmcv` for `Estimator` to create a new `MMCVRayEstimator`.

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
