### PR TITLE
Orca: add python 3.9 basic tests (nightly)

### DIFF
--- a/.github/actions/orca/orca-basic-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-basic-py39-spark3-action/nightly-test/action.yml
@@ -1,0 +1,19 @@
+name: 'Run Orca Basic Py39 Spark3'
+description: 'Run Orca Basic Py39 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py39
+        export SPARK_LOCAL_HOSTNAME=localhost
+        
+        pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3
+
+        pip list
+        chmod a+x python/orca/dev/test/run-pytests-basic-env.sh
+        python/orca/dev/test/run-pytests-basic-env.sh
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/orca-basic-pytorch-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-basic-pytorch-py39-spark3-action/nightly-test/action.yml
@@ -1,0 +1,19 @@
+name: 'Run Orca Basic Pytorch Py39 Spark3'
+description: 'Run Orca Basic Pytorch Py39 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py39
+        export SPARK_LOCAL_HOSTNAME=localhost
+        
+        pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
+        pip list
+        chmod a+x python/orca/dev/test/run-pytests-basic-pytorch.sh
+        python/orca/dev/test/run-pytests-basic-pytorch.sh
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/orca-basic-tf2-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-basic-tf2-py39-spark3-action/nightly-test/action.yml
@@ -1,0 +1,20 @@
+name: 'Run Orca Basic Tf2 Py39 Spark3'
+description: 'Run Orca Basic Tf2 Py39 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py39
+        export SPARK_LOCAL_HOSTNAME=localhost
+        
+        pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==2.9.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} grpcio==1.43.0
+        pip list
+        chmod a+x python/orca/dev/test/run-pytests-basic-tf2.sh
+        python/orca/dev/test/run-pytests-basic-tf2.sh
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/setup-env/setup-orca-python-py39-basic/action.yml
+++ b/.github/actions/orca/setup-env/setup-orca-python-py39-basic/action.yml
@@ -31,4 +31,3 @@ runs:
         
       env:
         BIGDL_ROOT: ${{ github.workspace }}
-        ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/setup-env/setup-orca-python-py39-basic/action.yml
+++ b/.github/actions/orca/setup-env/setup-orca-python-py39-basic/action.yml
@@ -1,4 +1,4 @@
- name: 'Run Orca Python Py39 Spark3'
+name: 'Run Orca Python Py39 Spark3'
 description: 'Run Orca Python Py39 Spark3'
 runs:
   using: "composite"

--- a/.github/actions/orca/setup-env/setup-orca-python-py39-basic/action.yml
+++ b/.github/actions/orca/setup-env/setup-orca-python-py39-basic/action.yml
@@ -1,0 +1,34 @@
+name: 'Run Orca Python Py39 Spark3'
+description: 'Run Orca Python Py39 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Set up Python 
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+
+    - name: Install dependencies
+      shell: bash
+      run: |
+        dpkg --configure -a
+        apt-get update
+        apt-get install wget
+    - name: Setup env
+      shell: bash
+      run: |
+        if [ -d "/opt/conda/envs/py39" ];then
+          rm -rf /opt/conda/envs/py39
+        fi
+        conda create -n py39 -y python==3.9 setuptools==58.0.4 -c ${GONDOLIN_CONDA_CHANNEL} --override-channels
+        conda info --env
+        source activate py39
+        pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-friesian bigdl-friesian-spark3
+        
+        wget https://raw.githubusercontent.com/analytics-zoo/gha-cicd-env/main/python-requirements/requirements-orca-python.txt -O ${{ github.workspace }}/requirements-orca-python.txt
+        pip uninstall -r ${{ github.workspace }}/requirements-orca-python.txt -y
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} -r ${{ github.workspace }}/requirements-orca-python.txt 
+        
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}
+        ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/setup-env/setup-orca-python-py39-basic/action.yml
+++ b/.github/actions/orca/setup-env/setup-orca-python-py39-basic/action.yml
@@ -1,4 +1,4 @@
-name: 'Run Orca Python Py39 Spark3'
+ name: 'Run Orca Python Py39 Spark3'
 description: 'Run Orca Python Py39 Spark3'
 runs:
   using: "composite"

--- a/.github/actions/remove-env/remove-env-py39/action.yml
+++ b/.github/actions/remove-env/remove-env-py39/action.yml
@@ -13,4 +13,3 @@ runs:
         conda remove -n py39 -y --all
       env:
         BIGDL_ROOT: ${{ github.workspace }}
-        ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/.github/actions/remove-env/remove-env-py39/action.yml
+++ b/.github/actions/remove-env/remove-env-py39/action.yml
@@ -1,0 +1,16 @@
+name: 'Remove Env'
+description: 'Remove Env'
+runs:
+  using: "composite"
+  steps:
+    - name: Remove Env
+      shell: bash
+      run: |
+        unset PYTHONHOME 
+        source activate py39
+        pip uninstall -y pyspark bigdl-friesian bigdl bigdl-dllib-spark3 bigdl-orca-spark3 bigdl-tf bigdl-math bigdl-orca  bigdl-dllib bigdl-tf bigdl-chronos bigdl-nano
+        source deactivate
+        conda remove -n py39 -y --all
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}
+        ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -2,7 +2,7 @@ name: Nightly Test
 
 on:
 
