### PR TITLE
Orca:  Make `loss_creator` optional

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -36,7 +36,6 @@ import logging
 import os
 import copy
 import tempfile
-from holidays import NO
 import torch
 import torch.nn as nn
 import numpy as np


### PR DESCRIPTION
## Description
In some cases losses are intergrated in models and do not require a loss_creator, like in mask r-cnn.