### PR TITLE
[Nano/Chronos] Fixed failure in API doc rendering

### DIFF
--- a/docs/readthedocs/source/conf.py
+++ b/docs/readthedocs/source/conf.py
@@ -18,7 +18,7 @@ import glob
 import shutil
 import urllib
 
-autodoc_mock_imports = ["openvino", "pytorch_lightning", "keras", "cpuinfo"]
+autodoc_mock_imports = ["openvino", "pytorch_lightning", "keras", "cpuinfo", "sigfig"]
 
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, '.')


### PR DESCRIPTION
## Description

Mock `sigfig` for doc build to fix the failed rendered API doc

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/315

### 3. How to test?
- [x] Document test: https://yuwentestdocs.readthedocs.io/en/fix-bigdl-api-doc/doc/PythonAPI/Nano/pytorch.html https://yuwentestdocs.readthedocs.io/en/fix-bigdl-api-doc/doc/PythonAPI/Chronos/autotsestimator.html
