### PR TITLE
Nano: fix tf bf16 conversion for functional API model with Conv2DTranspose layer

### DIFF
--- a/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
@@ -33,6 +33,7 @@ def BF16Model(model):
         # save or load operation may fail
         with TemporaryDirectory() as temp_dir:
             model.save(temp_dir)
+            # todo: fix loading custom object
             bf16_model = tf.keras.models.load_model(temp_dir)
     except Exception as _e:
         # if a functional model failed to save or load, try `from_config`

--- a/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/tf/keras/amp/bfloat16.py
@@ -13,25 +13,41 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-from tensorflow.keras import mixed_precision
+
 from tempfile import TemporaryDirectory
+
 import tensorflow as tf
+from tensorflow.keras import mixed_precision
+
+from bigdl.nano.utils.common import invalidInputError
+from bigdl.nano.utils.tf import patch_compiled
 
 
 def BF16Model(model):
-    original_model_policies = []
+    original_policies = []
     policy_bf16 = mixed_precision.Policy('mixed_bfloat16')
     for layer in model.layers:
-        original_model_policies.append(layer._dtype_policy)
-        layer._dtype_policy = policy_bf16
+        original_policies.append(layer._dtype_policy)
+        layer._set_dtype_policy(policy_bf16)
     try:
-        # save operation may fail
+        # save or load operation may fail
         with TemporaryDirectory() as temp_dir:
             model.save(temp_dir)
             bf16_model = tf.keras.models.load_model(temp_dir)
+    except Exception as _e:
+        # if a functional model failed to save or load, try `from_config`
+        if hasattr(model, "input_shape"):
+            config = model.get_config()
+            bf16_model = tf.keras.Model.from_config(config)
+            with TemporaryDirectory() as temp_dir:
+                model.save_weights(temp_dir)
+                bf16_model.load_weights(temp_dir)
+            patch_compiled(bf16_model, model)
+        else:
+            invalidInputError(False, "Failed to convert model to bfloat16 dtype.")
     finally:
-        for idx, layer in enumerate(model.layers):
-            layer._dtype_policy = original_model_policies[idx]
+        for policy, layer in zip(original_policies, model.layers):
+            layer._set_dtype_policy(policy)
     return bf16_model
 
 


### PR DESCRIPTION
## Description

Fix tf bf16 conversion for functional API model with Conv2DTranspose layer. i.e. issue 1 in <https://github.com/analytics-zoo/nano/issues/318>

### 1. Why the change?

Model with Conv2DTranspose layer cannot be saved after modifying its dtype policy,
and model with custom object cannot be simply loaded by current code

### 2. User API changes

N/A

### 3. Summary of the change 

If save or load failed, use `from_config` to create bf16 model.

### 4. How to test?
- [ ] Unit test

