### PR TITLE
Orca: add python 3.9 tests (nightly)

### DIFF
--- a/.github/actions/orca/orca-exampletest-ray-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-exampletest-ray-py39-spark3-action/nightly-test/action.yml
@@ -1,0 +1,34 @@
+name: 'Run Orca Python ExampleTest Ray Py39 Spark3'
+description: 'Run Orca Python ExampleTest Ray Py39 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py39
+        export SPARK_LOCAL_HOSTNAME=localhost
+        pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3[ray]
+
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==2.9.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchvision==0.8.2
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchmetrics==0.10.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pandas==1.1.5
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tabulate==0.8.7
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} xgboost_ray==0.1.8
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} gym[atari]==0.17.1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tqdm==4.46.1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} dm_tree==0.1.8
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} mxnet==1.6.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} matplotlib==3.5.3
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pyarrow==4.0.1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} albumentations
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} grpcio==1.43.0
+
+        chmod a+x python/orca/dev/example/run-example-test-ray.sh
+        python/orca/dev/example/run-example-test-ray.sh
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/orca-exampletest-ray-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-exampletest-ray-py39-spark3-action/nightly-test/action.yml
@@ -15,7 +15,7 @@ runs:
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchvision==0.8.2
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchmetrics==0.10.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pandas==1.1.5
-        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn==1.2.2
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tabulate==0.8.7
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} xgboost_ray==0.1.8
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} gym[atari]==0.17.1

--- a/.github/actions/orca/orca-pytest-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-pytest-py39-spark3-action/nightly-test/action.yml
@@ -26,4 +26,3 @@ runs:
         source deactivate
       env:
         BIGDL_ROOT: ${{ github.workspace }}
-        ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/orca-pytest-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-pytest-py39-spark3-action/nightly-test/action.yml
@@ -1,0 +1,29 @@
+name: 'Run Orca Python Py39 Spark3'
+description: 'Run Orca Python Py39 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py39
+        export SPARK_LOCAL_HOSTNAME=localhost
+        
+        # unit test test_inference_model requires "app.properties"
+        bash python/dev/release_default_linux_spark3.sh default false false false -Ddata-store-url=$HTTP_URI -U
+        
+        pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3
+
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchvision==0.8.2
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchmetrics==0.10.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pyarrow==4.0.1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pandas==1.1.5
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} h5py==2.10.0  
+
+        chmod a+x python/orca/dev/test/run-pytests-spark.sh
+        python/orca/dev/test/run-pytests-spark.sh
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}
+        ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/orca-pytest-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-pytest-py39-spark3-action/nightly-test/action.yml
@@ -19,7 +19,7 @@ runs:
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchmetrics==0.10.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pyarrow==4.0.1
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pandas==1.1.5
-        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} h5py==2.10.0  
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} h5py
 
         chmod a+x python/orca/dev/test/run-pytests-spark.sh
         python/orca/dev/test/run-pytests-spark.sh

--- a/.github/actions/orca/orca-pytest-ray-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-pytest-ray-py39-spark3-action/nightly-test/action.yml
@@ -19,7 +19,7 @@ runs:
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} mmcv==1.7.1
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} opencv-python-headless
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pandas==1.1.5
-        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn==0.22.2.post1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn==1.2.2
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} xgboost_ray==0.1.8
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tabulate==0.8.7
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-optimize==0.8.1

--- a/.github/actions/orca/orca-pytest-ray-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-pytest-ray-py39-spark3-action/nightly-test/action.yml
@@ -32,4 +32,3 @@ runs:
         source deactivate
       env:
         BIGDL_ROOT: ${{ github.workspace }}
-        ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/orca-pytest-ray-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-pytest-ray-py39-spark3-action/nightly-test/action.yml
@@ -1,0 +1,35 @@
+name: 'Run Orca Python Ray Py39 Spark3'
+description: 'Run Orca Python Ray Py39 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py39
+        export SPARK_LOCAL_HOSTNAME=localhost
+        
+        pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3[ray]
+
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==2.9.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchvision==0.8.2
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchmetrics==0.10.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pyarrow==4.0.1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} mmcv==1.7.1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} opencv-python-headless
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pandas==1.1.5
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn==0.22.2.post1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} xgboost_ray==0.1.8
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tabulate==0.8.7
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-optimize==0.8.1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} grpcio==1.43.0
+        
+        pip list
+        
+        chmod a+x python/orca/dev/test/run-pytests-ray.sh
+        python/orca/dev/test/run-pytests-ray.sh
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}
+        ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/orca-tutorial-ncf-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-tutorial-ncf-py39-spark3-action/nightly-test/action.yml
@@ -19,7 +19,7 @@ runs:
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchmetrics==0.10.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tqdm
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pandas
-        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn==1.2.2
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pyarrow
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} grpcio==1.43.0
 

