### PR TITLE
Chronos: fix `forecaster.evaluate` of tensorflow backend

### DIFF
--- a/python/chronos/src/bigdl/chronos/benchmark/benchmark_chronos.py
+++ b/python/chronos/src/bigdl/chronos/benchmark/benchmark_chronos.py
@@ -195,8 +195,11 @@ def accuracy(args, records, forecaster, train_loader, val_loader, test_loader):
     evaluate stage will record model accuracy.
     """
 
-    forecaster.fit(train_loader, validation_data=val_loader,
-                   epochs=args.training_epochs, validation_mode="best_epoch")
+    if args.framework == 'torch':
+        forecaster.fit(train_loader, validation_data=val_loader,
+                       epochs=args.training_epochs, validation_mode="best_epoch")
+    else:
+        forecaster.fit(train_loader, epochs=args.training_epochs)
 
     metrics = forecaster.evaluate(test_loader, multioutput='uniform_average')
 

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -378,9 +378,11 @@ class BaseTF2Forecaster(Forecaster):
         else:
             if isinstance(data, tuple):
                 input_data, target = data
+            elif isinstance(data, TSDataset):
+                input_data, target = data.to_numpy()
             else:
                 input_data = data
-                target = np.asarray(tuple(map(lambda x: x[1], data.as_numpy_iterator())))
+                target = np.concatenate(list((map(lambda x: x[1], data.as_numpy_iterator()))))
             if quantize:
                 invalidInputError(self.accelerate_method == "tensorflow_int8",
                                   "Can't find the quantized model, "

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_seq2seq_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_seq2seq_keras_forecaster.py
@@ -100,7 +100,29 @@ class TestSeq2SeqForecaster(TestCase):
         assert yhat.shape == (400, 2, 2)
         mse = self.forecaster.evaluate(test_data, multioutput="raw_values")
         assert mse[0].shape == test_data[-1].shape[1:]
-    
+
+    def test_seq2seq_forecaster_evaluate(self):
+        train_tsdata, _, test_tsdata = create_tsdataset()
+        forecaster = Seq2SeqForecaster.from_tsdataset(train_tsdata,
+                                                      past_seq_len=24,
+                                                      future_seq_len=2,
+                                                      lstm_hidden_dim=16,
+                                                      lstm_layer_num=2)
+        forecaster.fit(train_tsdata, epochs=1, batch_size=32)
+
+        # tf dataset
+        test = test_tsdata.to_tf_dataset(batch_size=32)
+        metrics = forecaster.evaluate(test, multioutput='uniform_average')
+
+        # TSDataset
+        metrics_tsdata = forecaster.evaluate(test_tsdata, multioutput='uniform_average')
+        np.testing.assert_almost_equal(metrics, metrics_tsdata, decimal=5)
+
+        # numpy
+        test_data = test_tsdata.to_numpy()
+        metrics_data = forecaster.evaluate(test_data, multioutput='uniform_average')
+        np.testing.assert_almost_equal(metrics_data, metrics_tsdata, decimal=5)
+
     def test_seq2seq_fit_tf_data(self):
         train_data, _, test_data = create_data(tf_data=True)
         self.forecaster.fit(train_data,

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
@@ -106,6 +106,24 @@ class TestTCNForecaster(TestCase):
                                        multioutput="raw_values")
         assert mse[0].shape == test_data[1].shape[1:]
 
+    def test_tcn_forecaster_evaluate(self):
+        train_tsdata, _, test_tsdata = create_tsdataset()
+        forecaster = TCNForecaster.from_tsdataset(train_tsdata, past_seq_len=24, future_seq_len=5)
+        forecaster.fit(train_tsdata, epochs=1, batch_size=32)
+
+        # tf dataset
+        test = test_tsdata.to_tf_dataset(batch_size=32)
+        metrics = forecaster.evaluate(test, multioutput='uniform_average')
+
+        # TSDataset
+        metrics_tsdata = forecaster.evaluate(test_tsdata, multioutput='uniform_average')
+        np.testing.assert_almost_equal(metrics, metrics_tsdata, decimal=5)
+
+        # numpy
+        test_data = test_tsdata.to_numpy()
+        metrics_data = forecaster.evaluate(test_data, multioutput='uniform_average')
+        np.testing.assert_almost_equal(metrics_data, metrics_tsdata, decimal=5)
+
     def test_tcn_forecaster_fit_tf_data(self):
         train_data, _, test_data = create_data(tf_data=True)
         self.forecaster.fit(train_data,


### PR DESCRIPTION
## Description

If input data of `forecaster.evaluate` under tensorflow backend is tf.data.Dataset or TSDataset, there exists errors.

### 2. User API changes

None

### 3. Summary of the change 

- fix internal implementation of `forecaster.evaluate`
- add related uts
- modify related usage in benchmark tool

### 4. How to test?
- [x] Unit test
