### PR TITLE
Nano: latency multi samples calculator

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -475,10 +475,10 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                                                       acce_model,
                                                                       input_sample,
                                                                       training_data,
-                                                                      forward_args)              
+                                                                      forward_args)
                         else:
                             result_map[method]["latency"], status =\
-                                latency_calculate_helper(latency_sample_num, baseline_time, 
+                                latency_calculate_helper(latency_sample_num, baseline_time,
                                                          func_test, acce_model, input_sample)
                         if status is False and method != "original":
                             result_map[method]["status"] = "early stopped"

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -202,13 +202,13 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 | Each element in the DataLoader can be one of the following:
                 |    a. a single Tensor or dict of Tensors
                 |    b. a tuple:
-                |         b1: if the lenth is 1, the first element will be treated as input
+                |         b1: if the length is 1, the first element will be treated as input
                 |             to the model
-                |         b2: if the lenth is 2, the first element will be treated as input
+                |         b2: if the length is 2, the first element will be treated as input
                 |             to the model, with the sencond element treated as label.
                 |             if the input to the model is a tuple, it will be unpacked as
                 |             multiple inputs.
-                |         b3: if the lengh is larger than 2, the first n elements as input
+                |         b3: if the length is larger than 2, the first n elements as input
                 |             to the model, with n being the argument lenth to the model.forward
                 |             and the rest will be treated as label
                 |
@@ -220,9 +220,9 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                 | 1. a torch.utils.data.dataloader.DataLoader object for accuracy evaluation.
                 |
                 | Each element in the DataLoader should be a tuple as least size of two:
-                |     a: if the lenth is 2, the first element will be treated as input
+                |     a: if the length is 2, the first element will be treated as input
                 |        to the model, with the sencond element treated as label
-                |     b: if the lengh is larger than 2, the first n elements as input
+                |     b: if the length is larger than 2, the first n elements as input
                 |        to the model, with n being the argument lenth to the model.forward
                 |        and the rest will be treated as label
                 |
@@ -310,6 +310,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                search. "original" will be ignored in the excludes.
         :param output_filename: (optional) a string filename is used to specify the file which the
                optimized table will be writed. The default is None which means don't write to file.
+        :param latency_calculate_all: if set True, calculate average latency by iterating all the 
+               provided dataloader until reaching the latency_sample_num. Default set to be False. 
         '''
 
         # check if model is a nn.Module or inherited from a nn.Module

--- a/python/nano/src/bigdl/nano/utils/common/optimizer/__init__.py
+++ b/python/nano/src/bigdl/nano/utils/common/optimizer/__init__.py
@@ -15,7 +15,7 @@
 #
 
 
-from .latency import latency_calculate_helper, latency_loader_calculate_helper
+from .latency import latency_calculate_helper, torch_loader_latency_calculate_helper
 
 from .acceleration_option import AccelerationOption
 from .acceleration_option import available_acceleration_combination

--- a/python/nano/src/bigdl/nano/utils/common/optimizer/__init__.py
+++ b/python/nano/src/bigdl/nano/utils/common/optimizer/__init__.py
@@ -15,7 +15,7 @@
 #
 
 
-from .latency import latency_calculate_helper
+from .latency import latency_calculate_helper, latency_loader_calculate_helper
 
 from .acceleration_option import AccelerationOption
 from .acceleration_option import available_acceleration_combination

--- a/python/nano/src/bigdl/nano/utils/common/optimizer/latency.py
+++ b/python/nano/src/bigdl/nano/utils/common/optimizer/latency.py
@@ -17,6 +17,8 @@
 
 import time
 import numpy as np
+from typing import Sequence
+from torch.utils.data import DataLoader
 
 
 def latency_calculate_helper(iterrun, baseline_time, func, *args):
@@ -41,6 +43,70 @@ def latency_calculate_helper(iterrun, baseline_time, func, *args):
         if i + 1 >= min(iterrun, 10) and (end - start_time) > 10:
             iterrun = i + 1
             break
+    time_list.sort()
+    # remove top and least 10% data
+    time_list = time_list[int(0.1 * iterrun): int(0.9 * iterrun)]
+    return np.mean(time_list) * 1000, True
+
+
+def latency_loader_calculate_helper(iterrun, baseline_time, func, model, warmup_sample, dataloader, forward_args):
+    '''
+    A simple helper to calculate average latency by using all the samples provided in the dataloader
+    '''
+    check_flag = True
+    if (not isinstance(dataloader, DataLoader)) and check_flag:
+        print("training_data is not a DataLoader, use single sample calculator instead!")
+        check_flag = False
+    if iterrun <= 2 and check_flag:  # TODO: control the numbers
+        print("Not enough iterations to test, use single sample calculator instead!")
+        check_flag = False
+    if dataloader.batch_size is not None and check_flag:
+        if len(dataloader.dataset) / dataloader.batch_size <= 2:  # TODO: control the numbers
+            print("Not enough batches to test, use single sample calculator instead!")
+            check_flag = False
+    else:
+        if len(dataloader.dataset) <= 2:  # TODO: control the numbers
+            print("Not enough samples to test, use single sample calculator instead!")
+            check_flag = False
+    
+    if not check_flag:        
+        return latency_calculate_helper(iterrun, baseline_time, func, model, warmup_sample)
+    
+    # test run two times for more accurate latency
+    for _ in range(2):
+        func(model, warmup_sample)
+
+    start_time = time.perf_counter()
+    time_list = []
+    end_flag = False
+    cur_itr = 0
+    while not end_flag:
+        for _, input_sample in enumerate(dataloader):
+            if isinstance(input_sample, Sequence):
+                if len(input_sample) <= 2:
+                    input_sample = input_sample[0]
+                else:
+                    input_sample = tuple(input_sample[:len(forward_args)])
+            
+            st = time.perf_counter()
+            func(model, input_sample)
+            end = time.perf_counter()
+            time_list.append(end - st)
+            # if three samples cost more than 4x time than baseline model, prune it
+            if cur_itr == 2 and sum(time_list) > 12 * baseline_time:
+                return np.mean(time_list) * 1000, False
+            # at least need 10 iters and try to control calculation
+            # time less than 10s
+            if cur_itr + 1 >= min(iterrun, 10) and (end - start_time) > 10:
+                end_flag = True
+                iterrun = cur_itr + 1
+                break
+            # if reaching the max iteration number
+            if cur_itr == iterrun - 1:
+                end_flag = True
+                break
+            cur_itr += 1
+    
     time_list.sort()
     # remove top and least 10% data
     time_list = time_list[int(0.1 * iterrun): int(0.9 * iterrun)]

--- a/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
@@ -913,7 +913,7 @@ class TestInferencePipeline(TestCase):
             InferenceOptimizer.trace(self.model, accelerator="jit",
                                      use_ipex=True, input_sample=input_sample,
                                      precision="bf16")
-    
+
     def test_multi_samples_single_input(self):
         inference_opt = InferenceOptimizer()
         inference_opt.optimize(model=self.model,
@@ -921,7 +921,7 @@ class TestInferencePipeline(TestCase):
                                 thread_num=1,
                                 latency_sample_num=200,
                                 latency_calculate_all=True)
-        
+
     def test_multi_samples_multi_input(self):
         x1 = torch.randn(32, 10)
         x2 = torch.randn(32, 10)

--- a/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
@@ -917,10 +917,10 @@ class TestInferencePipeline(TestCase):
     def test_multi_samples_single_input(self):
         inference_opt = InferenceOptimizer()
         inference_opt.optimize(model=self.model,
-                                training_data=self.train_loader,
-                                thread_num=1,
-                                latency_sample_num=200,
-                                latency_calculate_all=True)
+                               training_data=self.train_loader,
+                               thread_num=1,
+                               latency_sample_num=200,
+                               no_cache=True)
 
     def test_multi_samples_multi_input(self):
         x1 = torch.randn(32, 10)
@@ -931,7 +931,8 @@ class TestInferencePipeline(TestCase):
 
         inference_opt = InferenceOptimizer()
         inference_opt.optimize(model=model,
-                                training_data=dataloader,
-                                thread_num=1,
-                                latency_sample_num=200,
-                                latency_calculate_all=True)
+                               training_data=dataloader,
+                               excludes=["openvino_int8"],
+                               thread_num=1,
+                               latency_sample_num=200,
+                               no_cache=True)

--- a/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
@@ -913,3 +913,25 @@ class TestInferencePipeline(TestCase):
             InferenceOptimizer.trace(self.model, accelerator="jit",
                                      use_ipex=True, input_sample=input_sample,
                                      precision="bf16")
+    
+    def test_multi_samples_single_input(self):
+        inference_opt = InferenceOptimizer()
+        inference_opt.optimize(model=self.model,
+                                training_data=self.train_loader,
+                                thread_num=1,
+                                latency_sample_num=200,
+                                latency_calculate_all=True)
+        
+    def test_multi_samples_multi_input(self):
+        x1 = torch.randn(32, 10)
+        x2 = torch.randn(32, 10)
+        y = torch.randn(32, 1)
+        dataloader = DataLoader(TensorDataset(x1, x2, y), batch_size=1)
+        model = MultipleInputNet()
+
+        inference_opt = InferenceOptimizer()
+        inference_opt.optimize(model=model,
+                                training_data=dataloader,
+                                thread_num=1,
+                                latency_sample_num=200,
+                                latency_calculate_all=True)


### PR DESCRIPTION
## Description
Add `latency_calculate_all` option in Pytorch InferenceOptimizer.optimize API to calculate average latency by iterating all the provided dataloader. 

### 1. Why the change?
Some customized data input's size is large, using one input sample may omit the latency of loading various data from memory. Hence, calculating average latency by iterating all the provided dataloader will take this effect into account to get a more meaningful value. 

### 2. User API changes
- Add `latency_calculate_all` option in Pytorch InferenceOptimizer.optimize API
- Add `latency_loader_calculate_helper()` helper function

### 3. How to test?
Unit test in pytorch/tests/inference/test_inference_optimizer `test_multi_samples_single_input()` and `test_multi_samples_multi_input()`