--- a/.github/actions/orca/orca-tutorial-ncf-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-tutorial-ncf-py39-spark3-action/nightly-test/action.yml
@@ -1,0 +1,37 @@
+name: 'Run Orca Tutorial NCF Py39 Spark'
+description: 'Run Orca Tutorial NCF Py39 Spark'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py39
+        export SPARK_LOCAL_HOSTNAME=localhost
+
+        pip install -i https://pypi.org/simple --pre --upgrade bigdl-orca-spark3
+        unset SPARK_HOME
+        
+        # install requires
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==2.9.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchvision==0.8.2
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchmetrics==0.10.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tqdm
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pandas
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pyarrow
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} grpcio==1.43.0
+
+        pip list
+
+        # TODO: delete the following two lines after fix saving optimizer states in spark backend
+        sed 's/args.backend = "ray"/args.backend = "spark"/1' python/orca/tutorial/NCF/tf_train_spark_dataframe.py -i
+        sed 's/args.backend = "ray"/args.backend = "spark"/1' python/orca/tutorial/NCF/tf_train_xshards.py -i
+
+        chmod a+x python/orca/dev/test/run-tutorial-NCF.sh
+        python/orca/dev/test/run-tutorial-NCF.sh spark ml-1m
+        python/orca/dev/test/run-tutorial-NCF.sh spark ml-100k
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/orca-tutorial-ncf-ray-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-tutorial-ncf-ray-py39-spark3-action/nightly-test/action.yml
@@ -1,0 +1,33 @@
+name: 'Run Orca Tutorial NCF Ray Py39 Spark3'
+description: 'Run Orca Tutorial NCF Ray Py39 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py39
+
+        export SPARK_LOCAL_HOSTNAME=localhost
+        unset SPARK_HOME
+        
+        pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3[ray]
+
+        # install requires
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==2.9.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchvision==0.8.2
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchmetrics==0.10.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tqdm
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pandas
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pyarrow
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} grpcio==1.43.0
+
+        pip list
+        chmod a+x python/orca/dev/test/run-tutorial-NCF.sh
+        python/orca/dev/test/run-tutorial-NCF.sh ray ml-1m
+        python/orca/dev/test/run-tutorial-NCF.sh ray ml-100k
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/orca-tutorial-ncf-ray-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-tutorial-ncf-ray-py39-spark3-action/nightly-test/action.yml
@@ -20,7 +20,7 @@ runs:
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchmetrics==0.10.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tqdm
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pandas
-        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn==1.2.2
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pyarrow
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} grpcio==1.43.0
 

--- a/.github/actions/orca/orca-tutorial-notebook-xshards-image-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-tutorial-notebook-xshards-image-py39-spark3-action/nightly-test/action.yml
@@ -19,7 +19,7 @@ runs:
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==2.9.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchvision==0.8.2
-        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn==0.22.2.post1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn==1.2.2
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} opencv-python-headless
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} grpcio==1.43.0
         

--- a/.github/actions/orca/orca-tutorial-notebook-xshards-image-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-tutorial-notebook-xshards-image-py39-spark3-action/nightly-test/action.yml
@@ -11,7 +11,7 @@ runs:
         
         pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3[ray]
 
-        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} jep==3.9.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} jep==3.9.1
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} cloudpickle
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} jupyter
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} seaborn

--- a/.github/actions/orca/orca-tutorial-notebook-xshards-image-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-tutorial-notebook-xshards-image-py39-spark3-action/nightly-test/action.yml
@@ -1,0 +1,31 @@
+name: 'Run Orca Notebook Xshards Image Py39 Spark3'
+description: 'Run Notebook Xshards Image Py39 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py39
+        export SPARK_LOCAL_HOSTNAME=localhost
+        
+        pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3[ray]
+
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} jep==3.9.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} cloudpickle
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} jupyter
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} seaborn
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pyarrow 
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==2.9.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchvision==0.8.2
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn==0.22.2.post1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} opencv-python-headless
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} grpcio==1.43.0
+        
+        pip list
+        chmod a+x python/orca/dev/test/run-tutorial-xshards-images.sh
+        python/orca/dev/test/run-tutorial-xshards-images.sh
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}

