### PR TITLE
Orca: add python 3.9 xshards notebook tests (nightly)

### DIFF
--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -2,7 +2,7 @@ name: Nightly Test
 
 on:
 
-  pull_request:
+  #pull_request:
     #branchs: [ main ]
 
   schedule:
@@ -984,7 +984,7 @@ jobs:
         runner-hosted-on: 'Shanghai' 
   
   Orca-Tutorial-Notebook-Xshards-Py39-Spark3:
-    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-Notebook-Xshards-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
+    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-Notebook-Xshards-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -2,7 +2,7 @@ name: Nightly Test
 
 on:
 
-  #pull_request:
+  pull_request:
     #branchs: [ main ]
 
   schedule:
@@ -50,6 +50,7 @@ on:
         - Orca-Tutorial-Notebook-Xshards-Image-Py37-Spark3
         - Orca-Tutorial-Notebook-Xshards-Py38-Spark3
         - Orca-Tutorial-Notebook-Xshards-Image-Py38-Spark3
+        - Orca-Tutorial-Notebook-Xshards-Py39-Spark3
         - Orca-Tutorial-Notebook-Xshards-Image-Py39-Spark3
         - Orca-Tutorial-NCF-Ray-Py37-Spark3
         - Orca-Tutorial-NCF-Py37-Spark3
@@ -982,6 +983,35 @@ jobs:
         job-name: Orca-Tutorial-Notebook-Xshards-Py38-Spark3
         runner-hosted-on: 'Shanghai' 
   
+  Orca-Tutorial-Notebook-Xshards-Py39-Spark3:
+    #if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-Notebook-Xshards-Py39-Spark3' || github.event.inputs.artifact == 'all' }}
+    runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up JDK8
+      uses: ./.github/actions/jdk-setup-action
+    - name: Set up maven
+      uses: ./.github/actions/maven-setup-action 
+    - name: Setup env
+      uses: ./.github/actions/orca/setup-env/setup-orca-python-py39-basic
+    - name: Run Test
+      uses: ./.github/actions/orca/orca-tutorial-notebook-xshards-py39-spark3-action/nightly-test
+    - name: Remove Env
+      if: ${{ always() }}
+      uses: ./.github/actions/remove-env/remove-env-py39
+    - name: Create Job Badge
+      uses: ./.github/actions/create-job-status-badge
+      if: ${{ always() }}
+      with:
+        secret: ${{ secrets.GIST_SECRET}}
+        gist-id: ${{env.GIST_ID}}
+        is-self-hosted-runner: true
+        file-name: Orca-Tutorial-Notebook-Xshards-Py39-Spark3.json
+        type: job
+        job-name: Orca-Tutorial-Notebook-Xshards-Py39-Spark3
+        runner-hosted-on: 'Shanghai' 
+
   Orca-Tutorial-Notebook-Xshards-Image-Py38-Spark3:
     if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Tutorial-Notebook-Xshards-Image-Py38-Spark3' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]

--- a/python/orca/tutorial/xshards/ionosphere.py
+++ b/python/orca/tutorial/xshards/ionosphere.py
@@ -74,6 +74,7 @@ data_shard = label_encoder.fit_transform(data_shard)
 
 
 def update_label_to_zero_base(df):
+    df[:-1] = df[:-1].astype("float32")
     df['34'] = df['34'] - 1
     return df
 data_shard = data_shard.transform_shard(update_label_to_zero_base)

--- a/python/orca/tutorial/xshards/ionosphere.py
+++ b/python/orca/tutorial/xshards/ionosphere.py
@@ -78,15 +78,26 @@ def update_label_to_zero_base(df):
     return df
 data_shard = data_shard.transform_shard(update_label_to_zero_base)
 
-model = MLP(34)
+
+def model_creator(config):
+    model = MLP(config["n_inputs"])
+    model.train()
+    return model
+
+
+def optimizer_creator(model, config):
+    optimizer = SGD(model.parameters(), lr=config["lr"], momentum=config["momentum"])
+
 criterion = BCELoss()
-optimizer = SGD(model.parameters(), lr=0.01, momentum=0.9)
 
 orca_estimator = Estimator.from_torch(model=model,
                                       optimizer=optimizer,
                                       loss=criterion,
                                       metrics=[Accuracy()],
-                                      backend="bigdl")
+                                      backend="spark",
+                                      config={"n_inputs": 34,
+                                              "lr": 0.01,
+                                              "momentum": 0.9})
 
 data_shard = data_shard.assembleFeatureLabelCols(featureCols=list(column[:-1]),
                                                  labelCols=[column[-1]])

