### PR TITLE
[ORCA] Support multi-output model with tf2 ray estimator

### DIFF
--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -525,6 +525,9 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                prediction results is not guaranteed to be the same as the input order, so you need
                to add id information to the input to identify the corresponding prediction results.
                Default: None.
+        :param output_cols: Column name(s) of the model output data. Only used when data is
+               a Spark DataFrame, note the order of column name(s) should be consistent with the
+               model output data. Default: None.
         :return:
         """
         # Use the local batch size for each worker to convert to XShards

--- a/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/ray_estimator.py
@@ -497,7 +497,8 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                 callbacks: Optional[List["Callback"]]=None,
                 data_config: Optional[Dict]=None,
                 feature_cols: Optional[List[str]]=None,
-                min_partition_num: Optional[int]=None) -> Union["SparkXShards",
+                min_partition_num: Optional[int]=None,
+                output_cols: Optional[List[str]]=None) -> Union["SparkXShards",
                                                                 "SparkDataFrame"]:
         """
         Predict the input data
@@ -542,6 +543,7 @@ class TensorFlow2Estimator(OrcaRayEstimator):
             steps=steps,
             callbacks=callbacks,
             data_config=data_config,
+            output_cols=output_cols
         )
         from bigdl.orca.data import SparkXShards
         from pyspark.sql import DataFrame
@@ -556,7 +558,7 @@ class TensorFlow2Estimator(OrcaRayEstimator):
                                               accept_str_col=True,
                                               shard_size=local_batch_size)
             pred_shards = self._predict_spark_xshards(xshards, params)
-            result = convert_predict_xshards_to_dataframe(data, pred_shards)
+            result = convert_predict_xshards_to_dataframe(data, pred_shards, output_cols)
         elif isinstance(data, SparkXShards):
             xshards = data.to_lazy()
             if xshards._get_class_name() == 'pandas.core.frame.DataFrame':

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -482,7 +482,8 @@ class TFRunner:
 
         return stats
 
-    def predict(self, data_creator, batch_size, verbose, steps, callbacks, data_config):
+    def predict(self, data_creator, batch_size, verbose, steps, callbacks, data_config,
+                output_cols):
         config = copy.copy(self.config)
         if data_config is not None:
             config.update(data_config)
@@ -547,7 +548,13 @@ class TFRunner:
                 y = local_model.predict(shard["x"], **params)
             else:
                 y = local_model.predict(shard, **params)
-            return {"prediction": y}
+            if output_cols is None:
+                return {"prediction": y}
+            else:
+                if len(output_cols) == 1:
+                    return {output_cols[0]: y}
+                else:
+                    return dict(zip(output_cols, y))
 
         new_part = [predict_fn(shard) for shard in partition]
 


### PR DESCRIPTION
## Description
We previously added support for the pyspark backend in PR #7796, but we still need to align the code with the ray backend as well.

### 1. Why the change?
Ray backend also needs to support a multi-output model.

### 2. User API changes
We have added a new parameter, output_cols, for users to provide output column information.

```python
from bigdl.orca.learn.tf2 import Estimator

def model_creator(config):
    # define a multi-output model
    return model

estimator = Estimator.from_keras(model_creator=model_creator, backend="ray")
estimator.predict(df, feature_cols=["input"], output_cols=["tf_output_1", "tf2_output_2"])
```

- Single-dimensional prediction output:

| index | input_1 |  tf_output_1 | tf_output_2 |
| --- | --- | --- | --- |
| 0 | [[[0.535554111003... | [0.34790271520614... | [0.02838393114507... |
| 1 | [[[0.880806922912... | [0.29939782619476... | [-0.0265996530652... |

- Multi-dimensional prediction output:

| index | input_1 | input_2 | tf_output_1 | tf_output_2 |
| --- | --- | --- | --- | --- |
| 0 | [[[0.022802922874... | [[[0.198862820863... | [[[-0.76845872402... | [[[-0.18314521014... |
| 1 | [[[0.502752780914... | [[[0.679012894630... | [[[-0.35531336069... | [[[-0.26589363813... |


### 3. Summary of the change 
Reconstructed the Spark DataFrame as the return result with the provided columns.

### 4. How to test?
- [x] Unit test