### PR TITLE
Nano: add sample_size limit to quantize of ipex and jit_int8

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_quantization_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_quantization_model.py
@@ -95,7 +95,9 @@ class PytorchIPEXQuantizationModel(AcceleratedLightningModule):
                              inplace=inplace)
 
         # calibration model
-        for x in calib_data:
+        for idx, x in enumerate(calib_data):
+            if idx >= calib_data._nano_calib_sample_size:
+                break
             # data transform of calib_data
             if isinstance(x, (tuple, list)) and len(x) > 1:
                 x = x[0]

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -819,6 +819,12 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                                                      calib_dataloader,
                                                                      input_sample)
 
+            # Add sample_size property to calib_dataloader to make the for loop in
+            # `ipex_quantization_model.py`
+            # `jit_int8_model.py`
+            # load sample items less than this value
+            calib_dataloader._nano_calib_sample_size = sample_size
+
             # transform the dataloader to inc mode
             inc_calib_dataloader =\
                 transform_multiple_input_dataloader_to_inc_mode(model,

--- a/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
+++ b/python/nano/src/bigdl/nano/pytorch/low_precision/jit_int8_model.py
@@ -128,7 +128,9 @@ class PytorchJITINT8Model(AcceleratedLightningModule):
 
         # TODO: multiple input data not supported during calibration
         # the same problem as ipex_quantization model
-        for x in calib_data:
+        for idx, x in enumerate(calib_data):
+            if idx >= calib_data._nano_calib_sample_size:
+                break
             if isinstance(x, (tuple, list)) and len(x) > 1:
                 x = x[0]
             if isinstance(x, Sequence):


### PR DESCRIPTION
## Description
Add a small change to make the ipex_quantize model for loop has a limit times

### 1. Why the change?
* add `_nano_calib_sample_size` property for calib_data
* change the for loop logic in ipex_quantize_model and jit_int8_model