--- a/.github/actions/orca/orca-tutorial-notebook-xshards-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-tutorial-notebook-xshards-py39-spark3-action/nightly-test/action.yml
@@ -1,4 +1,4 @@
- name: 'Run Orca Notebook Xshards Py39 Spark3'
+name: 'Run Orca Notebook Xshards Py39 Spark3'
 description: 'Run Notebook Xshards Py39 Spark3'
 runs:
   using: "composite"

--- a/.github/actions/orca/orca-tutorial-notebook-xshards-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-tutorial-notebook-xshards-py39-spark3-action/nightly-test/action.yml
@@ -12,7 +12,7 @@ runs:
         pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3[ray]
 
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==2.9.0
-        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} jep==3.9.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} jep==3.9.1
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} cloudpickle
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} jupyter
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} seaborn

--- a/.github/actions/orca/orca-tutorial-notebook-xshards-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-tutorial-notebook-xshards-py39-spark3-action/nightly-test/action.yml
@@ -1,4 +1,4 @@
-name: 'Run Orca Notebook Xshards Py39 Spark3'
+ name: 'Run Orca Notebook Xshards Py39 Spark3'
 description: 'Run Notebook Xshards Py39 Spark3'
 runs:
   using: "composite"

--- a/.github/actions/orca/orca-tutorial-notebook-xshards-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-tutorial-notebook-xshards-py39-spark3-action/nightly-test/action.yml
@@ -19,7 +19,7 @@ runs:
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pyarrow
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchvision==0.8.2
-        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn==0.22.2.post1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn==1.2.2
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} grpcio==1.43.0
         
         pip list

--- a/.github/actions/orca/orca-tutorial-notebook-xshards-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-tutorial-notebook-xshards-py39-spark3-action/nightly-test/action.yml
@@ -1,0 +1,31 @@
+name: 'Run Orca Notebook Xshards Py39 Spark3'
+description: 'Run Notebook Xshards Py39 Spark3'
+runs:
+  using: "composite"
+  steps:
+    - name: Run Test
+      shell: bash
+      run: |
+        source activate py39
+        export SPARK_LOCAL_HOSTNAME=localhost
+
+        pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3[ray]
+
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==2.9.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} jep==3.9.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} cloudpickle
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} jupyter
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} seaborn
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pyarrow
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchvision==0.8.2
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} scikit-learn==0.22.2.post1
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} grpcio==1.43.0
+        
+        pip list
+
+        chmod a+x python/orca/dev/test/run-tutorial-xshards-notebooks.sh
+        python/orca/dev/test/run-tutorial-xshards-notebooks.sh
+        source deactivate
+      env:
+        BIGDL_ROOT: ${{ github.workspace }}

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -2,7 +2,7 @@ name: Nightly Test
 
 on:
 
-  pull_request:
+  #pull_request:
     #branchs: [ main ]
 
   schedule:
@@ -50,7 +50,7 @@ on:
         - Orca-Tutorial-Notebook-Xshards-Image-Py37-Spark3
         - Orca-Tutorial-Notebook-Xshards-Py38-Spark3
         - Orca-Tutorial-Notebook-Xshards-Image-Py38-Spark3
-        - Orca-Tutorial-Notebook-Xshards-Py39-Spark3
+        #- Orca-Tutorial-Notebook-Xshards-Py39-Spark3
         - Orca-Tutorial-Notebook-Xshards-Image-Py39-Spark3
         - Orca-Tutorial-NCF-Ray-Py37-Spark3
         - Orca-Tutorial-NCF-Py37-Spark3
@@ -433,7 +433,7 @@ jobs:
         runner-hosted-on: 'Shanghai'
 
   Orca-ExampleTest-Ray-Py39-Spark3:
-    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-ExampleTest-Ray-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-ExampleTest-Ray-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
@@ -665,7 +665,7 @@ jobs:
         runner-hosted-on: 'Shanghai'
 
   Orca-Pytest-Ray-Py39-Spark3:
-    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Pytest-Ray-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Pytest-Ray-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
@@ -752,7 +752,7 @@ jobs:
         runner-hosted-on: 'Shanghai'
 
   Orca-Pytest-Py39-Spark3:
