### PR TITLE
Nano: support tf onnx passing kwargs

### DIFF
--- a/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/tensorflow/model.py
@@ -17,7 +17,7 @@ import os
 import pickle
 import yaml
 from pathlib import Path
-from typing import Sequence, Any
+from typing import Sequence, Any, Union, Dict
 
 from neural_compressor.model.model import TensorflowModel
 
@@ -37,10 +37,10 @@ class KerasQuantizedModel(KerasOptimizedModel):
         self._output = model.output_tensor
         self._sess = model.sess
 
-    def preprocess(self, inputs: Sequence[Any]):
-        return convert_all(inputs, "numpy")
+    def preprocess(self, args: Sequence[Any], kwargs: Dict[str, Any]):
+        return convert_all(args, "numpy")
 
-    def forward(self, inputs: Sequence[Any]):
+    def forward(self, inputs: Union[Sequence[Any], Dict[str, Any]]):
         input_dict = dict(zip(self._input, inputs))
         outputs = self._sess.run(self._output, feed_dict=input_dict)
         return outputs

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/tensorflow/model.py
@@ -18,11 +18,9 @@
 import os
 import pickle
 from pathlib import Path
-from typing import Sequence, Any
+from typing import Sequence, Any, Union, Dict
 from tempfile import TemporaryDirectory
 import tensorflow as tf
-from bigdl.nano.utils.common import get_default_args
-from bigdl.nano.utils.tf import KERAS_VERSION_LESS_2_10
 from bigdl.nano.utils.tf import convert_all
 from bigdl.nano.tf.model import KerasOptimizedModel
 from bigdl.nano.utils.common import invalidInputError
@@ -54,39 +52,45 @@ class KerasONNXRuntimeModel(ONNXRuntimeModel, KerasOptimizedModel):
         KerasOptimizedModel.__init__(self)
         with TemporaryDirectory() as tmpdir:
             if isinstance(model, tf.keras.Model):
-                if input_spec is not None:
-                    input_spec = input_spec
-                elif hasattr(model, "input_shape"):
+                invalidInputError(hasattr(model, "input_shape") or input_spec is not None,
+                                  "Subclassed model must specify `input_spec` parameter.")
+                self._mode = "arg"
+                if input_spec is None:
                     input_spec = tf.TensorSpec(model.input_shape, model.dtype)
-                else:
-                    invalidInputError(False,
-                                      "Subclassed model must specify `input_spec` parameter.")
-
-                if not isinstance(input_spec, (tuple, list)):
-                    # ONNX requires that `input_spec` must be a tuple or list
+                elif isinstance(input_spec, dict):
+                    input_spec = [tf.TensorSpec.from_spec(spec, name=name)
+                                  for name, spec in input_spec.items()]
+                    self._mode = "kwarg"
+                if isinstance(input_spec, tf.TensorSpec):
                     input_spec = (input_spec, )
+
+                if self._mode == "arg":
+                    self._inputs_dtypes = [spec.dtype.as_numpy_dtype for spec in input_spec]
+                else:
+                    self._inputs_dtypes = {spec.name: spec.dtype.as_numpy_dtype
+                                           for spec in input_spec}
+
                 onnx_path = os.path.join(tmpdir, "tmp.onnx")
                 tf2onnx.convert.from_keras(model, input_signature=input_spec,
                                            output_path=onnx_path, **export_kwargs)
-                self._inputs_dtypes = [inp.dtype.as_numpy_dtype for inp in input_spec]
-                self._default_kwargs = get_default_args(model.call)
-                if KERAS_VERSION_LESS_2_10:
-                    self._call_fn_args_backup = model._call_fn_args
-                else:
-                    from keras.utils import tf_inspect
-                    self._call_fn_args_backup = tf_inspect.getargspec(model.call).args[1:]
+
             else:
                 onnx_path = model
             ONNXRuntimeModel.__init__(self, onnx_path, session_options=onnxruntime_session_options)
 
-    def preprocess(self, inputs: Sequence[Any]):
+    def preprocess(self, args: Sequence[Any], kwargs: Dict[str, Any]):
         invalidInputError(self.ortsess is not None,
                           "Please create an instance by InferenceOptimizer.trace()")
+        # todo: add argument check
+        inputs = args if self._mode == "arg" else kwargs
         inputs = convert_all(inputs, "numpy", self._inputs_dtypes)
         return inputs
 
-    def forward(self, inputs: Sequence[Any]):
-        return self.forward_step(*inputs)
+    def forward(self, inputs: Union[Sequence[Any], Dict[str, Any]]):
+        if isinstance(inputs, Sequence):
+            return self.forward_step(*inputs)
+        else:
+            return self.ortsess.run(None, inputs)
 
     def postprocess(self, outputs: Sequence[Any]):
         outputs = convert_all(outputs, types="tf", dtypes=tf.float32)
@@ -144,8 +148,7 @@ class KerasONNXRuntimeModel(ONNXRuntimeModel, KerasOptimizedModel):
 
         super()._save_model(path / self.status['onnx_path'])
 