--- a/python/orca/tutorial/xshards/ionosphere.py
+++ b/python/orca/tutorial/xshards/ionosphere.py
@@ -87,6 +87,7 @@ def model_creator(config):
 
 def optimizer_creator(model, config):
     optimizer = SGD(model.parameters(), lr=config["lr"], momentum=config["momentum"])
+    return optimizer
 
 criterion = BCELoss()
 

--- a/python/orca/tutorial/xshards/ionosphere.py
+++ b/python/orca/tutorial/xshards/ionosphere.py
@@ -90,8 +90,8 @@ def optimizer_creator(model, config):
 
 criterion = BCELoss()
 
-orca_estimator = Estimator.from_torch(model=model,
-                                      optimizer=optimizer,
+orca_estimator = Estimator.from_torch(model=model_creator,
+                                      optimizer=optimizer_creator,
                                       loss=criterion,
                                       metrics=[Accuracy()],
                                       backend="spark",

--- a/python/orca/tutorial/xshards/ionosphere.py
+++ b/python/orca/tutorial/xshards/ionosphere.py
@@ -74,8 +74,8 @@ data_shard = label_encoder.fit_transform(data_shard)
 
 
 def update_label_to_zero_base(df):
-    df[:-1] = df[:-1].astype("float32")
     df['34'] = df['34'] - 1
+    df = df.astype("float32")
     return df
 data_shard = data_shard.transform_shard(update_label_to_zero_base)
 

--- a/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
+++ b/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
@@ -428,8 +428,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\r\n",
-      "[Stage 12:>                                                         (0 + 1) / 1]\r\n",
+      "\r",
+      "[Stage 12:>                                                         (0 + 1) / 1]\r",
       "                                                                                \r"
      ]
     }

--- a/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
+++ b/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
@@ -620,9 +620,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "py37tf2_x",
    "language": "python",
-   "name": "python3"
+   "name": "py37tf2_x"
   },
   "language_info": {
    "codemirror_mode": {
@@ -634,7 +634,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.13"
+   "version": "3.7.10"
   }
  },
  "nbformat": 4,

--- a/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
+++ b/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
@@ -456,8 +456,9 @@
    "outputs": [],
    "source": [
     "def update_label_to_zero_base(df):\n",
-    "    df[:-1] = df[:-1].astype(\"float32\")\n",
+    "    df = df.astype(\"float32\")\n",
     "    df['34'] = df['34'] - 1\n",
+    "    df['34'] = df['34'].astype(\"int32\")\n",
     "    return df\n",
     "data_shards = data_shards.transform_shard(update_label_to_zero_base)\n",
     "print(data_shards.head(5), data_shards.get_schema())"

--- a/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
+++ b/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
@@ -428,8 +428,8 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "\r",
-      "[Stage 12:>                                                         (0 + 1) / 1]\r",
+      "\r\n",
+      "[Stage 12:>                                                         (0 + 1) / 1]\r\n",
       "                                                                                \r"
      ]
     }
@@ -535,7 +535,11 @@
     "        X = self.act3(X)\n",
     "        return X\n",
     "\n",
-    "model = MLP(34)"
+    "\n",
+    "def model_creator(config):\n",
+    "    model = MLP(config[\"n_inputs\"])\n",
+    "    model.train()\n",
+    "    return model"
    ]
   },
   {
@@ -546,8 +550,10 @@
    "outputs": [],
    "source": [
     "# define criterion and optimizer\n",
-    "criterion = BCELoss()\n",
-    "optimizer = SGD(model.parameters(), lr=0.01, momentum=0.9)"
+    "def optimizer_creator(model, config):\n",
+    "    optimizer = SGD(model.parameters(), lr=config[\"lr\"], momentum=config[\"momentum\"])\n",
+    "\n",
+    "criterion = BCELoss()\n"
    ]
   },
   {
@@ -569,11 +575,14 @@
    ],
    "source": [
     "# build Orca Estimator\n",
-    "orca_estimator = Estimator.from_torch(model=model,\n",
-    "                                      optimizer=optimizer,\n",
+    "orca_estimator = Estimator.from_torch(model=model_creator,\n",
+    "                                      optimizer=optimizer_creator,\n",
     "                                      loss=criterion,\n",
     "                                      metrics=[Accuracy()],\n",
-    "                                      backend=\"bigdl\")\n"
+    "                                      backend=\"spark\",\n",
+    "                                      config={\"n_inputs\": 34,\n",
+    "                                              \"lr\": 0.01,\n",
+    "                                              \"momentum\": 0.9})\n"
    ]
   },
   {

--- a/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
+++ b/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
@@ -455,6 +455,7 @@
    "outputs": [],
    "source": [
     "def update_label_to_zero_base(df):\n",
+    "    df[:-1] = df[:-1].astype(float)\n",
     "    df['34'] = df['34'] - 1\n",
     "    return df\n",
     "data_shards = data_shards.transform_shard(update_label_to_zero_base)"
@@ -619,9 +620,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "py37tf2_x",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "py37tf2_x"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -633,7 +634,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.10"
+   "version": "3.7.13"
   }
  },
  "nbformat": 4,

