### PR TITLE
Orca: Deprecate Jep/Horovod Related Tests

### DIFF
--- a/.github/workflows/PR_validation.yml
+++ b/.github/workflows/PR_validation.yml
@@ -389,44 +389,6 @@ jobs:
       if: ${{ always() }}
       uses: ./.github/actions/remove-env/remove-env-py38
 
-  Orca-Pytest-Horovod-Py37-Spark3:
-    needs: changes
-    if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
-    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK8
-      uses: ./.github/actions/jdk-setup-action
-    - name: Set up maven
-      uses: ./.github/actions/maven-setup-action 
-    - name: Setup env
-      uses: ./.github/actions/orca/setup-env/setup-orca-python-py37-basic
-    - name: Run Test
-      uses: ./.github/actions/orca/orca-pytest-horovod-py37-spark3-action/pr-test
-    - name: Remove Env
-      if: ${{ always() }}
-      uses: ./.github/actions/remove-env
-
-  Orca-Pytest-Jep-Py37-Spark3:
-    needs: changes
-    if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
-    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK8
-      uses: ./.github/actions/jdk-setup-action
-    - name: Set up maven
-      uses: ./.github/actions/maven-setup-action
-    - name: Setup env
-      uses: ./.github/actions/orca/setup-env/setup-orca-python-py37-basic
-    - name: Run Test
-      uses: ./.github/actions/orca/orca-pytest-jep-py37-spark3-action/pr-test
-    - name: Remove Env
-      if: ${{ always() }}
-      uses: ./.github/actions/remove-env
-
   Orca-Pytest-AutoML-Py37-Spark3:
     needs: changes
     if: ${{ needs.changes.outputs.orca-pytest == 'true' }}


### PR DESCRIPTION
## Description


### 1. Why the change?

<!-- Provide the related github issue link if available -->

Deprecate 2 PR-test, only keep nightly-test
+ Orca-Pytest-Jep-Py37-Spark3
+ Orca-Pytest-Horovod-Py37-Spark3