-    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Pytest-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Pytest-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
@@ -1011,38 +1011,9 @@ jobs:
         type: job
         job-name: Orca-Tutorial-Notebook-Xshards-Image-Py38-Spark3
         runner-hosted-on: 'Shanghai' 
-
-  Orca-Tutorial-Notebook-Xshards-Py39-Spark3:
-    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-Notebook-Xshards-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
-    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK8
-      uses: ./.github/actions/jdk-setup-action
-    - name: Set up maven
-      uses: ./.github/actions/maven-setup-action 
-    - name: Setup env
-      uses: ./.github/actions/orca/setup-env/setup-orca-python-py39-basic
-    - name: Run Test
-      uses: ./.github/actions/orca/orca-tutorial-notebook-xshards-py39-spark3-action/nightly-test
-    - name: Remove Env
-      if: ${{ always() }}
-      uses: ./.github/actions/remove-env/remove-env-py39
-    - name: Create Job Badge
-      uses: ./.github/actions/create-job-status-badge
-      if: ${{ always() }}
-      with:
-        secret: ${{ secrets.GIST_SECRET}}
-        gist-id: ${{env.GIST_ID}}
-        is-self-hosted-runner: true
-        file-name: Orca-Tutorial-Notebook-Xshards-Py39-Spark3.json
-        type: job
-        job-name: Orca-Tutorial-Notebook-Xshards-Py39-Spark3
-        runner-hosted-on: 'Shanghai' 
   
   Orca-Tutorial-Notebook-Xshards-Image-Py39-Spark3:
-    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-Notebook-Xshards-Image-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-Notebook-Xshards-Image-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
@@ -1188,7 +1159,7 @@ jobs:
         runner-hosted-on: 'Shanghai' 
 
   Orca-Tutorial-NCF-Ray-Py39-Spark3:
-    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-NCF-Ray-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-NCF-Ray-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
@@ -1217,7 +1188,7 @@ jobs:
         runner-hosted-on: 'Shanghai' 
 
   Orca-Tutorial-NCF-Py39-Spark3:
-    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-NCF-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-NCF-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -50,7 +50,6 @@ on:
         - Orca-Tutorial-Notebook-Xshards-Image-Py37-Spark3
         - Orca-Tutorial-Notebook-Xshards-Py38-Spark3
         - Orca-Tutorial-Notebook-Xshards-Image-Py38-Spark3
-        #- Orca-Tutorial-Notebook-Xshards-Py39-Spark3
         - Orca-Tutorial-Notebook-Xshards-Image-Py39-Spark3
         - Orca-Tutorial-NCF-Ray-Py37-Spark3
         - Orca-Tutorial-NCF-Py37-Spark3

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -2,7 +2,7 @@ name: Nightly Test
 
 on:
 
-  #pull_request:
+  pull_request:
     #branchs: [ main ]
 
   schedule:
@@ -27,8 +27,10 @@ on:
         - Orca-Basic-Tf2-Py39-Spark3
         - Orca-Pytest-Ray-Py37-Spark3
         - Orca-Pytest-Ray-Py38-Spark3
+        - Orca-Pytest-Ray-Py39-Spark3
         - Orca-Pytest-Py37-Spark3-Tf1
         - Orca-Pytest-Py38-Spark3
+        - Orca-Pytest-Py39-Spark3
         - Orca-ExampleTest-Ray-Ctx-Py37-Spark3
         - Orca-Pytest-Horovod-Py37-Spark3
         - Orca-Pytest-Jep-Py37-Spark3
@@ -37,6 +39,7 @@ on:
         - Orca-ExampleTest-Tf1-Py37-Spark3
         - Orca-ExampleTest-Ray-Py37-Spark3
         - Orca-ExampleTest-Ray-Py38-Spark3
+        - Orca-ExampleTest-Ray-Py39-Spark3
         - Orca-ExampleTest-Horovod-Pytorch-Py37-Spark3
         - Orca-ExampleTest-Horovod-Tf2-Py37-Spark3
         - Orca-ExampleTest-Horovod-Pytorch-Py38-Spark3
@@ -47,10 +50,14 @@ on:
         - Orca-Tutorial-Notebook-Xshards-Image-Py37-Spark3
         - Orca-Tutorial-Notebook-Xshards-Py38-Spark3
         - Orca-Tutorial-Notebook-Xshards-Image-Py38-Spark3