--- a/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
+++ b/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
@@ -552,6 +552,7 @@
     "# define criterion and optimizer\n",
     "def optimizer_creator(model, config):\n",
     "    optimizer = SGD(model.parameters(), lr=config[\"lr\"], momentum=config[\"momentum\"])\n",
+    "    return optimizer\n",
     "\n",
     "criterion = BCELoss()\n"
    ]

--- a/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
+++ b/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
@@ -458,7 +458,8 @@
     "    df[:-1] = df[:-1].astype(float)\n",
     "    df['34'] = df['34'] - 1\n",
     "    return df\n",
-    "data_shards = data_shards.transform_shard(update_label_to_zero_base)"
+    "data_shards = data_shards.transform_shard(update_label_to_zero_base)\n",
+    "print(data_shards.head(5), data_shards.get_schema())"
    ]
   },
   {

--- a/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
+++ b/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
@@ -52,6 +52,7 @@
    "outputs": [],
    "source": [
     "# import necessary libraries\n",
+    "import numpy as np\n",
     "from torch.nn import Linear\n",
     "from torch.nn import ReLU\n",
     "from torch.nn import Sigmoid\n",
@@ -455,7 +456,7 @@
    "outputs": [],
    "source": [
     "def update_label_to_zero_base(df):\n",
-    "    df[:-1] = df[:-1].astype(float)\n",
+    "    df[:-1] = df[:-1].astype(np.float32)\n",
     "    df['34'] = df['34'] - 1\n",
     "    return df\n",
     "data_shards = data_shards.transform_shard(update_label_to_zero_base)\n",

--- a/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
+++ b/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
@@ -52,7 +52,6 @@
    "outputs": [],
    "source": [
     "# import necessary libraries\n",
-    "import numpy as np\n",
     "from torch.nn import Linear\n",
     "from torch.nn import ReLU\n",
     "from torch.nn import Sigmoid\n",
@@ -459,8 +458,7 @@
     "    df['34'] = df['34'] - 1\n",
     "    df = df.astype(\"float32\")\n",
     "    return df\n",
-    "data_shards = data_shards.transform_shard(update_label_to_zero_base)\n",
-    "print(data_shards.head(5), data_shards.get_schema())"
+    "data_shards = data_shards.transform_shard(update_label_to_zero_base)"
    ]
   },
   {

--- a/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
+++ b/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
@@ -456,7 +456,7 @@
    "outputs": [],
    "source": [
     "def update_label_to_zero_base(df):\n",
-    "    df[:-1] = df[:-1].astype(np.float32)\n",
+    "    df[:-1] = df[:-1].astype(\"float32\")\n",
     "    df['34'] = df['34'] - 1\n",
     "    return df\n",
     "data_shards = data_shards.transform_shard(update_label_to_zero_base)\n",

--- a/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
+++ b/python/orca/tutorial/xshards/notebooks/ionosphere.ipynb
@@ -456,9 +456,8 @@
    "outputs": [],
    "source": [
     "def update_label_to_zero_base(df):\n",
-    "    df = df.astype(\"float32\")\n",
     "    df['34'] = df['34'] - 1\n",
-    "    df['34'] = df['34'].astype(\"int32\")\n",
+    "    df = df.astype(\"float32\")\n",
     "    return df\n",
     "data_shards = data_shards.transform_shard(update_label_to_zero_base)\n",
     "print(data_shards.head(5), data_shards.get_schema())"


### PR DESCRIPTION
## Description
https://github.com/analytics-zoo/arda-docker/issues/773#issuecomment-1478978515

### 1. Summary of the change 

add orca nightly test with python=3.9
- add 1 xshards tutorial test.
- change backend from `bigdl` to `spark` in `ionosphere.py` and `ionosphere.ipynb`

### 2. How to test?
Tutorial Tests
- [ ] Orca-Tutorial-Notebook-Xshards-Py39-Spark3
