### PR TITLE
Orca: add python 3.8 basic tests (pr+nightly)

### DIFF
--- a/.github/actions/orca/orca-basic-py38-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-basic-py38-spark3-action/nightly-test/action.yml
@@ -1,0 +1,19 @@
+name: 'Run Orca Basic Py38 Spark3'
+description: 'Run Orca Basic Py38 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py38
+        export SPARK_LOCAL_HOSTNAME=localhost
+        
+        pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3
+
+        pip list
+        chmod a+x python/orca/dev/test/run-pytests-basic-env.sh
+        python/orca/dev/test/run-pytests-basic-env.sh
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/orca-basic-py38-spark3-action/pr-test/action.yml
+++ b/.github/actions/orca/orca-basic-py38-spark3-action/pr-test/action.yml
@@ -1,0 +1,25 @@
+name: 'Run Orca Basic Py38 Spark3'
+description: 'Run Orca Basic Py38 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py38
+        export SPARK_LOCAL_HOSTNAME=localhost
+        
+        bash python/dev/release_default_linux_spark3.sh default false false false -Ddata-store-url=$HTTP_URI -U
+        
+        # install dllib
+        pip install -i https://pypi.org/simple python/dllib/src/dist/bigdl_dllib*-py3-none-manylinux1_x86_64.whl
+
+        # install orca
+        pip install -i https://pypi.org/simple python/orca/src/dist/bigdl_orca*-py3-none-manylinux1_x86_64.whl
+     
+        pip list
+        chmod a+x python/orca/dev/test/run-pytests-basic-env.sh
+        python/orca/dev/test/run-pytests-basic-env.sh
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/orca-basic-pytorch-py38-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-basic-pytorch-py38-spark3-action/nightly-test/action.yml
@@ -1,0 +1,20 @@
+name: 'Run Orca Basic Pytorch Py38 Spark3'
+description: 'Run Orca Basic Pytorch Py38 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py38
+        export SPARK_LOCAL_HOSTNAME=localhost
+        
+        pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3
+
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
+        pip list
+        chmod a+x python/orca/dev/test/run-pytests-basic-pytorch.sh
+        python/orca/dev/test/run-pytests-basic-pytorch.sh
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/orca-basic-pytorch-py38-spark3-action/pr-test/action.yml
+++ b/.github/actions/orca/orca-basic-pytorch-py38-spark3-action/pr-test/action.yml
@@ -1,0 +1,25 @@
+name: 'Run Orca Basic Pytorch Py38 Spark3'
+description: 'Run Orca Basic Pytorch Py38 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py38
+        export SPARK_LOCAL_HOSTNAME=localhost
+        
+        bash python/dev/release_default_linux_spark3.sh default false false false -Ddata-store-url=$HTTP_URI -U
+        
+        # install dllib
+        pip install -i https://pypi.org/simple python/dllib/src/dist/bigdl_dllib*-py3-none-manylinux1_x86_64.whl
+        # install orca
+        pip install -i https://pypi.org/simple python/orca/src/dist/bigdl_orca*-py3-none-manylinux1_x86_64.whl
+     
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
+        pip list
+        chmod a+x python/orca/dev/test/run-pytests-basic-pytorch.sh
+        python/orca/dev/test/run-pytests-basic-pytorch.sh
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/orca-basic-tf2-py38-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-basic-tf2-py38-spark3-action/nightly-test/action.yml
@@ -1,0 +1,21 @@
+name: 'Run Orca Basic Tf2 Py38 Spark3'
+description: 'Run Orca Basic Tf2 Py38 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py38
+        export SPARK_LOCAL_HOSTNAME=localhost
+        
+        pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3
+
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==2.9.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} grpcio==1.43.0
+        pip list
+        chmod a+x python/orca/dev/test/run-pytests-basic-tf2.sh
+        python/orca/dev/test/run-pytests-basic-tf2.sh
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/orca-basic-tf2-py38-spark3-action/pr-test/action.yml
+++ b/.github/actions/orca/orca-basic-tf2-py38-spark3-action/pr-test/action.yml
@@ -1,0 +1,26 @@
+name: 'Run Orca Basic Tf2 Py38 Spark3'
+description: 'Run Orca Basic Tf2 Py38 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py38
+        export SPARK_LOCAL_HOSTNAME=localhost
+        
+        bash python/dev/release_default_linux_spark3.sh default false false false -Ddata-store-url=$HTTP_URI -U
+        
+        # install dllib
+        pip install -i https://pypi.org/simple python/dllib/src/dist/bigdl_dllib*-py3-none-manylinux1_x86_64.whl
+        # install orca
+        pip install -i https://pypi.org/simple python/orca/src/dist/bigdl_orca*-py3-none-manylinux1_x86_64.whl
+     
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==2.9.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} grpcio==1.43.0
+        pip list
+        chmod a+x python/orca/dev/test/run-pytests-basic-tf2.sh
+        python/orca/dev/test/run-pytests-basic-tf2.sh
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}