+        - Orca-Tutorial-Notebook-Xshards-Py39-Spark3
+        - Orca-Tutorial-Notebook-Xshards-Image-Py39-Spark3
         - Orca-Tutorial-NCF-Ray-Py37-Spark3
         - Orca-Tutorial-NCF-Py37-Spark3
         - Orca-Tutorial-NCF-Ray-Py38-Spark3
         - Orca-Tutorial-NCF-Py38-Spark3
+        - Orca-Tutorial-NCF-Ray-Py39-Spark3
+        - Orca-Tutorial-NCF-Py39-Spark3
         - Orca-Pytest-Ray-Ctx-Py37-Spark3
         - Dllib-Scala-UT
         - Friesian-Scala-UT
@@ -425,6 +432,35 @@ jobs:
         job-name: Orca-ExampleTest-Ray-Py38-Spark3
         runner-hosted-on: 'Shanghai'
 
+  Orca-ExampleTest-Ray-Py39-Spark3:
+    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-ExampleTest-Ray-Py39-Spark3' || github.event.inputs.artifact == 'all' }} 
+    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Set up maven
+      uses: ./.github/actions/maven-setup-action
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py39-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-exampletest-ray-py39-spark3-action/nightly-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py39
+    - name: Create Job Badge
+      uses: ./.github/actions/create-job-status-badge
+      if: ${{ always() }}
+      with:
+        secret: ${{ secrets.GIST_SECRET}}
+        gist-id: ${{env.GIST_ID}}
+        is-self-hosted-runner: true
+        file-name: Orca-ExampleTest-Ray-Py39-Spark3.json
+        type: job
+        job-name: Orca-ExampleTest-Ray-Py39-Spark3
+        runner-hosted-on: 'Shanghai'
+
   Orca-ExampleTest-Jep-Py37-Spark3:
     if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-ExampleTest-Jep-Py37-Spark3' || github.event.inputs.artifact == 'all' }} 
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
@@ -628,6 +664,35 @@ jobs:
         job-name: Orca-Pytest-Ray-Py38-Spark3
         runner-hosted-on: 'Shanghai'
 
+  Orca-Pytest-Ray-Py39-Spark3:
+    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Pytest-Ray-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
+    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Set up maven
+      uses: ./.github/actions/maven-setup-action
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py39-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-pytest-ray-py39-spark3-action/nightly-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py39
+    - name: Create Job Badge
+      uses: ./.github/actions/create-job-status-badge
+      if: ${{ always() }}
+      with:
+        secret: ${{ secrets.GIST_SECRET}}
+        gist-id: ${{env.GIST_ID}}
+        is-self-hosted-runner: true
+        file-name: Orca-Pytest-Ray-Py39-Spark3.json
+        type: job
+        job-name: Orca-Pytest-Ray-Py39-Spark3
+        runner-hosted-on: 'Shanghai'
+
   Orca-Pytest-Py37-Spark3-Tf1:
     if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Pytest-Py37-Spark3-Tf1' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
@@ -684,6 +749,35 @@ jobs:
         file-name: Orca-Pytest-Py38-Spark3.json
         type: job
         job-name: Orca-Pytest-Py38-Spark3
+        runner-hosted-on: 'Shanghai'
+
+  Orca-Pytest-Py39-Spark3:
+    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Pytest-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
+    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Set up maven
+      uses: ./.github/actions/maven-setup-action
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py39-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-pytest-py39-spark3-action/nightly-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py39
+    - name: Create Job Badge
+      uses: ./.github/actions/create-job-status-badge
+      if: ${{ always() }}
+      with:
+        secret: ${{ secrets.GIST_SECRET}}
+        gist-id: ${{env.GIST_ID}}
+        is-self-hosted-runner: true
+        file-name: Orca-Pytest-Py39-Spark3.json
+        type: job
+        job-name: Orca-Pytest-Py39-Spark3
         runner-hosted-on: 'Shanghai'
 
   Orca-Pytest-Horovod-Py37-Spark3:
@@ -918,6 +1012,64 @@ jobs:
         job-name: Orca-Tutorial-Notebook-Xshards-Image-Py38-Spark3
         runner-hosted-on: 'Shanghai' 
 
