### PR TITLE
Fix test string input for tf 2.9.0

### DIFF
--- a/python/orca/test/bigdl/orca/learn/ray/horovod/test_tf2_horovod_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/horovod/test_tf2_horovod_backend.py
@@ -248,28 +248,7 @@ class TestTFHorovodEstimator(TestCase):
         else:
             # skip tests in horovod lower version
             pass
-    
-    # TODO: modify this ut to be compatible with tensorflow 2.9.0
-    def test_string_input(self):
 
-        def model_creator(config):
-            vectorize_layer = tf.keras.layers.experimental.preprocessing.TextVectorization(
-                max_tokens=10, output_mode='int', output_sequence_length=4,
-                vocabulary=["foo", "bar", "baz"])
-            model = tf.keras.models.Sequential()
-            model.add(tf.keras.Input(shape=(1,), dtype=tf.string))
-            model.add(vectorize_layer)
-            return model
-
-        from pyspark.sql.types import StructType, StructField, StringType
-        spark = OrcaContext.get_spark_session()
-        schema = StructType([StructField("input", StringType(), True)])
-        input_data = [["foo qux bar"], ["qux baz"]]
-        input_df = spark.createDataFrame(input_data, schema)
-        estimator = Estimator.from_keras(model_creator=model_creator)
-        output_df = estimator.predict(input_df, batch_size=1, feature_cols=["input"])
-        output = output_df.collect()
-        print(output)
 
 if __name__ == "__main__":
     pytest.main([__file__])

--- a/python/orca/test/bigdl/orca/learn/ray/horovod/test_tf2_horovod_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/horovod/test_tf2_horovod_backend.py
@@ -254,7 +254,8 @@ class TestTFHorovodEstimator(TestCase):
 
         def model_creator(config):
             vectorize_layer = tf.keras.layers.experimental.preprocessing.TextVectorization(
-                max_tokens=10, output_mode='int', output_sequence_length=4)
+                max_tokens=10, output_mode='int', output_sequence_length=4,
+                vocabulary=["foo", "bar", "baz"])
             model = tf.keras.models.Sequential()
             model.add(tf.keras.Input(shape=(1,), dtype=tf.string))
             model.add(vectorize_layer)


### PR DESCRIPTION
Fix https://github.com/intel-analytics/BigDL/issues/7779

Seems for later tf versions, TextVectorization layers must be given a vocabulary or be adapted. (previously tf 2.3.0 doesn't have such constraint)
https://www.tensorflow.org/api_docs/python/tf/keras/layers/TextVectorization

The vocabulary for the layer must be either supplied on construction or learned via adapt().