--- a/.github/workflows/PR_validation.yml
+++ b/.github/workflows/PR_validation.yml
@@ -313,6 +313,63 @@ jobs:
       if: ${{ always() }}
       uses: ./.github/actions/remove-env
 
+  Orca-Basic-Py38-Spark3:
+    needs: changes
+    if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
+    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
+        
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up JDK8
+        uses: ./.github/actions/jdk-setup-action
+      - name: Set up maven
+        uses: ./.github/actions/maven-setup-action
+      - name: Setup env
+        uses: ./.github/actions/orca/setup-env/setup-orca-python-py38-basic
+      - name: Run test
+        uses: ./.github/actions/orca/orca-basic-py38-spark3-action/pr-test
+      - name: Remove Env
+        if: ${{ always() }}
+        uses: ./.github/actions/remove-env/remove-env-py38
+
+  Orca-Basic-PyTorch-Py38-Spark3:
+    needs: changes
+    if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
+    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Set up maven
+      uses: ./.github/actions/maven-setup-action
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py38-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-basic-pytorch-py38-spark3-action/pr-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py38
+
+  Orca-Basic-Tf2-Py38-Spark3:
+    needs: changes
+    if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
+    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Set up maven
+      uses: ./.github/actions/maven-setup-action
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py38-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-basic-tf2-py38-spark3-action/pr-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py38
+
   Orca-Pytest-Py37-Spark3-Tf1:
     needs: changes
     if: ${{ needs.changes.outputs.orca-pytest == 'true' }}

--- a/.github/workflows/PR_validation.yml
+++ b/.github/workflows/PR_validation.yml
@@ -67,10 +67,10 @@ jobs:
       friesian-pytest: ${{ steps.filter.outputs.friesian-pytest }}
       friesian-example: ${{ steps.filter.outputs.friesian-example }}
       dllib: ${{ steps.filter.outputs.dllib }}
-      orca-pytest: ${{ steps.filter.outputs.orca-pytest }}
-      orca-pytest-openvino: ${{ steps.filter.outputs.orca-pytest-openvino }}
-      orca-tutorial: ${{ steps.filter.outputs.orca-tutorial }}
-      orca-example: ${{ steps.filter.outputs.orca-example }}
+      # orca-pytest: ${{ steps.filter.outputs.orca-pytest }}
+      # orca-pytest-openvino: ${{ steps.filter.outputs.orca-pytest-openvino }}
+      # orca-tutorial: ${{ steps.filter.outputs.orca-tutorial }}
+      # orca-example: ${{ steps.filter.outputs.orca-example }}
       ppml: ${{ steps.filter.outputs.ppml }}
     steps:
       - uses: actions/checkout@v3
@@ -315,7 +315,7 @@ jobs:
 
   Orca-Basic-Py38-Spark3:
     needs: changes
-    if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
+    # if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
         
     steps:
@@ -334,7 +334,7 @@ jobs:
 
   Orca-Basic-PyTorch-Py38-Spark3:
     needs: changes
-    if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
+    # if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
@@ -353,7 +353,7 @@ jobs:
 
   Orca-Basic-Tf2-Py38-Spark3:
     needs: changes