+  Orca-Tutorial-Notebook-Xshards-Py39-Spark3:
+    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-Notebook-Xshards-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
+    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Set up maven
+      uses: ./.github/actions/maven-setup-action 
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py39-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-tutorial-notebook-xshards-py39-spark3-action/nightly-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py39
+    - name: Create Job Badge
+      uses: ./.github/actions/create-job-status-badge
+      if: ${{ always() }}
+      with:
+        secret: ${{ secrets.GIST_SECRET}}
+        gist-id: ${{env.GIST_ID}}
+        is-self-hosted-runner: true
+        file-name: Orca-Tutorial-Notebook-Xshards-Py39-Spark3.json
+        type: job
+        job-name: Orca-Tutorial-Notebook-Xshards-Py39-Spark3
+        runner-hosted-on: 'Shanghai' 
+  
+  Orca-Tutorial-Notebook-Xshards-Image-Py39-Spark3:
+    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-Notebook-Xshards-Image-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
+    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Set up maven
+      uses: ./.github/actions/maven-setup-action 
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py39-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-tutorial-notebook-xshards-image-py39-spark3-action/nightly-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py39
+    - name: Create Job Badge
+      uses: ./.github/actions/create-job-status-badge
+      if: ${{ always() }}
+      with:
+        secret: ${{ secrets.GIST_SECRET}}
+        gist-id: ${{env.GIST_ID}}
+        is-self-hosted-runner: true
+        file-name: Orca-Tutorial-Notebook-Xshards-Image-Py39-Spark3.json
+        type: job
+        job-name: Orca-Tutorial-Notebook-Xshards-Image-Py39-Spark3
+        runner-hosted-on: 'Shanghai' 
+
   Orca-Tutorial-NCF-Ray-Py37-Spark3:
     if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-NCF-Ray-Py37-Spark3' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
@@ -1033,6 +1185,64 @@ jobs:
         file-name: Orca-Tutorial-NCF-Py38-Spark3.json
         type: job
         job-name: Orca-Tutorial-NCF-Py38-Spark3
+        runner-hosted-on: 'Shanghai' 
+
+  Orca-Tutorial-NCF-Ray-Py39-Spark3:
+    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-NCF-Ray-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
+    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Set up maven
+      uses: ./.github/actions/maven-setup-action 
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py39-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-tutorial-ncf-ray-py39-spark3-action/nightly-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py39
+    - name: Create Job Badge
+      uses: ./.github/actions/create-job-status-badge
+      if: ${{ always() }}
+      with:
+        secret: ${{ secrets.GIST_SECRET}}
+        gist-id: ${{env.GIST_ID}}
+        is-self-hosted-runner: true
+        file-name: Orca-Tutorial-NCF-Ray-Py39-Spark3.json
+        type: job
+        job-name: Orca-Tutorial-NCF-Ray-Py39-Spark3
+        runner-hosted-on: 'Shanghai' 
+
+  Orca-Tutorial-NCF-Py39-Spark3:
+    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-NCF-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
+    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Set up maven
+      uses: ./.github/actions/maven-setup-action 
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py39-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-tutorial-ncf-py39-spark3-action/nightly-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py39
+    - name: Create Job Badge
+      uses: ./.github/actions/create-job-status-badge
+      if: ${{ always() }}
+      with:
+        secret: ${{ secrets.GIST_SECRET}}
+        gist-id: ${{env.GIST_ID}}
+        is-self-hosted-runner: true
+        file-name: Orca-Tutorial-NCF-Py39-Spark3.json
+        type: job
+        job-name: Orca-Tutorial-NCF-Py39-Spark3
         runner-hosted-on: 'Shanghai' 
 
   Orca-Pytest-Ray-Ctx-Py37-Spark3:


### PR DESCRIPTION
## Description
https://github.com/analytics-zoo/arda-docker/issues/773#issuecomment-1478978515

### 1. Summary of the change 

add orca nightly test with python=3.9
- add 2 pytests, 4 tutorial tests, 1 exampletest.

### 2. How to test?
 PR Pytests
- [ ] Orca-Pytest-Py39-Spark3
- [ ] Orca-Pytest-Ray-Py39-Spark3

Tutorial Tests
- [ ] Orca-Tutorial-Notebook-Xshards-Py39-Spark3
- [ ] Orca-Tutorial-Notebook-Xshards-Image-Py39-Spark3
- [ ] Orca-Tutorial-NCF-Py39-Spark3
- [ ] Orca-Tutorial-NCF-Ray-Py39-Spark3

Example Tests
- [ ] Orca-ExampleTest-Ray-Py39-Spark3 
