### PR TITLE
Limit sgx memory usage of torchserve frontend to 8g.

### DIFF
--- a/ppml/trusted-dl-serving/base/ppml/torchserve/start-torchserve-frontend.sh
+++ b/ppml/trusted-dl-serving/base/ppml/torchserve/start-torchserve-frontend.sh
@@ -24,11 +24,15 @@ done
 cd /ppml || exit
 
 if [[ $SGX_ENABLED == "false" ]]; then
-    taskset -c "$core" /opt/jdk11/bin/java \
+    /opt/jdk11/bin/java \
             -Dmodel_server_home=/usr/local/lib/python3.8/dist-packages \
             -cp .:/ppml/torchserve/* \
-            -Xmx5g \
+            -Xmx1g \
             -Xms1g \
+            -Xss1024K \
+            -XX:MetaspaceSize=64m \
+            -XX:MaxMetaspaceSize=128m \
+            -XX:MaxDirectMemorySize=128m \
             org.pytorch.serve.ModelServer \
             --python /usr/bin/python3 \
             -f "$configFile" \
@@ -45,3 +49,4 @@ else
             -ncs"
     taskset -c "$core" gramine-sgx bash 2>&1 | tee frontend-sgx.log
 fi
+


### PR DESCRIPTION
## Description

Limit sgx memory usage of torchserve frontend to 8g.

### 1. Why the change?

Limit sgx memory usage of torchserve processes to 8g and reduce total sgx memory.

### 2. User API changes

None.

### 3. Summary of the change 

Add serveral JVM settings to frontend.