-    if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
+    # if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:

--- a/.github/workflows/PR_validation.yml
+++ b/.github/workflows/PR_validation.yml
@@ -67,10 +67,10 @@ jobs:
       friesian-pytest: ${{ steps.filter.outputs.friesian-pytest }}
       friesian-example: ${{ steps.filter.outputs.friesian-example }}
       dllib: ${{ steps.filter.outputs.dllib }}
-      # orca-pytest: ${{ steps.filter.outputs.orca-pytest }}
-      # orca-pytest-openvino: ${{ steps.filter.outputs.orca-pytest-openvino }}
-      # orca-tutorial: ${{ steps.filter.outputs.orca-tutorial }}
-      # orca-example: ${{ steps.filter.outputs.orca-example }}
+      orca-pytest: ${{ steps.filter.outputs.orca-pytest }}
+      orca-pytest-openvino: ${{ steps.filter.outputs.orca-pytest-openvino }}
+      orca-tutorial: ${{ steps.filter.outputs.orca-tutorial }}
+      orca-example: ${{ steps.filter.outputs.orca-example }}
       ppml: ${{ steps.filter.outputs.ppml }}
     steps:
       - uses: actions/checkout@v3
@@ -315,7 +315,7 @@ jobs:
 
   Orca-Basic-Py38-Spark3:
     needs: changes
-    # if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
+    if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
         
     steps:
@@ -334,7 +334,7 @@ jobs:
 
   Orca-Basic-PyTorch-Py38-Spark3:
     needs: changes
-    # if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
+    if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
@@ -353,7 +353,7 @@ jobs:
 
   Orca-Basic-Tf2-Py38-Spark3:
     needs: changes
-    # if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
+    if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -2,7 +2,7 @@ name: Nightly Test
 
 on:
 
-  pull_request:
+  #pull_request:
     #branchs: [ main ]
 
   schedule:
@@ -169,7 +169,7 @@ jobs:
         runner-hosted-on: 'Shanghai'
 
   Orca-Basic-Py38-Spark3:
-    # if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Py38-Spark3' || github.event.inputs.artifact == 'all' }} 
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Py38-Spark3' || github.event.inputs.artifact == 'all' }} 
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
@@ -196,7 +196,7 @@ jobs:
         runner-hosted-on: 'Shanghai'
 
   Orca-Basic-PyTorch-Py38-Spark3:
-    # if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-PyTorch-Py38-Spark3' || github.event.inputs.artifact == 'all' }} 
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-PyTorch-Py38-Spark3' || github.event.inputs.artifact == 'all' }} 
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
@@ -223,7 +223,7 @@ jobs:
         runner-hosted-on: 'Shanghai'
 
   Orca-Basic-Tf2-Py38-Spark3:
-    # if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Tf2-Py38-Spark3' || github.event.inputs.artifact == 'all' }} 
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Tf2-Py38-Spark3' || github.event.inputs.artifact == 'all' }} 
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -2,7 +2,7 @@ name: Nightly Test
 
 on:
 
-  #pull_request:
+  pull_request:
     #branchs: [ main ]
 
   schedule:
@@ -19,6 +19,9 @@ on:
         - Orca-Basic-Py37-Spark3
         - Orca-Basic-PyTorch-Py37-Spark3
         - Orca-Basic-Tf2-Py37-Spark3
+        - Orca-Basic-Py38-Spark3
+        - Orca-Basic-PyTorch-Py38-Spark3
+        - Orca-Basic-Tf2-Py38-Spark3
         - Orca-Pytest-Ray-Py37-Spark3
         - Orca-Pytest-Ray-Py38-Spark3
         - Orca-Pytest-Py37-Spark3-Tf1
@@ -163,6 +166,87 @@ jobs:
         file-name: Orca-Basic-Tf2-Py37-Spark3.json
         type: job
         job-name: Orca-Basic-Tf2-Py37-Spark3
