### PR TITLE
Nano: Remove output_shape usage

### DIFF
--- a/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/model.py
@@ -103,10 +103,7 @@ class KerasQuantizedModel(KerasOptimizedModel):
                 tune_cfg = yaml.safe_load(f)
                 qmodel.tune_cfg = tune_cfg
         model = KerasQuantizedModel(qmodel)
-        with open(Path(path) / status['attr_path'], "rb") as f:
-            attrs = pickle.load(f)
-        for attr_name, attr_value in attrs.items():
-            setattr(model, attr_name, attr_value)
+
         if os.path.exists(Path(path) / status['compile_path']):
             with open(Path(path) / status['compile_path'], "rb") as f:
                 kwargs = pickle.load(f)

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/model.py
@@ -54,8 +54,7 @@ class KerasQuantizedModel(KerasOptimizedModel):
     @property
     def status(self):
         status = super().status
-        status.update({"attr_path": "inc_saved_model_attr.pkl",
-                       "compile_path": "inc_saved_model_compile.pkl"})
+        status.update({"compile_path": "inc_saved_model_compile.pkl"})
         return status
 
     def _save(self, path, compression="fp32"):
@@ -64,11 +63,6 @@ class KerasQuantizedModel(KerasOptimizedModel):
 
         self.model.save(path)
         self._dump_status(path)
-
-        # save normal attrs
-        attrs = {"_output_shape": self._output_shape}
-        with open(path / self.status['attr_path'], "wb") as f:
-            pickle.dump(attrs, f)
 
         # save compile attr
         if self._is_compiled:

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -24,7 +24,7 @@ import numpy as np
 import tensorflow as tf
 
 from bigdl.nano.utils.common import invalidInputError
-from bigdl.nano.utils.tf import try_compute_output_shape
+from bigdl.nano.utils.tf import try_fake_inference
 from bigdl.nano.utils.tf import convert_all, tensors_to_numpy
 from bigdl.nano.tf.model import KerasOptimizedModel
 
@@ -63,8 +63,7 @@ class KerasOpenVINOModel(KerasOptimizedModel):
         with TemporaryDirectory() as tmp_dir:
             tmp_dir = Path(tmp_dir)
             if isinstance(model, tf.keras.Model):
-                self._output_shape = try_compute_output_shape(model, input_spec,
-                                                              try_fake_inference=not model.built)
+                try_fake_inference(model, input_spec)
                 export(model, str(tmp_dir / 'tmp.xml'),
                        precision=precision,
                        logging=logging,
@@ -99,7 +98,6 @@ class KerasOpenVINOModel(KerasOptimizedModel):
     def status(self):
         status = super().status
         status.update({"xml_path": 'ov_saved_model.xml',
-                       "attr_path": "ov_saved_model_attr.pkl",
                        "compile_path": "ov_saved_model_compile.pkl",
                        "weight_path": 'ov_saved_model.bin',
                        "config": self.ov_model.final_config,
@@ -129,7 +127,6 @@ class KerasOpenVINOModel(KerasOptimizedModel):
         q_model = KerasOpenVINOModel(model, precision='int8',
                                      config=config, thread_num=thread_num,
                                      device=self.ov_model._device)
-        q_model._output_shape = self._output_shape
         return q_model
 
     @staticmethod
@@ -183,11 +180,6 @@ class KerasOpenVINOModel(KerasOptimizedModel):
 
         xml_path = path / self.status['xml_path']
         save(self.ov_model.ie_network, xml_path)
-
-        # save normal attrs
-        attrs = {"_output_shape": self._output_shape}
-        with open(Path(path) / self.status['attr_path'], "wb") as f:
-            pickle.dump(attrs, f)
 
         # save compile attr
         if self._is_compiled:

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -156,10 +156,6 @@ class KerasOpenVINOModel(KerasOptimizedModel):
                                    config=status['config'],
                                    thread_num=thread_num,
                                    device=device)
-        with open(Path(path) / status['attr_path'], "rb") as f:
-            attrs = pickle.load(f)
-        for attr_name, attr_value in attrs.items():
-            setattr(model, attr_name, attr_value)
         if os.path.exists(Path(path) / status['compile_path']):
             with open(Path(path) / status['compile_path'], "rb") as f:
                 kwargs = pickle.load(f)

--- a/python/nano/src/bigdl/nano/utils/tf/__init__.py
+++ b/python/nano/src/bigdl/nano/utils/tf/__init__.py
@@ -25,7 +25,7 @@ from .attributes import patch_compiled_and_attrs
 
 from .backend import MultiprocessingBackend
 
-from .preprocess import try_compute_output_shape
+from .preprocess import try_fake_inference
 
 from .data import convert
 from .data import convert_all

--- a/python/nano/test/tf/inference/test_trace_and_quantize.py
+++ b/python/nano/test/tf/inference/test_trace_and_quantize.py
@@ -46,15 +46,6 @@ class MyModel(tf.keras.Model):
         pass
 
 
-class MyModelReturnList(tf.keras.Model):
-    def __init__(self):
-        super().__init__()
-        self.dense1 = tf.keras.layers.Dense(4, activation=tf.nn.relu)
-
-    def call(self, inputs: tf.Tensor):
-        return [self.dense1(inputs)]
-
-
 class MyModelCannotComputeOutputShape(tf.keras.Model):
     def __init__(self):
         super().__init__()
@@ -240,19 +231,6 @@ class TestTraceAndQuantize(TestCase):
                 InferenceOptimizer.save(m, tmp_dir_name)
                 new_model = InferenceOptimizer.load(tmp_dir_name, model)
                 new_model.evaluate(x=x, y=y)
-
-    def test_inference_output_shape(self):
-        model = MyModelReturnList()
-        x = np.random.random((100, 4))
-        traced_model = InferenceOptimizer.trace(model, accelerator="onnxruntime",
-                                                input_spec=tf.TensorSpec(shape=(None, 4), dtype=tf.float32))
-        outputs = traced_model(x)
-        assert isinstance(outputs, list) and isinstance(outputs[0], tf.Tensor)
-
-        quantized_model = InferenceOptimizer.quantize(model, accelerator="onnxruntime",
-                                                      input_spec=tf.TensorSpec(shape=(None, 4)), x=x)
-        outputs = quantized_model(x)
-        assert isinstance(outputs, list) and isinstance(outputs[0], tf.Tensor)
 
     def test_quantize_bf16(self):
         # for custom model, quantized model still return fp32 output


### PR DESCRIPTION
## Description

We don't need output_shape any more after removing py_function usage, so this PR removes related code.

### 4. How to test?
- [x] Unit test