### PR TITLE
Friesian: support backend choice in workflow examples

### DIFF
--- a/python/friesian/example/two_tower/train_2tower.py
+++ b/python/friesian/example/two_tower/train_2tower.py
@@ -188,23 +188,20 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    ray_on_spark = args.backend == "ray"
     if args.cluster_mode == "local":
-        sc = init_orca_context("local", init_ray_on_spark=ray_on_spark)
+        sc = init_orca_context("local")
     elif args.cluster_mode == "standalone":
         sc = init_orca_context("standalone", master=args.master,
                                cores=args.executor_cores, num_nodes=args.num_executors,
                                memory=args.executor_memory,
                                driver_cores=args.driver_cores, driver_memory=args.driver_memory,
-                               conf=spark_conf,
-                               init_ray_on_spark=ray_on_spark)
+                               conf=spark_conf)
     elif args.cluster_mode == "yarn":
         sc = init_orca_context("yarn-client", cores=args.executor_cores,
                                num_nodes=args.num_executors, memory=args.executor_memory,
                                driver_cores=args.driver_cores, driver_memory=args.driver_memory,
                                conf=spark_conf, extra_python_lib="model.py",
-                               object_store_memory="80g",
-                               init_ray_on_spark=ray_on_spark)
+                               object_store_memory="80g")
     elif args.cluster_mode == "spark-submit":
         sc = init_orca_context("spark-submit")
     else:

--- a/python/friesian/example/two_tower/train_2tower.py
+++ b/python/friesian/example/two_tower/train_2tower.py
@@ -163,8 +163,8 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Two Tower Training/Inference')
     parser.add_argument('--cluster_mode', type=str, default="local",
                         help='The cluster mode, such as local, yarn, standalone or spark-submit.')
-    parser.add_argument('--backend', type=str, default='ray',
-                        choices=('spark', 'ray'),
+    parser.add_argument('--backend', type=str, default="ray",
+                        choices=("spark", "ray"),
                         help='The backend of Orca Estimator, either ray or spark.')
     parser.add_argument('--master', type=str, default=None,
                         help='The master url, only used when cluster mode is standalone.')
@@ -188,7 +188,7 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
-    ray_on_spark = True if args.backend=='ray' else False
+    ray_on_spark = args.backend == "ray"
     if args.cluster_mode == "local":
         sc = init_orca_context("local", init_ray_on_spark=ray_on_spark)
     elif args.cluster_mode == "standalone":

--- a/python/friesian/example/two_tower/train_2tower.py
+++ b/python/friesian/example/two_tower/train_2tower.py
@@ -42,7 +42,7 @@ spark_conf = {"spark.network.timeout": "10000000",
               "spark.executor.memoryOverhead": "120g"}
 
 
-def train(config, train_tbl, test_tbl, epochs=1, batch_size=128, model_dir='.'):
+def train(config, train_tbl, test_tbl, epochs=1, batch_size=128, model_dir='.', backend='ray'):
     two_tower = TwoTowerModel(config["user_col_info"], config["item_col_info"])
 
     def model_creator(config):
@@ -56,6 +56,7 @@ def train(config, train_tbl, test_tbl, epochs=1, batch_size=128, model_dir='.'):
 
     estimator = Estimator.from_keras(model_creator=model_creator,
                                      verbose=False,
+                                     backend=backend,
                                      config=config)
 
     callbacks = []
@@ -162,6 +163,9 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Two Tower Training/Inference')
     parser.add_argument('--cluster_mode', type=str, default="local",
                         help='The cluster mode, such as local, yarn, standalone or spark-submit.')
+    parser.add_argument('--backend', type=str, default='ray',
+                        choices=('spark', 'ray'),
+                        help='The backend of Orca Estimator, either ray or spark.')
     parser.add_argument('--master', type=str, default=None,
                         help='The master url, only used when cluster mode is standalone.')
     parser.add_argument('--executor_cores', type=int, default=8,
@@ -184,22 +188,23 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
 
+    ray_on_spark = True if args.backend=='ray' else False
     if args.cluster_mode == "local":
-        sc = init_orca_context("local", init_ray_on_spark=True)
+        sc = init_orca_context("local", init_ray_on_spark=ray_on_spark)
     elif args.cluster_mode == "standalone":
         sc = init_orca_context("standalone", master=args.master,
                                cores=args.executor_cores, num_nodes=args.num_executors,
                                memory=args.executor_memory,
                                driver_cores=args.driver_cores, driver_memory=args.driver_memory,
                                conf=spark_conf,
-                               init_ray_on_spark=True)
+                               init_ray_on_spark=ray_on_spark)
     elif args.cluster_mode == "yarn":
         sc = init_orca_context("yarn-client", cores=args.executor_cores,
                                num_nodes=args.num_executors, memory=args.executor_memory,
                                driver_cores=args.driver_cores, driver_memory=args.driver_memory,
                                conf=spark_conf, extra_python_lib="model.py",
                                object_store_memory="80g",
-                               init_ray_on_spark=True)
+                               init_ray_on_spark=ray_on_spark)
     elif args.cluster_mode == "spark-submit":
         sc = init_orca_context("spark-submit")
     else:
@@ -235,6 +240,6 @@ if __name__ == '__main__':
                     "intra_op_parallelism": args.executor_cores}
 
     train(train_config, train_tbl, test_tbl, epochs=args.epochs, batch_size=args.batch_size,
-          model_dir=args.model_dir)
+          model_dir=args.model_dir, backend=args.backend)
 
     stop_orca_context()