+        runner-hosted-on: 'Shanghai'
+
+  Orca-Basic-Py38-Spark3:
+    # if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Py38-Spark3' || github.event.inputs.artifact == 'all' }} 
+    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py38-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-basic-py38-spark3-action/nightly-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py38
+    - name: Create Job Badge
+      uses: ./.github/actions/create-job-status-badge
+      if: ${{ always() }}
+      with:
+        secret: ${{ secrets.GIST_SECRET}}
+        gist-id: ${{env.GIST_ID}}
+        is-self-hosted-runner: true
+        file-name: Orca-Basic-Py38-Spark3.json
+        type: job
+        job-name: Orca-Basic-Py38-Spark3
+        runner-hosted-on: 'Shanghai'
+
+  Orca-Basic-PyTorch-Py38-Spark3:
+    # if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-PyTorch-Py38-Spark3' || github.event.inputs.artifact == 'all' }} 
+    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py38-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-basic-pytorch-py38-spark3-action/nightly-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py38
+    - name: Create Job Badge
+      uses: ./.github/actions/create-job-status-badge
+      if: ${{ always() }}
+      with:
+        secret: ${{ secrets.GIST_SECRET}}
+        gist-id: ${{env.GIST_ID}}
+        is-self-hosted-runner: true
+        file-name: Orca-Basic-PyTorch-Py38-Spark3.json
+        type: job
+        job-name: Orca-Basic-PyTorch-Py38-Spark3
+        runner-hosted-on: 'Shanghai'
+
+  Orca-Basic-Tf2-Py38-Spark3:
+    # if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Tf2-Py38-Spark3' || github.event.inputs.artifact == 'all' }} 
+    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py38-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-basic-tf2-py38-spark3-action/nightly-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py38
+    - name: Create Job Badge
+      uses: ./.github/actions/create-job-status-badge
+      if: ${{ always() }}
+      with:
+        secret: ${{ secrets.GIST_SECRET}}
+        gist-id: ${{env.GIST_ID}}
+        is-self-hosted-runner: true
+        file-name: Orca-Basic-Tf2-Py38-Spark3.json
+        type: job
+        job-name: Orca-Basic-Tf2-Py38-Spark3
         runner-hosted-on: 'Shanghai'
 
   Orca-ExampleTest-Tf1-Py37-Spark3:

--- a/python/orca/test/bigdl/orca/learn/test_pytorch_basic.py
+++ b/python/orca/test/bigdl/orca/learn/test_pytorch_basic.py
@@ -285,7 +285,7 @@ class TestPyTorchEstimatorBasic(TestCase):
         sc = init_nncontext()
         spark = SparkSession.builder.getOrCreate()
         rdd = sc.range(0, 100)
