### PR TITLE
Nano: how-to for HPO TensorFlow

### DIFF
--- a/docs/readthedocs/source/_toc.yml
+++ b/docs/readthedocs/source/_toc.yml
@@ -177,6 +177,10 @@ subtrees:
                               - file: doc/Nano/Howto/Inference/TensorFlow/tensorflow_inference_bf16
                               - file: doc/Nano/Howto/Inference/TensorFlow/tensorflow_save_and_load_onnx
                               - file: doc/Nano/Howto/Inference/TensorFlow/tensorflow_save_and_load_openvino
+                  - file: doc/Nano/Howto/hpo/index
+                    subtrees:
+                      - entries:
+                        - file: doc/Nano/Howto/hpo/use_hpo_tune_hyperparameters_tensorflow
                   - file: doc/Nano/Howto/Install/index
                     subtrees:
                       - entries:

--- a/docs/readthedocs/source/doc/Nano/Howto/hpo/index.rst
+++ b/docs/readthedocs/source/doc/Nano/Howto/hpo/index.rst
@@ -1,0 +1,4 @@
+Hyper-Parameter Optimization
+=========================
+
+* `How to search the best hyper-parameters for TensorFlow models via Nano HPO <use_hpo_tune_hyperparameters_tensorflow.html>`_

--- a/docs/readthedocs/source/doc/Nano/Howto/hpo/use_hpo_tune_hyperparameters_tensorflow.nblink
+++ b/docs/readthedocs/source/doc/Nano/Howto/hpo/use_hpo_tune_hyperparameters_tensorflow.nblink
@@ -1,0 +1,3 @@
+{
+    "path": "../../../../../../../python/nano/tutorial/notebook/hpo/use_hpo_tune_hyperparameters_tensorflow.ipynb"
+}

--- a/docs/readthedocs/source/doc/Nano/Howto/index.rst
+++ b/docs/readthedocs/source/doc/Nano/Howto/index.rst
@@ -84,6 +84,10 @@ TensorFlow
 * `How to save and load optimized ONNXRuntime model in TensorFlow <Inference/TensorFlow/tensorflow_save_and_load_onnx.html>`_
 * `How to save and load optimized OpenVINO model in TensorFlow <Inference/TensorFlow/tensorflow_save_and_load_openvino.html>`_
 
+AutoML
+-------------------------
+* `How to search the best hyper-parameters for TensorFlow models via Nano HPO <hpo/use_hpo_tune_hyperparameters_tensorflow.html>`_
+
 Install
 -------------------------
 * `How to install BigDL-Nano in Google Colab <Install/install_in_colab.html>`_

--- a/docs/readthedocs/source/doc/Nano/Overview/hpo.rst
+++ b/docs/readthedocs/source/doc/Nano/Overview/hpo.rst
@@ -25,7 +25,7 @@ Next, install a few dependencies required for Nano HPO using below commands.
 Search Spaces
 =============
 
