### PR TITLE
[Nano] Bug fix when enabling channels last on variable length input models

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -181,7 +181,8 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
 
             # change the data to suitable mem format
             inputs = tuple(map(
-                lambda idx: apply_proper_channels_last(self.channels_last_available[idx], inputs[idx]),
+                lambda idx: apply_proper_channels_last(
+                    self.channels_last_available[idx], inputs[idx]),
                 range(min(len(self.channels_last_available), len(inputs)))))
 
         return self.model(*inputs)

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -180,9 +180,9 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                 self.channels_last_available = generate_channels_last_available(inputs)
 
             # change the data to suitable mem format
-            inputs = tuple(map(lambda item: apply_proper_channels_last(
-                self.channels_last_available[item[0]], item[1]),
-                enumerate(inputs)))
+            inputs = tuple(map(
+                lambda idx: apply_proper_channels_last(self.channels_last_available[idx], inputs[idx]),
+                range(min(len(self.channels_last_available), len(inputs)))))
 
         return self.model(*inputs)
 

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -130,7 +130,8 @@ class BF16Model(AcceleratedLightningModule):
 
             # change the data to suitable mem format
             inputs = tuple(map(
-                lambda idx: apply_proper_channels_last(self.channels_last_available[idx], inputs[idx]),
+                lambda idx: apply_proper_channels_last(
+                    self.channels_last_available[idx], inputs[idx]),
                 range(min(len(self.channels_last_available), len(inputs)))))
 
         return self.model(*inputs)

--- a/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
+++ b/python/nano/src/bigdl/nano/pytorch/amp/bfloat16.py
@@ -129,9 +129,9 @@ class BF16Model(AcceleratedLightningModule):
                 self.channels_last_available = generate_channels_last_available(inputs)
 
             # change the data to suitable mem format
-            inputs = tuple(map(lambda item: apply_proper_channels_last(
-                self.channels_last_available[item[0]], item[1]),
-                enumerate(inputs)))
+            inputs = tuple(map(
+                lambda idx: apply_proper_channels_last(self.channels_last_available[idx], inputs[idx]),
+                range(min(len(self.channels_last_available), len(inputs)))))
 
         return self.model(*inputs)
 


### PR DESCRIPTION
## Description

[Enabling channels last on variable length input models may cause forward to fail](https://github.com/analytics-zoo/nano/issues/319)