-        data = rdd.map(lambda x: (np.random.randn(50).astype(np.float).tolist(),
+        data = rdd.map(lambda x: (np.random.randn(50).astype(np.float32).tolist(),
                                   [float(np.random.randint(0, 2, size=()))])
                        )
         schema = StructType([
@@ -309,7 +309,7 @@ class TestPyTorchEstimatorBasic(TestCase):
         sc = init_nncontext()
         spark = SparkSession.builder.getOrCreate()
         rdd = sc.range(200, numSlices=1)
-        data = rdd.map(lambda x: (np.random.randn(50).astype(np.float).tolist(),
+        data = rdd.map(lambda x: (np.random.randn(50).astype(np.float32).tolist(),
                                   [float(np.random.randint(0, 2, size=()))])
                        )
         schema = StructType([
@@ -533,7 +533,7 @@ class TestPyTorchEstimatorBasic(TestCase):
         spark = SparkSession.builder.getOrCreate()
         rdd = sc.range(0, 100)
         epochs = 2
-        data = rdd.map(lambda x: (np.random.randn(50).astype(np.float).tolist(),
+        data = rdd.map(lambda x: (np.random.randn(50).astype(np.float32).tolist(),
                                   [float(np.random.randint(0, 2, size=()))])
                        )
         schema = StructType([
@@ -579,7 +579,7 @@ class TestPyTorchEstimatorBasic(TestCase):
         spark = SparkSession.builder.getOrCreate()
         rdd = sc.range(0, 100)
         epochs = 2
-        data = rdd.map(lambda x: (np.random.randn(50).astype(np.float).tolist(),
+        data = rdd.map(lambda x: (np.random.randn(50).astype(np.float32).tolist(),
                                   [float(np.random.randint(0, 2, size=()))])
                        )
         schema = StructType([

--- a/python/orca/test/bigdl/orca/learn/test_tf2_basic.py
+++ b/python/orca/test/bigdl/orca/learn/test_tf2_basic.py
@@ -75,7 +75,7 @@ class TestTFEstimatorBasic(TestCase):
         spark = OrcaContext.get_spark_session()
 
         from pyspark.ml.linalg import DenseVector
-        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float)),
+        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
                                 int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
 
         config = {
@@ -118,7 +118,7 @@ class TestTFEstimatorBasic(TestCase):
         spark = OrcaContext.get_spark_session()
 
         from pyspark.ml.linalg import DenseVector
-        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float)),
+        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
                                 int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
 
         config = {
@@ -164,11 +164,11 @@ class TestTFEstimatorBasic(TestCase):
         spark = OrcaContext.get_spark_session()
 
         from pyspark.ml.linalg import DenseVector
-        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float)),
+        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
                                 int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
 
         val_rdd = sc.range(0, 20, numSlices=6)
-        val_df = val_rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float)),
+        val_df = val_rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
                                 int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
 
         config = {
@@ -206,11 +206,11 @@ class TestTFEstimatorBasic(TestCase):
         spark = OrcaContext.get_spark_session()
 
         from pyspark.ml.linalg import DenseVector
-        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float)),
+        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
                                 int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
 
         val_rdd = sc.range(0, 20, numSlices=6)
-        val_df = val_rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float)),
+        val_df = val_rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
                                 int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
 
         config = {
@@ -244,7 +244,7 @@ class TestTFEstimatorBasic(TestCase):
         spark = OrcaContext.get_spark_session()
 
         from pyspark.ml.linalg import DenseVector
-        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float)),
+        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
                                 int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
 
         config = {
@@ -304,7 +304,7 @@ class TestTFEstimatorBasic(TestCase):
         spark = OrcaContext.get_spark_session()
 
         from pyspark.ml.linalg import DenseVector
-        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float)),
+        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
                                 int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
 
         config = {

--- a/python/orca/test/bigdl/orca/tfpark/test_tf_dataset.py
+++ b/python/orca/test/bigdl/orca/tfpark/test_tf_dataset.py
@@ -325,7 +325,7 @@ class TestTFDataset(ZooTestCase):
         dataset = tf.data.Dataset.from_tensor_slices((np.random.randn(102, 28, 28, 1),
                                                       np.random.randint(0, 10, size=(102,)),
                                                       np.ones(shape=(102, 28, 28, 1),
-                                                              dtype=np.bool)))
+                                                              dtype=bool)))
         dataset = TFDataset.from_tf_data_dataset(dataset, batch_size=16)
 
         feature, labels, mask = dataset.tensors
@@ -401,7 +401,7 @@ class TestTFDataset(ZooTestCase):
     def test_tfdataset_with_dataframe(self):
 
         rdd = self.sc.range(0, 1000)
-        df = rdd.map(lambda x: (DenseVector(np.random.rand(20).astype(np.float)),
+        df = rdd.map(lambda x: (DenseVector(np.random.rand(20).astype(np.float32)),
                                 x % 10)).toDF(["feature", "label"])
         train_df, val_df = df.randomSplit([0.7, 0.3])
 


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->


### 1. How to test?

PR-test:
- [x] Orca-Basic-Py38-Spark3
- [x] Orca-Basic-Pytorch-Py38-Spark3
- [x] Orca-Basic-Tf2-Py38-Spark3

Nightly-test:
- [x] Orca-Basic-Py38-Spark3
- [x] Orca-Basic-Pytorch-Py38-Spark3
- [x] Orca-Basic-Tf2-Py38-Spark3

### 2. Summary of the change
+ add 3 pr-tests and 3 nightly-tests
+ fix type deperecations: `np.float` -> `np.float32`

Now, all the uts are supporting np 1.24.