-Search spaces are value range specifications that the search engine uses for sampling hyperparameters. The available search spaces in Nano HPO is defined in ``bigdl.nano.automl.hpo.space``. Refer to [Search Space API doc]() for more details.
+Search spaces are value range specifications that the search engine uses for sampling hyperparameters. The available search spaces in Nano HPO is defined in ``bigdl.nano.automl.hpo.space``. Refer to [Search Space API doc](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/hpo_api.html#search-space) for more details.
 
 
 
@@ -176,11 +176,11 @@ To search the batch size, specify search space in ``batch_size`` argument in ``m
 Launch Hyperparameter Search and Review the Results
 ----------------------------------------------------
 
-To launch hyperparameter search, call ``model.search`` after compile, as shown below. ``model.search`` runs the ``n_trials`` number of trials (meaning ``n_trials`` set of hyperparameter combinations are searched), and optimizes the ``target_metric`` in the specified ``direction``. Besides search arguments, you also need to specify fit arguments in ``model.search`` which will be used in the fitting process in each trial. Refer to [API docs]() for details.
+To launch hyperparameter search, call ``model.search`` after compile, as shown below. ``model.search`` runs the ``n_trials`` number of trials (meaning ``n_trials`` set of hyperparameter combinations are searched), and optimizes the ``target_metric`` in the specified ``direction``. Besides search arguments, you also need to specify fit arguments in ``model.search`` which will be used in the fitting process in each trial. Refer to [API docs](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/hpo_api.html#bigdl.nano.automl.tf.keras.Model.search) for details.
 
-Call ``model.search_summary`` to retrieve the search results, which you can use to get all trial statistics in pandas dataframe format, pick the best trial, or do visualizations.  Examples of search results analysis and visualization can be found [here](#analysis-and-visualization).
+Call ``model.search_summary`` to retrieve the search results, which you can use to get all trial statistics in pandas dataframe format, pick the best trial, or do visualizations.  Examples of search results analysis and visualization can be found [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/hpo.html#analysis-and-visualization).
 
-Finally, ``model.fit`` will automatically fit the model using the best set of hyper parameters found in the search. You can also use the hyperparameters from a particular trial other than the best one. Refer to [API docs]() for details.
+Finally, ``model.fit`` will automatically fit the model using the best set of hyper parameters found in the search. You can also use the hyperparameters from a particular trial other than the best one. Refer to [API docs](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/tensorflow.html#bigdl.nano.tf.keras.Model.fit) for details.
 
 .. code-block:: python
     :linenos:
@@ -199,7 +199,7 @@ For PyTorch Users
 ==================
 
 
-Nano-HPO now only supports hyperparameter search for [pytorch-lightning]() modules.
+Nano-HPO now only supports hyperparameter search for [pytorch-lightning](https://github.com/Lightning-AI/lightning) modules.
 
 
 Search the Model Architecture
@@ -291,9 +291,9 @@ First of all, import ``Trainer`` from ``bigdl.nano.pytorch`` instead of ``pytorc
 
 To launch hyperparameter search, call ``Trainer.search`` after model is defined. ``Trainer.search`` takes the decorated model as input. Similar to tensorflow, ``trainer.search`` runs the ``n_trials`` number of trials (meaning ``n_trials`` set of hyperparameter combinations are searched), and optimizes the ``target_metric`` in the specified ``direction``. There's an extra argument ``max_epochs`` which is used only in the fitting process in search trials without affecting ``Trainer.fit``. ``Trainer.search`` returns a model configured with the best set of hyper parameters.
 
-Call ``Trainer.search_summary`` to retrieve the search results, which you can use to get all trial statistics in pandas dataframe format, pick the best trial, or do visualizations.  Examples of search results analysis and visualization can be found [here](#analysis-and-visualization).
+Call ``Trainer.search_summary`` to retrieve the search results, which you can use to get all trial statistics in pandas dataframe format, pick the best trial, or do visualizations.  Examples of search results analysis and visualization can be found [here](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/hpo.html#analysis-and-visualization).
 
-Finally you can use ``Trainer.fit()`` to fit the best model. You can also get a model constructed with hyperparameters from a particular trial other than the best one. Refer to [Trainer.search API doc]() for more details.
+Finally you can use ``Trainer.fit()`` to fit the best model. You can also get a model constructed with hyperparameters from a particular trial other than the best one. Refer to [Trainer.search API doc](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/hpo_api.html#bigdl.nano.pytorch.Trainer.search) for more details.
 
 .. code-block:: python
     :linenos:

--- a/docs/readthedocs/source/doc/Nano/Overview/hpo.rst
+++ b/docs/readthedocs/source/doc/Nano/Overview/hpo.rst
@@ -25,7 +25,7 @@ Next, install a few dependencies required for Nano HPO using below commands.
 Search Spaces
 =============
 
-Search spaces are value range specifications that the search engine uses for sampling hyperparameters. The available search spaces in Nano HPO is defined in ``bigdl.nano.automl.hpo.space``. Refer to [Search Space API doc](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/hpo_api.html#search-space) for more details.
+Search spaces are value range specifications that the search engine uses for sampling hyperparameters. The available search spaces in Nano HPO is defined in ``bigdl.nano.automl.hpo.space``. Refer to `Search Space API doc<https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/hpo_api.html#search-space>`_ for more details.
 
 
 

--- a/docs/readthedocs/source/doc/Nano/Overview/hpo.rst
+++ b/docs/readthedocs/source/doc/Nano/Overview/hpo.rst
@@ -25,7 +25,7 @@ Next, install a few dependencies required for Nano HPO using below commands.
 Search Spaces
 =============
 
-Search spaces are value range specifications that the search engine uses for sampling hyperparameters. The available search spaces in Nano HPO is defined in ``bigdl.nano.automl.hpo.space``. Refer to `Search Space API doc<https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/hpo_api.html#search-space>`_ for more details.
+Search spaces are value range specifications that the search engine uses for sampling hyperparameters. The available search spaces in Nano HPO is defined in ``bigdl.nano.automl.hpo.space``. Refer to `Search Space API doc <https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/hpo_api.html#search-space>`_ for more details.
 
 
 

--- a/python/nano/src/bigdl/nano/tf/keras/training_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/training_utils.py
@@ -52,7 +52,7 @@ class TrainingUtils:
         Override tf.keras.Model.fit to add more parameters.
 
         All arguments that already exists in tf.keras.Model.fit has the same sementics with
-        tf.keras.Model.fit.
+        tf.keras.Model.fit(https://www.tensorflow.org/api_docs/python/tf/keras/Model#fit).
 
         Additional parameters:
 

--- a/python/nano/tutorial/hpo/notebook/use_hpo_tune_hyperparameters_tensorflow.ipynb
+++ b/python/nano/tutorial/hpo/notebook/use_hpo_tune_hyperparameters_tensorflow.ipynb
@@ -1,0 +1,88 @@
+{
+  "cells": [
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/hpo/notebook/use_hpo_tune_hyperparameters_tensorflow.ipynb)"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Use Nano HPO to tune the hyper-parameters in TensorFlow training"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "You can use Nano HPO (Hyper-Parameter Optimization) to "
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {
+        "nbsphinx": "hidden"
+      },
+      "source": [
+        "To apply JIT/IPEX acceleration, you should install BigDL-Nano for PyTorch first："
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {
+        "nbsphinx": "hidden"
+      },
+      "outputs": [],
+      "source": [
+        "!pip install --pre --upgrade bigdl-nano[pytorch] # install the nightly-built version\n",
+        "!source bigdl-nano-init"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {
+        "nbsphinx": "hidden"
+      },
+      "source": [
+        "> 📝 **Note**\n",
+        ">\n",
+        "> We recommend to run the commands above, especially `source bigdl-nano-init` before jupyter kernel is started, or some of the optimizations may not take effect."
+      ]
+    }
+  ],
+  "metadata": {
+    "kernelspec": {
+      "display_name": "nano-pytorch",
+      "language": "python",
+      "name": "python3"
+    },
+    "language_info": {
+      "codemirror_mode": {
+        "name": "ipython",
+        "version": 3
+      },
+      "file_extension": ".py",
+      "mimetype": "text/x-python",
+      "name": "python",
+      "nbconvert_exporter": "python",
+      "pygments_lexer": "ipython3",
+      "version": "3.7.15 (default, Nov 24 2022, 21:12:53) \n[GCC 11.2.0]"
+    },
+    "orig_nbformat": 4,
+    "vscode": {
+      "interpreter": {
+        "hash": "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1"
+      }
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 2
+}

--- a/python/nano/tutorial/hpo/notebook/use_hpo_tune_hyperparameters_tensorflow.ipynb
+++ b/python/nano/tutorial/hpo/notebook/use_hpo_tune_hyperparameters_tensorflow.ipynb
@@ -13,7 +13,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "# Use Nano HPO to tune the hyper-parameters in TensorFlow training"
+        "# Use Nano HPO to Tune the Hyper-Parameters in TensorFlow Training"
       ]
     },
     {
@@ -21,7 +21,15 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "You can use Nano HPO (Hyper-Parameter Optimization) to "
+        "With the help of Nano HPO (Hyper-Parameter Optimization), you can search the model architecture (layer, activation, etc.) and training procedure (learning rate, batch size) simply by specifying their search spaces. Specifically, search spaces refer to value range specifications that the search engine uses for sampling hyper-parameters. You can use `model.search()` to launch search trials, and `model.search_summary()` to review the search results."
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Prepare the environment and datasets"
       ]
     },
     {
@@ -31,7 +39,7 @@
         "nbsphinx": "hidden"
       },
       "source": [
-        "To apply JIT/IPEX acceleration, you should install BigDL-Nano for PyTorch first："
+        "To apply Nano HPO, you should install BigDL-Nano for TensorFlow and its dependencies first："
       ]
     },
     {
@@ -42,7 +50,7 @@
       },
       "outputs": [],
       "source": [
-        "!pip install --pre --upgrade bigdl-nano[pytorch] # install the nightly-built version\n",
+        "!pip install --pre --upgrade bigdl-nano[tensorflow] # install the nightly-built version\n",
         "!source bigdl-nano-init"
       ]
     },
@@ -56,11 +64,609 @@
         ">\n",
         "> We recommend to run the commands above, especially `source bigdl-nano-init` before jupyter kernel is started, or some of the optimizations may not take effect."
       ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# install dependencies\n",
+        "!pip install pandas\n",
+        "!pip install ConfigSpace\n",
+        "!pip install optuna"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We need to enable Nano HPO before tensorflow training."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import bigdl.nano.automl as nano_automl\n",
+        "nano_automl.hpo_config.enable_hpo_tf()"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> 📝 **Note**\n",
+        ">\n",
+        "> To disable HPO, you can call `nano_automl.hpo_config.disable_hpo_tf()` similarly. This will remove the searchable objects from `bigdl.nano.tf` module."
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Taking the tuning of a simple CNN on the MINST dataset as an example. We first prepare the datasets for training and testing."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from tensorflow import keras\n",
+        "\n",
+        "(x_train, y_train), (x_test, y_test) = keras.datasets.mnist.load_data()\n",
+        "\n",
+        "CLASSES = 10\n",
+        "img_x, img_y = x_train.shape[1], x_train.shape[2]\n",
+        "input_shape = (img_x, img_y, 1)\n",
+        "x_train = x_train.reshape(-1, img_x, img_y,1).astype(\"float32\") / 255\n",
+        "x_test = x_test.reshape(-1, img_x, img_y,1).astype(\"float32\") / 255"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Build a searchable model"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We support three different ways to exploit existing models or create new ones, i.e., using either TensorFlow `Sequential` or `Functional` API, or subclassing `tensorflow.keras.Model`. You can choose an appropriate approach depending on your (preferred) code structure."
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Option 1. Define a searchable model using `Sequential` API"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Nano HPO provides the same `Sequential` model creation like native TensorFlow do. Therefore, you can easily define your `Sequential`-like model while specifying the search space for each component. Before achieving this, you should change the imports from `tensorflow.keras` to `bigdl.nano` as below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from bigdl.nano.automl.tf.keras import Sequential\n",
+        "from bigdl.nano.tf.keras.layers import Dense, Flatten, Conv2D\n",
+        "import bigdl.nano.automl.hpo.space as space"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "In this example, we can assign the search spaces for `filters`, `kernel_size`, `strides`, `activation` (all are categorical with two choices) of a `Conv2D` layer."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "model = Sequential()\n",
+        "model.add(Conv2D(\n",
+        "    filters=space.Categorical(32, 64),\n",
+        "    kernel_size=space.Categorical(3, 5),\n",
+        "    strides=space.Categorical(1, 2),\n",
+        "    activation=space.Categorical(\"relu\", \"linear\"),\n",
+        "    input_shape=input_shape))\n",
+        "model.add(Flatten())\n",
+        "model.add(Dense(CLASSES, activation=\"softmax\"))"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> 📝 **Note**\n",
+        ">\n",
+        "> In general, Nano supports four kinds of parameter types in `bigdl.nano.automl.hpo.space`, which are `Categorical(*data, prefix=None)`, `Real(lower, upper, default=None, log=False, prefix=None)`, `Int(lower, upper, default=None, prefix=None)` and `Bool(default=None, prefix=None)`. For their detailed usage, you can refer to the [corresponding API doc](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/hpo_api.html#search-space).\n",
+        "> \n",
+        "> Note that search spaces can only be specified in key-word argument (which means `Dense(space.Int(...))` should be changed to `Dense(units=space.Int(...))`). "
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Option 2. Define a searchable model using `Functional` API"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Nano HPO provides the same `Functional` model creation like native TensorFlow do. Therefore, you can easily define your `Functional`-like model while specifying the search space for each component. Before achieving this, you should change the imports from `tensorflow.keras` to `bigdl.nano` as below."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from bigdl.nano.tf.keras.layers import Dense, Flatten, Conv2D\n",
+        "from bigdl.nano.tf.keras import Input\n",
+        "from bigdl.nano.automl.tf.keras import Model\n",
+        "import bigdl.nano.automl.hpo.space as space"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "In this example, we can assign the search spaces for `filters`, `kernel_size`, `strides`, `activation` (all are categorical with two choices) of a `Conv2D` layer."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "inputs = Input(shape=(28,28,1))\n",
+        "x = Conv2D(\n",
+        "    filters=space.Categorical(32, 64),\n",
+        "    kernel_size=space.Categorical(3, 5),\n",
+        "    strides=space.Categorical(1, 2),\n",
+        "    activation=space.Categorical(\"relu\", \"linear\"),\n",
+        "    input_shape=input_shape)(inputs)\n",
+        "x = Flatten()(x)\n",
+        "outputs = Dense(CLASSES, activation=\"softmax\")(x)\n",
+        "model = Model(inputs=inputs, outputs=outputs, name=\"mnist_model\")"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> 📝 **Note**\n",
+        ">\n",
+        "> In general, Nano supports four kinds of parameter types in `bigdl.nano.automl.hpo.space`, which are `Categorical(*data, prefix=None)`, `Real(lower, upper, default=None, log=False, prefix=None)`, `Int(lower, upper, default=None, prefix=None)` and `Bool(default=None, prefix=None)`. For their detailed usage, you can refer to the [corresponding API doc](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/hpo_api.html#search-space).\n",
+        "> \n",
+        "> Note that if a layer is used more than once in the model, we strongly suggest you assign a `prefix` for each search space in such layer to distinguish them, or they will share the same search space (the last space will override all previous definition)."
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Option 3. Define a searchable model by subclassing `tensorflow.keras.Model`"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "You can transfer a model that subclasses `tf.keras.Model` to a searchable object flexibly via `@hpo.tfmodel` decorator. Then you will able to specify either search spaces or normal values in the model init arguments.\n",
+        "\n",
+        "In this example, we can assign the search spaces for `filters`, `kernel_size`, `strides`, `activation` (all are categorical with two choices) of a `Conv2D` layer."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "import bigdl.nano.automl.hpo as hpo\n",
+        "import tensorflow as tf\n",
+        "from tensorflow.keras.layers import Conv2D, Dropout, MaxPooling2D\n",
+        "from tensorflow.keras.layers import Dense\n",
+        "from tensorflow.keras.layers import Flatten\n",
+        "\n",
+        "@hpo.tfmodel()\n",
+        "class MyModel(tf.keras.Model):\n",
+        "\n",
+        "    def __init__(self, filters, kernel_size, strides, activation):\n",
+        "        super().__init__()\n",
+        "        self.conv1 = Conv2D(\n",
+        "            filters=filters,\n",
+        "            kernel_size=kernel_size,\n",
+        "            strides=strides,\n",
+        "            activation=activation)\n",
+        "        self.pool1 = MaxPooling2D(pool_size=2)\n",
+        "        self.drop1 = Dropout(0.3)\n",
+        "        self.flat = Flatten()\n",
+        "        self.dense1 = Dense(256, activation='relu')\n",
+        "        self.drop3 = Dropout(0.5)\n",
+        "        self.dense2 = Dense(CLASSES, activation=\"softmax\")\n",
+        "\n",
+        "    def call(self, inputs):\n",
+        "        x = self.conv1(inputs)\n",
+        "        x = self.pool1(x)\n",
+        "        x = self.drop1(x)\n",
+        "        x = self.flat(x)\n",
+        "        x = self.dense1(x)\n",
+        "        x = self.drop3(x)\n",
+        "        x = self.dense2(x)\n",
+        "        return x\n",
+        "model = MyModel(\n",
+        "    filters=hpo.space.Categorical(32, 64),\n",
+        "    kernel_size=hpo.space.Categorical(2, 4),\n",
+        "    strides=hpo.space.Categorical(1, 2),\n",
+        "    activation=hpo.space.Categorical(\"relu\", \"linear\")\n",
+        ")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> 📝 **Note**\n",
+        ">\n",
+        "> In general, Nano supports four kinds of parameter types in `bigdl.nano.automl.hpo.space`, which are `Categorical(*data, prefix=None)`, `Real(lower, upper, default=None, log=False, prefix=None)`, `Int(lower, upper, default=None, prefix=None)` and `Bool(default=None, prefix=None)`. For their detailed usage, you can refer to the [corresponding API doc](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/hpo_api.html#search-space)."
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "### Compile the model"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "We now compile our model with loss function, optimizer and metrics."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from tensorflow.keras.optimizers import RMSprop\n",
+        "model.compile(\n",
+        "    loss=\"sparse_categorical_crossentropy\",\n",
+        "    optimizer=RMSprop(learning_rate=0.001),\n",
+        "    metrics=[\"accuracy\"]\n",
+        ")"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> 📝 **Note**\n",
+        ">\n",
+        "> `learning_rate` is also a searchable hyper-parameter. Two steps are needed before and during calling `model.compile()` if you want to optimize the learning rate:\n",
+        "> \n",
+        "> 1) import the optimizer from `bigdl.nano.tf.optimizers` instead of `tf.keras.optimizers`, i.e., `from bigdl.nano.tf.optimizers import RMSprop`\n",
+        "> 2) specify the search space for `learning_rate` in the optimizer argument in `model.compile()`, e.g., `optimizer=RMSprop(learning_rate=space.Real(0.0001, 0.01, log=True))`"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Find the best hyper-parameters"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "Then we can call `model.search()` to start searching hyper-parameters. Nano HPO will test `n_trials` sets of hyper-parameter combination in the search space range, and optimize the `target_metric` in the specified `direction`. We need to pass the necessary arguments for `model.fit()`, like `x`, `y`, `batch_size`, `epochs`, etc. Additionally, `pruner` is supported to stop non-promising trials early."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from bigdl.nano.automl.hpo.backend import PrunerType\n",
+        "model.search(\n",
+        "    n_trials=8,\n",
+        "    target_metric='val_accuracy',\n",
+        "    direction=\"maximize\",\n",
+        "    pruner=PrunerType.HyperBand,\n",
+        "    pruner_kwargs={'min_resource':1, 'max_resource':100, 'reduction_factor':3},\n",
+        "    x=x_train,\n",
+        "    y=y_train,\n",
+        "    batch_size=128,\n",
+        "    epochs=5,\n",
+        "    validation_split=0.2,\n",
+        "    verbose=False\n",
+        ")"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> 📝 **Note**\n",
+        ">\n",
+        "> `batch_size` is also a searchable hyper-parameter. If you want to optimize it, you can specify the search space for `batch_size` argument in `model.search()`, e.g., `batch_size=space.Categorical(128,64)`"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "When the search completes, you can use `model.search_summary()` to retrive the search results for analysis, which can be used to collect trial statistics in pandas dataframe format, pick the best trial, or do visualizations."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 12,
+      "metadata": {},
+      "outputs": [
+        {
+          "name": "stdout",
+          "output_type": "stream",
+          "text": [
+            "Number of finished trials: 8\n",
+            "Best trial:\n",
+            "  Value: 0.9805833101272583\n",
+            "  Params: \n",
+            "    activation▁choice: 0\n",
+            "    filters▁choice: 1\n",
+            "    kernel_size▁choice: 1\n",
+            "    strides▁choice: 1\n"
+          ]
+        }
+      ],
+      "source": [
+        "study = model.search_summary()"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "After the search, `model.fit()` will autotmatically apply the best hyper-parmeters found to fit the model. Then we can use the testing dataset to evaluate it."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "history = model.fit(x_train, y_train,\n",
+        "                    batch_size=128, epochs=5, validation_split=0.2)\n",
+        "\n",
+        "test_scores = model.evaluate(x_test, y_test, verbose=2)\n",
+        "print(\"Test loss:\", test_scores[0])\n",
+        "print(\"Test accuracy:\", test_scores[1])"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "The detailed information for each trial can be reviewed through `trials_dataframe()`."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": 13,
+      "metadata": {},
+      "outputs": [
+        {
+          "data": {
+            "text/html": [
+              "<div>\n",
+              "<style scoped>\n",
+              "    .dataframe tbody tr th:only-of-type {\n",
+              "        vertical-align: middle;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe tbody tr th {\n",
+              "        vertical-align: top;\n",
+              "    }\n",
+              "\n",
+              "    .dataframe thead th {\n",
+              "        text-align: right;\n",
+              "    }\n",
+              "</style>\n",
+              "<table border=\"1\" class=\"dataframe\">\n",
+              "  <thead>\n",
+              "    <tr style=\"text-align: right;\">\n",
+              "      <th></th>\n",
+              "      <th>number</th>\n",
+              "      <th>value</th>\n",
+              "      <th>params_activation▁choice</th>\n",
+              "      <th>params_filters▁choice</th>\n",
+              "      <th>params_kernel_size▁choice</th>\n",
+              "      <th>params_strides▁choice</th>\n",
+              "      <th>state</th>\n",
+              "    </tr>\n",
+              "  </thead>\n",
+              "  <tbody>\n",
+              "    <tr>\n",
+              "      <th>0</th>\n",
+              "      <td>0</td>\n",
+              "      <td>0.920917</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>1</th>\n",
+              "      <td>1</td>\n",
+              "      <td>0.923250</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>2</th>\n",
+              "      <td>2</td>\n",
+              "      <td>0.920083</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>PRUNED</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>3</th>\n",
+              "      <td>3</td>\n",
+              "      <td>0.920000</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>4</th>\n",
+              "      <td>4</td>\n",
+              "      <td>0.980583</td>\n",
+              "      <td>0</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>5</th>\n",
+              "      <td>5</td>\n",
+              "      <td>0.926583</td>\n",
+              "      <td>1</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>0</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>6</th>\n",
+              "      <td>6</td>\n",
+              "      <td>0.916000</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>PRUNED</td>\n",
+              "    </tr>\n",
+              "    <tr>\n",
+              "      <th>7</th>\n",
+              "      <td>7</td>\n",
+              "      <td>0.922417</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>1</td>\n",
+              "      <td>COMPLETE</td>\n",
+              "    </tr>\n",
+              "  </tbody>\n",
+              "</table>\n",
+              "</div>"
+            ],
+            "text/plain": [
+              "   number     value  params_activation▁choice  params_filters▁choice  \\\n",
+              "0       0  0.920917                         1                      1   \n",
+              "1       1  0.923250                         1                      1   \n",
+              "2       2  0.920083                         1                      0   \n",
+              "3       3  0.920000                         1                      1   \n",
+              "4       4  0.980583                         0                      1   \n",
+              "5       5  0.926583                         1                      0   \n",
+              "6       6  0.916000                         1                      1   \n",
+              "7       7  0.922417                         1                      1   \n",
+              "\n",
+              "   params_kernel_size▁choice  params_strides▁choice     state  \n",
+              "0                          1                      0  COMPLETE  \n",
+              "1                          1                      1  COMPLETE  \n",
+              "2                          1                      1    PRUNED  \n",
+              "3                          1                      1  COMPLETE  \n",
+              "4                          1                      1  COMPLETE  \n",
+              "5                          0                      0  COMPLETE  \n",
+              "6                          1                      1    PRUNED  \n",
+              "7                          1                      1  COMPLETE  "
+            ]
+          },
+          "execution_count": 13,
+          "metadata": {},
+          "output_type": "execute_result"
+        }
+      ],
+      "source": [
+        "study.trials_dataframe(attrs=(\"number\", \"value\", \"params\", \"state\"))"
+      ]
+    },
+    {
+      "attachments": {},
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "> 📚 **Related Readings**\n",
+        ">\n",
+        "> - [How to install BigDL-Nano](https://bigdl.readthedocs.io/en/latest/doc/Nano/Overview/install.html)"
+      ]
     }
   ],
   "metadata": {
     "kernelspec": {
-      "display_name": "nano-pytorch",
+      "display_name": "sirui-tf",
       "language": "python",
       "name": "python3"
     },
@@ -74,12 +680,12 @@
       "name": "python",
       "nbconvert_exporter": "python",
       "pygments_lexer": "ipython3",
-      "version": "3.7.15 (default, Nov 24 2022, 21:12:53) \n[GCC 11.2.0]"
+      "version": "3.7.0"
     },
     "orig_nbformat": 4,
     "vscode": {
       "interpreter": {
-        "hash": "8a5edab282632443219e051e4ade2d1d5bbc671c781051bf1437897cbdfea0f1"
+        "hash": "6736a9b3787e01acdf2961a7787db6e0fae80ab1beed22d6c7ff123b160f18b9"
       }
     }
   },

--- a/python/nano/tutorial/notebook/hpo/use_hpo_tune_hyperparameters_tensorflow.ipynb
+++ b/python/nano/tutorial/notebook/hpo/use_hpo_tune_hyperparameters_tensorflow.ipynb
@@ -5,7 +5,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/hpo/use_hpo_tune_hyperparameters_tensorflow.ipynb)"
+        "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/notebook/hpo/use_hpo_tune_hyperparameters_tensorflow.ipynb)"
       ]
     },
     {
@@ -39,7 +39,7 @@
         "nbsphinx": "hidden"
       },
       "source": [
-        "To apply Nano HPO, you should install BigDL-Nano for TensorFlow and its dependencies first："
+        "To apply Nano HPO, you should install BigDL-Nano for TensorFlow and its dependencies first:"
       ]
     },
     {
@@ -450,7 +450,6 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 12,
       "metadata": {},
       "outputs": [
         {
@@ -504,7 +503,6 @@
     },
     {
       "cell_type": "code",
-      "execution_count": 13,
       "metadata": {},
       "outputs": [
         {

--- a/python/nano/tutorial/notebook/hpo/use_hpo_tune_hyperparameters_tensorflow.ipynb
+++ b/python/nano/tutorial/notebook/hpo/use_hpo_tune_hyperparameters_tensorflow.ipynb
@@ -450,6 +450,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {},
       "outputs": [
         {
@@ -503,6 +504,7 @@
     },
     {
       "cell_type": "code",
+      "execution_count": null,
       "metadata": {},
       "outputs": [
         {

--- a/python/nano/tutorial/notebook/hpo/use_hpo_tune_hyperparameters_tensorflow.ipynb
+++ b/python/nano/tutorial/notebook/hpo/use_hpo_tune_hyperparameters_tensorflow.ipynb
@@ -5,7 +5,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/hpo/notebook/use_hpo_tune_hyperparameters_tensorflow.ipynb)"
+        "[View the runnable example on GitHub](https://github.com/intel-analytics/BigDL/tree/main/python/nano/tutorial/hpo/use_hpo_tune_hyperparameters_tensorflow.ipynb)"
       ]
     },
     {

--- a/python/nano/tutorial/notebook/hpo/use_hpo_tune_hyperparameters_tensorflow.ipynb
+++ b/python/nano/tutorial/notebook/hpo/use_hpo_tune_hyperparameters_tensorflow.ipynb
@@ -110,7 +110,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Taking the tuning of a simple CNN on the MINST dataset as an example. We first prepare the datasets for training and testing."
+        "Taking the hyper-tuning of a simple CNN on the MINST dataset as an example. We first prepare the datasets for training and testing."
       ]
     },
     {
@@ -207,7 +207,7 @@
         ">\n",
         "> In general, Nano supports four kinds of parameter types in `bigdl.nano.automl.hpo.space`, which are `Categorical(*data, prefix=None)`, `Real(lower, upper, default=None, log=False, prefix=None)`, `Int(lower, upper, default=None, prefix=None)` and `Bool(default=None, prefix=None)`. For their detailed usage, you can refer to the [corresponding API doc](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/hpo_api.html#search-space).\n",
         "> \n",
-        "> Note that search spaces can only be specified in key-word argument (which means `Dense(space.Int(...))` should be changed to `Dense(units=space.Int(...))`). "
+        "> Note that search spaces can only be specified in key-word arguments (which means `Dense(space.Int(...))` should be changed to `Dense(units=space.Int(...))`). And if a layer is used more than once in the model, we strongly suggest you assign a `prefix` for each search space in such layer to distinguish them, or they will share the same search space (the last space will override all previous definition)."
       ]
     },
     {
@@ -273,7 +273,7 @@
         ">\n",
         "> In general, Nano supports four kinds of parameter types in `bigdl.nano.automl.hpo.space`, which are `Categorical(*data, prefix=None)`, `Real(lower, upper, default=None, log=False, prefix=None)`, `Int(lower, upper, default=None, prefix=None)` and `Bool(default=None, prefix=None)`. For their detailed usage, you can refer to the [corresponding API doc](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/hpo_api.html#search-space).\n",
         "> \n",
-        "> Note that if a layer is used more than once in the model, we strongly suggest you assign a `prefix` for each search space in such layer to distinguish them, or they will share the same search space (the last space will override all previous definition)."
+        "> Note that search spaces can only be specified in key-word arguments (which means `Dense(space.Int(...))` should be changed to `Dense(units=space.Int(...))`). And if a layer is used more than once in the model, we strongly suggest you assign a `prefix` for each search space in such layer to distinguish them, or they will share the same search space (the last space will override all previous definition)."
       ]
     },
     {
@@ -341,12 +341,15 @@
       ]
     },
     {
+      "attachments": {},
       "cell_type": "markdown",
       "metadata": {},
       "source": [
         "> 📝 **Note**\n",
         ">\n",
-        "> In general, Nano supports four kinds of parameter types in `bigdl.nano.automl.hpo.space`, which are `Categorical(*data, prefix=None)`, `Real(lower, upper, default=None, log=False, prefix=None)`, `Int(lower, upper, default=None, prefix=None)` and `Bool(default=None, prefix=None)`. For their detailed usage, you can refer to the [corresponding API doc](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/hpo_api.html#search-space)."
+        "> In general, Nano supports four kinds of parameter types in `bigdl.nano.automl.hpo.space`, which are `Categorical(*data, prefix=None)`, `Real(lower, upper, default=None, log=False, prefix=None)`, `Int(lower, upper, default=None, prefix=None)` and `Bool(default=None, prefix=None)`. For their detailed usage, you can refer to the [corresponding API doc](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/hpo_api.html#search-space).\n",
+        "> \n",
+        "> Note that search spaces can only be specified in key-word arguments (which means `Dense(space.Int(...))` should be changed to `Dense(units=space.Int(...))`). And if a layer is used more than once in the model, we strongly suggest you assign a `prefix` for each search space in such layer to distinguish them, or they will share the same search space (the last space will override all previous definition)."
       ]
     },
     {
@@ -405,7 +408,7 @@
       "cell_type": "markdown",
       "metadata": {},
       "source": [
-        "Then we can call `model.search()` to start searching hyper-parameters. Nano HPO will test `n_trials` sets of hyper-parameter combination in the search space range, and optimize the `target_metric` in the specified `direction`. We need to pass the necessary arguments for `model.fit()`, like `x`, `y`, `batch_size`, `epochs`, etc. Additionally, `pruner` is supported to stop non-promising trials early."
+        "Then we can call `model.search()` (corresponding API reference can be found [here](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/hpo_api.html#hpo-for-tensorflow)) to start searching hyper-parameters. Nano HPO will test `n_trials` sets of hyper-parameter combination in the search space range, and optimize the `target_metric` in the specified `direction`. We need to pass the necessary arguments for `model.fit()`, like `x`, `y`, `batch_size`, `epochs`, etc., referring to its [API doc](https://bigdl.readthedocs.io/en/latest/doc/PythonAPI/Nano/tensorflow.html#bigdl.nano.tf.keras.Model.fit). Additionally, `pruner` is supported to stop non-promising trials early."
       ]
     },
     {


### PR DESCRIPTION
### Description

Add hands-on guides for users to tune the hyper-parameters via Nano __HPO__. How-to guides aim at giving multiple bite-sized, task-oriented, and executable examples for user to check when they need to do similar tasks.

### User API changes

N/A.

### How to test?
- [ ] Document test: https://siruitestdoc.readthedocs.io/en/nano_hpo/doc/Nano/Howto/hpo/use_hpo_tune_hyperparameters_tensorflow.html
- [ ] GitHub Notebook Preview: https://github.com/Siritao/BigDL/blob/nano_hpo/python/nano/tutorial/notebook/hpo/use_hpo_tune_hyperparameters_tensorflow.ipynb
- [ ] Notebook test locally