-  #pull_request:
+  pull_request:
     #branchs: [ main ]
 
   schedule:
@@ -258,7 +258,7 @@ jobs:
         runner-hosted-on: 'Shanghai'
 
   Orca-Basic-Py39-Spark3:
-    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
+    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
@@ -285,7 +285,7 @@ jobs:
         runner-hosted-on: 'Shanghai'
 
   Orca-Basic-PyTorch-Py39-Spark3:
-    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-PyTorch-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
+    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-PyTorch-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
@@ -312,7 +312,7 @@ jobs:
         runner-hosted-on: 'Shanghai'
 
   Orca-Basic-Tf2-Py39-Spark3:
-    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Tf2-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
+    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Tf2-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -22,6 +22,9 @@ on:
         - Orca-Basic-Py38-Spark3
         - Orca-Basic-PyTorch-Py38-Spark3
         - Orca-Basic-Tf2-Py38-Spark3
+        - Orca-Basic-Py39-Spark3
+        - Orca-Basic-PyTorch-Py39-Spark3
+        - Orca-Basic-Tf2-Py39-Spark3
         - Orca-Pytest-Ray-Py37-Spark3
         - Orca-Pytest-Ray-Py38-Spark3
         - Orca-Pytest-Py37-Spark3-Tf1

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -2,7 +2,7 @@ name: Nightly Test
 
 on:
 
-  pull_request:
+  #pull_request:
     #branchs: [ main ]
 
   schedule:
@@ -258,7 +258,7 @@ jobs:
         runner-hosted-on: 'Shanghai'
 
   Orca-Basic-Py39-Spark3:
-    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
@@ -285,7 +285,7 @@ jobs:
         runner-hosted-on: 'Shanghai'
 
   Orca-Basic-PyTorch-Py39-Spark3:
-    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-PyTorch-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-PyTorch-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
@@ -312,7 +312,7 @@ jobs:
         runner-hosted-on: 'Shanghai'
 
   Orca-Basic-Tf2-Py39-Spark3:
-    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Tf2-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Tf2-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -257,6 +257,87 @@ jobs:
         job-name: Orca-Basic-Tf2-Py38-Spark3
         runner-hosted-on: 'Shanghai'
 
+  Orca-Basic-Py39-Spark3:
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
+    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py39-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-basic-py39-spark3-action/nightly-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py39
+    - name: Create Job Badge
+      uses: ./.github/actions/create-job-status-badge
+      if: ${{ always() }}
+      with:
+        secret: ${{ secrets.GIST_SECRET}}
+        gist-id: ${{env.GIST_ID}}
+        is-self-hosted-runner: true
+        file-name: Orca-Basic-Py39-Spark3.json
+        type: job
+        job-name: Orca-Basic-Py39-Spark3
+        runner-hosted-on: 'Shanghai'
+
+  Orca-Basic-PyTorch-Py39-Spark3:
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-PyTorch-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
+    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py39-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-basic-pytorch-py39-spark3-action/nightly-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py39
+    - name: Create Job Badge
+      uses: ./.github/actions/create-job-status-badge
+      if: ${{ always() }}
+      with:
+        secret: ${{ secrets.GIST_SECRET}}
+        gist-id: ${{env.GIST_ID}}
+        is-self-hosted-runner: true
+        file-name: Orca-Basic-PyTorch-Py39-Spark3.json
+        type: job
+        job-name: Orca-Basic-PyTorch-Py39-Spark3
+        runner-hosted-on: 'Shanghai'
+
+  Orca-Basic-Tf2-Py39-Spark3:
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Basic-Tf2-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
+    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py39-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-basic-tf2-py39-spark3-action/nightly-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py39
+    - name: Create Job Badge
+      uses: ./.github/actions/create-job-status-badge
+      if: ${{ always() }}
+      with:
+        secret: ${{ secrets.GIST_SECRET}}
+        gist-id: ${{env.GIST_ID}}
+        is-self-hosted-runner: true
+        file-name: Orca-Basic-Tf2-Py39-Spark3.json
+        type: job
+        job-name: Orca-Basic-Tf2-Py39-Spark3
+        runner-hosted-on: 'Shanghai'
+
   Orca-ExampleTest-Tf1-Py37-Spark3:
     if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-ExampleTest-Tf1-Py37-Spark3' || github.event.inputs.artifact == 'all' }} 
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]


### PR DESCRIPTION
## Description

### 1. Summary of the change 

add orca basic test with python=3.9
- create conda env `py39`
- add 3 nightly-tests
- remove conda env `py39`

### 2. How to test?
Nightly-test:
- [ ] Orca-Basic-Py39-Spark3
- [ ]  Orca-Basic-Pytorch-Py39-Spark3
- [ ]  Orca-Basic-Tf2-Py39-Spark3
