### PR TITLE
change default hadoop user name from root to os.env[HADOOP_USER_NAME] or current user

### DIFF
--- a/python/dllib/src/bigdl/dllib/nncontext.py
+++ b/python/dllib/src/bigdl/dllib/nncontext.py
@@ -65,7 +65,7 @@ def init_spark_on_yarn(hadoop_conf,
                        extra_python_lib=None,
                        penv_archive=None,
                        additional_archive=None,
-                       hadoop_user_name="root",
+                       hadoop_user_name=None,
                        spark_yarn_archive=None,
                        spark_log_level="WARN",
                        redirect_spark_log=True,
@@ -93,7 +93,8 @@ def init_spark_on_yarn(hadoop_conf,
            Default to be None.
     :param additional_archive: Comma-separated list of additional archives to be uploaded and
            unpacked on executors. Default to be None.
-    :param hadoop_user_name: The user name for running the yarn cluster. Default to be 'root'.
+    :param hadoop_user_name: The user name for running the yarn cluster. Default to be None.
+           None means os.environ["HADOOP_USER_NAME"], or current user if HADOOP_USER_NAME is unset.
     :param spark_yarn_archive: Conf value for setting spark.yarn.archive. Default to be None.
     :param spark_log_level: The log level for Spark. Default to be 'WARN'.
     :param redirect_spark_log: Whether to redirect the Spark log to local file. Default to be True.
@@ -140,7 +141,7 @@ def init_spark_on_yarn_cluster(hadoop_conf,
                                extra_python_lib=None,
                                penv_archive=None,
                                additional_archive=None,
-                               hadoop_user_name="root",
+                               hadoop_user_name=None,
                                spark_yarn_archive=None,
                                spark_log_level="WARN",
                                redirect_spark_log=True,
@@ -168,7 +169,8 @@ def init_spark_on_yarn_cluster(hadoop_conf,
            Default to be None.
     :param additional_archive: Comma-separated list of additional archives to be uploaded and
            unpacked on executors. Default to be None.
-    :param hadoop_user_name: The user name for running the yarn cluster. Default to be 'root'.
+    :param hadoop_user_name: The user name for running the yarn cluster. Default to be None.
+           None means os.environ["HADOOP_USER_NAME"], or current user if HADOOP_USER_NAME is unset.
     :param spark_yarn_archive: Conf value for setting spark.yarn.archive. Default to be None.
     :param spark_log_level: The log level for Spark. Default to be 'WARN'.
     :param redirect_spark_log: Whether to redirect the Spark log to local file. Default to be True.

--- a/python/dllib/src/bigdl/dllib/nncontext.py
+++ b/python/dllib/src/bigdl/dllib/nncontext.py
@@ -94,7 +94,8 @@ def init_spark_on_yarn(hadoop_conf,
     :param additional_archive: Comma-separated list of additional archives to be uploaded and
            unpacked on executors. Default to be None.
     :param hadoop_user_name: The user name for running the yarn cluster. Default to be None.
-           None means os.environ["HADOOP_USER_NAME"], or current user if HADOOP_USER_NAME is unset.
+           The default None means reading from env, the value of os.environ["HADOOP_USER_NAME"],
+           or current user if HADOOP_USER_NAME is unset.
     :param spark_yarn_archive: Conf value for setting spark.yarn.archive. Default to be None.
     :param spark_log_level: The log level for Spark. Default to be 'WARN'.
     :param redirect_spark_log: Whether to redirect the Spark log to local file. Default to be True.
@@ -170,7 +171,8 @@ def init_spark_on_yarn_cluster(hadoop_conf,
     :param additional_archive: Comma-separated list of additional archives to be uploaded and
            unpacked on executors. Default to be None.
     :param hadoop_user_name: The user name for running the yarn cluster. Default to be None.
-           None means os.environ["HADOOP_USER_NAME"], or current user if HADOOP_USER_NAME is unset.
+           The default None means reading from env, the value of os.environ["HADOOP_USER_NAME"],
+           or current user if HADOOP_USER_NAME is unset.
     :param spark_yarn_archive: Conf value for setting spark.yarn.archive. Default to be None.
     :param spark_log_level: The log level for Spark. Default to be 'WARN'.
     :param redirect_spark_log: Whether to redirect the Spark log to local file. Default to be True.

--- a/python/dllib/src/bigdl/dllib/utils/spark.py
+++ b/python/dllib/src/bigdl/dllib/utils/spark.py
@@ -77,7 +77,7 @@ class SparkRunner:
                            extra_python_lib=None,
                            penv_archive=None,
                            additional_archive=None,
-                           hadoop_user_name="root",
+                           hadoop_user_name=None,
                            spark_yarn_archive=None,
                            conf=None,
                            jars=None,
@@ -85,7 +85,10 @@ class SparkRunner:
         print("Initializing SparkContext for yarn-client mode")
         executor_python_env = "python_env"
         os.environ["HADOOP_CONF_DIR"] = hadoop_conf
-        os.environ["HADOOP_USER_NAME"] = hadoop_user_name
+        if hadoop_user_name:
+            os.environ["HADOOP_USER_NAME"] = hadoop_user_name
+        elif not os.environ.get("HADOOP_USER_NAME"):
+            os.environ["HADOOP_USER_NAME"] = os.getlogin()
         os.environ["PYSPARK_PYTHON"] = "{}/bin/python".format(executor_python_env)
 
         pack_env = False
@@ -149,7 +152,7 @@ class SparkRunner:
                                    extra_python_lib=None,
                                    penv_archive=None,
                                    additional_archive=None,
-                                   hadoop_user_name="root",
+                                   hadoop_user_name=None,
                                    spark_yarn_archive=None,
                                    conf=None,
                                    jars=None,
@@ -157,7 +160,10 @@ class SparkRunner:
         print("Initializing job for yarn-cluster mode")
         executor_python_env = "python_env"
         os.environ["HADOOP_CONF_DIR"] = hadoop_conf
-        os.environ["HADOOP_USER_NAME"] = hadoop_user_name
+        if hadoop_user_name:
+            os.environ["HADOOP_USER_NAME"] = hadoop_user_name
+        elif not os.environ.get("HADOOP_USER_NAME"):
+            os.environ["HADOOP_USER_NAME"] = os.getlogin()
 
         pack_env = False
         invalidInputError(penv_archive or conda_name,


### PR DESCRIPTION
## Description

change default hadoop user name in init_nncontext_on_yarn

### 1. Why the change?

fixed #7905 

### 2. User API changes

None

### 3. Summary of the change 

change default hadoop user name in init_nncontext_on_yarn

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

