### PR TITLE
Nano: support dynamic axes for GPU

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -73,13 +73,14 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
             if isinstance(model, torch.nn.Module):
                 # cope with dynamic axes for GPU
                 if device != 'CPU':
-                    if dynamic_axes is True or (isinstance(dynamic_axes, dict) and  # type: ignore
-                                                len(dynamic_axes) > 0):
+                    if dynamic_axes is True or (
+                        isinstance(dynamic_axes, dict) and len(dynamic_axes) > 0
+                    ):
                         invalidInputError("input_shape" in kwargs,
                                           "For model has dynamic axes, if you want to inference on "
                                           "non-CPU device, must define input_shape for model "
-                                          "optimizer. For more details about model optimizer, you can "
-                                          "see mo --help .")
+                                          "optimizer. For more details about model optimizer, you "
+                                          "can see mo --help .")
                 export(model, input_sample, str(tmpdir / 'tmp.xml'),
                        precision=precision, dynamic_axes=dynamic_axes,
                        logging=logging, **kwargs)

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -232,9 +232,9 @@ class TestOpenVINO(TestCase):
 
         try:
             optimized_model = InferenceOptimizer.quantize(model,
-                                                        accelerator='openvino',
-                                                        input_sample=x,
-                                                        precision='bf16')
+                                                          accelerator='openvino',
+                                                          input_sample=x,
+                                                          precision='bf16')
         except RuntimeError as e:
             assert e.__str__() == "Platform doesn't support BF16 format"
             return
@@ -253,20 +253,45 @@ class TestOpenVINO(TestCase):
             assert y_hat.shape == (3, 10)
             assert new_model.ov_model.additional_config["INFERENCE_PRECISION_HINT"] == "bf16"
 
-    def test_openvino_gpu_quatize(self):
+    def test_openvino_gpu_quantize(self):
         # test whether contains GPU
         from openvino.runtime import Core
         core = Core()
         devices = core.available_devices
         gpu_avaliable = any('GPU' in x for x in devices)
-        
-        if gpu_avaliable is False:
-            return
-
         model = mobilenet_v3_small(num_classes=10)
 
         x = torch.rand((1, 3, 256, 256))
         x2 = torch.rand((10, 3, 256, 256))
+
+        # test dynamic_shape
+        with pytest.raises(RuntimeError,
+                           match="For model has dynamic axes, if you want to inference on non-CPU device, must define "
+                                 "input_shape for model optimizer. For more details about model optimizer, you can see mo --help ."):
+            openvino_model = InferenceOptimizer.quantize(model,
+                                                         input_sample=x,
+                                                         accelerator='openvino',
+                                                         precision='fp16',
+                                                         device='GPU')
+        with pytest.raises(RuntimeError,
+                           match="For model has dynamic axes, if you want to inference on non-CPU device, must define "
+                                 "input_shape for model optimizer. For more details about model optimizer, you can see mo --help ."):
+            openvino_model = InferenceOptimizer.quantize(model,
+                                                         input_sample=x,
+                                                         accelerator='openvino',
+                                                         dynamic_axes={'x': [0]},
+                                                         precision='fp16',
+                                                         device='GPU')
+
+        if gpu_avaliable is False:
+            with pytest.raises(RuntimeError):
+                openvino_model = InferenceOptimizer.quantize(model,
+                                                             input_sample=x,
+                                                             accelerator='openvino',
+                                                             device='GPU',
+                                                             input_shape='[1,3,256,256]',
+                                                             precision='fp16')
+            return
 
         # test GPU fp16
         openvino_model = InferenceOptimizer.quantize(model,
@@ -281,11 +306,10 @@ class TestOpenVINO(TestCase):
 
         # test GPU int8
         openvino_model = InferenceOptimizer.quantize(model,
-                                                     input_sample=x,
+                                                     calib_data=x,
                                                      accelerator='openvino',
                                                      device='GPU',
-                                                     precision='int8',
-                                                     calib_data=x)
+                                                     precision='int8')
         result = openvino_model(x)
         # GPU don't support dynamic shape
         with pytest.raises(RuntimeError):
@@ -308,11 +332,11 @@ class TestOpenVINO(TestCase):
 
         # test VPU int8
         openvino_model = InferenceOptimizer.quantize(model,
+                                                     calib_data=x,
                                                      input_sample=x,
                                                      accelerator='openvino',
                                                      device='VPUX',
-                                                     precision='int8',
-                                                     calib_data=x)
+                                                     precision='int8')
         result = openvino_model(x)
         # VPU don't support dynamic shape
         with pytest.raises(RuntimeError):


### PR DESCRIPTION
## Description

support dynamic axes for GPU device by specifying `input_shape` (with `input`).

### 1. Why the change?

support dynamic axes for GPU device.

### 2. User API changes
Now user can specify `dynamic_axes` for GPU model as long as you pass in related `input_shape` (with input).
```python
openvino_model = InferenceOptimizer.quantize(model,
                                             input_sample=x,
                                             accelerator='openvino',
                                             device='GPU',
                                             input_shape='[1,3,256,256]',
                                             precision='fp16')
```

### 3. Summary of the change 

- support dynamic axes for GPU device by specifying `input_shape` (with `input`)
- related UT

### 4. How to test?
- [x] Unit test