-        attrs = {"_default_kwargs": self._default_kwargs,
-                 "_call_fn_args_backup": self._call_fn_args_backup,
+        attrs = {"_mode": self._mode,
                  "_inputs_dtypes": self._inputs_dtypes}
         with open(path / self.status['attr_path'], "wb") as f:
             pickle.dump(attrs, f)

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -17,7 +17,7 @@
 import os
 import pickle
 from pathlib import Path
-from typing import Sequence, Any
+from typing import Sequence, Any, Union, Dict
 from tempfile import TemporaryDirectory
 
 import numpy as np
@@ -75,14 +75,14 @@ class KerasOpenVINOModel(KerasOptimizedModel):
                                           thread_num=thread_num,
                                           config=config)
 
-    def preprocess(self, inputs: Sequence[Any]):
+    def preprocess(self, args: Sequence[Any], kwargs: Dict[str, Any]):
         self.ov_model._model_exists_or_err()
         # todo: We should perform dtype conversion based on the
         # dtype of the arguments that the model expects
-        inputs = convert_all(inputs, types="numpy", dtypes=np.float32)
+        inputs = convert_all(args, types="numpy", dtypes=np.float32)
         return inputs
 
-    def forward(self, inputs: Sequence[Any]):
+    def forward(self, inputs: Union[Sequence[Any], Dict[str, Any]]):
         return self.ov_model.forward_step(*inputs)
 
     def postprocess(self, outputs: Sequence[Any]):

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -738,6 +738,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                   onnx_option='tensorflow',
                                   onnxruntime_session_options=onnxruntime_session_options)
             result._inputs_dtypes = onnx_model._inputs_dtypes
+            result._mode = "arg"    # todo
         else:
             invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
         return patch_compiled_and_attrs(result, original_model)

--- a/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/tf/keras/inference/optimizer.py
@@ -738,8 +738,6 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                   onnx_option='tensorflow',
                                   onnxruntime_session_options=onnxruntime_session_options)
             result._inputs_dtypes = onnx_model._inputs_dtypes
-            result._default_kwargs = onnx_model._default_kwargs
-            result._call_fn_args_backup = onnx_model._call_fn_args_backup
         else:
             invalidInputError(False, "Accelerator {} is invalid.".format(accelerator))
         return patch_compiled_and_attrs(result, original_model)

--- a/python/nano/src/bigdl/nano/tf/model.py
+++ b/python/nano/src/bigdl/nano/tf/model.py
@@ -16,7 +16,7 @@
 
 
 from pathlib import Path
-from typing import Sequence, Any
+from typing import Sequence, Any, Union, Dict
 
 import yaml
 import tensorflow as tf
@@ -27,13 +27,10 @@ from bigdl.nano.utils.common import invalidInputError
 class KerasOptimizedModel(tf.keras.Model):
     """A base class for keras optimized model."""
 
-    def __call__(self, *inputs, **kwargs):
+    def __call__(self, *args, **kwargs):
         """Run inference, automatically perform type and dtype conversion."""
-        # todo: we should parse the `kwargs` and add it into `inputs`
-        for k in kwargs.keys():
-            invalidInputError(k == 'training',
-                              "Now we do not support passing arguments with `key=value` format")
-        inputs = self.preprocess(inputs)
+        kwargs.pop("training", None)
+        inputs = self.preprocess(args, kwargs)
         outputs = self.forward(inputs)
         outputs = self.postprocess(outputs)
         return outputs
@@ -42,13 +39,13 @@ class KerasOptimizedModel(tf.keras.Model):
         """The same as __call__."""
         return self(*args, **kwargs)
 
-    def preprocess(self, inputs: Sequence[Any]):
+    def preprocess(self, args: Sequence[Any], kwargs: Dict[str, Any]):
         """Preprocess inputs, such as convert inputs to numpy ndarray."""
-        return inputs
+        invalidInputError(False, "preprocess function is not implemented.")
 
-    def forward(self, inputs: Sequence[Any]):
+    def forward(self, inputs: Union[Sequence[Any], Dict[str, Any]]):
         """Run inference."""
-        return self.model(*inputs)
+        invalidInputError(False, "forward function is not implemented.")
 
     def postprocess(self, outputs: Sequence[Any]):
         """Postprocess outputs, such as convert outputs to tensorflow Tensor."""


### PR DESCRIPTION
## Description

support tf onnx passing kwargs

### 1. Why the change?

For cases like bert, we should support passing arguments with format like `arg=arg`.

### 2. User API changes

For bert, we can optimize it and run inference like this:
```python
model = InferenceOptimizer.trace(model,
                                 input_spec={
                                     "input_ids": tf.TensorSpec(shape=(None, None), dtype=tf.int32),
                                     "token_type_ids": tf.TensorSpec(shape=(None, None), dtype=tf.int32),
                                     "attention_mask": tf.TensorSpec(shape=(None, None), dtype=tf.int32),
                                 },
                                 accelerator="onnxruntime"
                                )
output = model(attention_mask=inputs["attention_mask"], input_ids=inputs["input_ids"], token_type_ids=inputs["token_type_ids"])
start_scores, end_scores = output[1], output[0]
```

### 3. Summary of the change 

support tf onnx passing kwargs

### 4. How to test?
- [x] manual test