--- a/python/friesian/example/wnd/recsys2021/wnd_train_recsys.py
+++ b/python/friesian/example/wnd/recsys2021/wnd_train_recsys.py
@@ -263,7 +263,6 @@ if __name__ == "__main__":
     parser.add_option('--cluster_mode', type=str, default="local",
                       help='The cluster mode, such as local, yarn or standalone.')
     parser.add_option('--backend', type=str, default="ray",
-                      choices=("spark", "ray"),
                       help='The backend of Orca Estimator, either ray or spark.')
     parser.add_option('--master', type=str, default=None,
                       help='The master url, only used when cluster mode is standalone.')
@@ -289,7 +288,7 @@ if __name__ == "__main__":
     (options, args) = parser.parse_args(sys.argv)
     options.hidden_units = [int(x) for x in options.hidden_units.split(',')]
 
-    ray_on_spark = args.backend == "ray"
+    ray_on_spark = options.backend == "ray"
     if options.cluster_mode == "local":
         init_orca_context("local", cores=options.executor_cores, memory=options.executor_memory,
                           init_ray_on_spark=ray_on_spark)

--- a/python/friesian/example/wnd/recsys2021/wnd_train_recsys.py
+++ b/python/friesian/example/wnd/recsys2021/wnd_train_recsys.py
@@ -262,6 +262,9 @@ if __name__ == "__main__":
     parser = OptionParser()
     parser.add_option('--cluster_mode', type=str, default="local",
                       help='The cluster mode, such as local, yarn or standalone.')
+    parser.add_option('--backend', type=str, default="ray",
+                      choices=("spark", "ray"),
+                      help='The backend of Orca Estimator, either ray or spark.')
     parser.add_option('--master', type=str, default=None,
                       help='The master url, only used when cluster mode is standalone.')
     parser.add_option('--executor_cores', type=int, default=44,
@@ -286,22 +289,23 @@ if __name__ == "__main__":
     (options, args) = parser.parse_args(sys.argv)
     options.hidden_units = [int(x) for x in options.hidden_units.split(',')]
 
+    ray_on_spark = args.backend == "ray"
     if options.cluster_mode == "local":
         init_orca_context("local", cores=options.executor_cores, memory=options.executor_memory,
-                          init_ray_on_spark=True)
+                          init_ray_on_spark=ray_on_spark)
     elif options.cluster_mode == "standalone":
         init_orca_context("standalone", master=options.master,
                           cores=options.executor_cores, num_nodes=options.num_executor,
                           memory=options.executor_memory,
                           driver_cores=options.driver_cores, driver_memory=options.driver_memory,
                           conf=conf,
-                          init_ray_on_spark=True)
+                          init_ray_on_spark=ray_on_spark)
     elif options.cluster_mode == "yarn":
         init_orca_context("yarn-client", cores=options.executor_cores,
                           num_nodes=options.num_executor, memory=options.executor_memory,
                           driver_cores=options.driver_cores, driver_memory=options.driver_memory,
                           conf=conf,
-                          init_ray_on_spark=True)
+                          init_ray_on_spark=ray_on_spark)
     elif options.cluster_mode == "spark-submit":
         init_orca_context("spark-submit")
     else:
@@ -336,7 +340,7 @@ if __name__ == "__main__":
         model_creator=model_creator,
         verbose=True,
         config=config,
-        backend="ray")
+        backend=args.backend)
 
     train_count = train_tbl.size()
     print("train size: ", train_count)

--- a/python/friesian/example/wnd/recsys2021/wnd_train_recsys.py
+++ b/python/friesian/example/wnd/recsys2021/wnd_train_recsys.py
@@ -339,7 +339,7 @@ if __name__ == "__main__":
         model_creator=model_creator,
         verbose=True,
         config=config,
-        backend=args.backend)
+        backend=options.backend)
 
     train_count = train_tbl.size()
     print("train size: ", train_count)

--- a/python/friesian/example/wnd/recsys2021/wnd_train_recsys.py
+++ b/python/friesian/example/wnd/recsys2021/wnd_train_recsys.py
@@ -288,23 +288,19 @@ if __name__ == "__main__":
     (options, args) = parser.parse_args(sys.argv)
     options.hidden_units = [int(x) for x in options.hidden_units.split(',')]
 
-    ray_on_spark = options.backend == "ray"
     if options.cluster_mode == "local":
-        init_orca_context("local", cores=options.executor_cores, memory=options.executor_memory,
-                          init_ray_on_spark=ray_on_spark)
+        init_orca_context("local", cores=options.executor_cores, memory=options.executor_memory)
     elif options.cluster_mode == "standalone":
         init_orca_context("standalone", master=options.master,
                           cores=options.executor_cores, num_nodes=options.num_executor,
                           memory=options.executor_memory,
                           driver_cores=options.driver_cores, driver_memory=options.driver_memory,
-                          conf=conf,
-                          init_ray_on_spark=ray_on_spark)
+                          conf=conf)
     elif options.cluster_mode == "yarn":
         init_orca_context("yarn-client", cores=options.executor_cores,
                           num_nodes=options.num_executor, memory=options.executor_memory,
                           driver_cores=options.driver_cores, driver_memory=options.driver_memory,
-                          conf=conf,
-                          init_ray_on_spark=ray_on_spark)
+                          conf=conf)
     elif options.cluster_mode == "spark-submit":
         init_orca_context("spark-submit")
     else:


### PR DESCRIPTION
## Description


### 1. Why the change?

As title, user can choose backend via program args `--backend` when running the example

### 2. How to test?

- [ ] Fresian-Example-Test