### PR TITLE
Orca: [test] rm ut config `spark.python.worker.reuse`

### DIFF
--- a/.github/workflows/PR_validation.yml
+++ b/.github/workflows/PR_validation.yml
@@ -67,10 +67,10 @@ jobs:
       friesian-pytest: ${{ steps.filter.outputs.friesian-pytest }}
       friesian-example: ${{ steps.filter.outputs.friesian-example }}
       dllib: ${{ steps.filter.outputs.dllib }}
-      orca-pytest: ${{ steps.filter.outputs.orca-pytest }}
-      orca-pytest-openvino: ${{ steps.filter.outputs.orca-pytest-openvino }}
-      orca-tutorial: ${{ steps.filter.outputs.orca-tutorial }}
-      orca-example: ${{ steps.filter.outputs.orca-example }}
+      # orca-pytest: ${{ steps.filter.outputs.orca-pytest }}
+      # orca-pytest-openvino: ${{ steps.filter.outputs.orca-pytest-openvino }}
+      # orca-tutorial: ${{ steps.filter.outputs.orca-tutorial }}
+      # orca-example: ${{ steps.filter.outputs.orca-example }}
       ppml: ${{ steps.filter.outputs.ppml }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -2,7 +2,7 @@ name: Nightly Test
 
 on:
 
-  #pull_request:
+  pull_request:
     #branchs: [ main ]
 
   schedule:
@@ -571,7 +571,7 @@ jobs:
         runner-hosted-on: 'Shanghai'
 
   Orca-Pytest-Ray-Py37-Spark3:
-    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Pytest-Ray-Py37-Spark3' || github.event.inputs.artifact == 'all' }}
+    # if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Pytest-Ray-Py37-Spark3' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
@@ -600,7 +600,7 @@ jobs:
         runner-hosted-on: 'Shanghai'
 
   Orca-Pytest-Ray-Py38-Spark3:
-    if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Pytest-Ray-Py38-Spark3' || github.event.inputs.artifact == 'all' }}
+    # if: ${{ github.event.schedule || github.event.inputs.artifact == 'Orca-Pytest-Ray-Py38-Spark3' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:

--- a/python/orca/test/bigdl/orca/learn/ray/tf/conftest.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/conftest.py
@@ -22,7 +22,7 @@ from pyspark.sql import SparkSession
 @pytest.fixture(autouse=True, scope='package')
 def orca_context_fixture():
     conf = {"spark.python.worker.reuse": "false"}
-    sc = init_orca_context(cores=8, conf=conf)
+    sc = init_orca_context(cores=8)
 
     def to_array_(v):
         return v.toArray().tolist()

--- a/python/orca/test/bigdl/orca/learn/ray/tf/conftest.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/conftest.py
@@ -21,7 +21,6 @@ from pyspark.sql import SparkSession
 
 @pytest.fixture(autouse=True, scope='package')
 def orca_context_fixture():
-    conf = {"spark.python.worker.reuse": "false"}
     sc = init_orca_context(cores=8)
 
     def to_array_(v):

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf2estimator_ray_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf2estimator_ray_backend.py
@@ -799,7 +799,8 @@ class TestTF2EstimatorRayBackend(TestCase):
 
         from pyspark.ml.linalg import DenseVector
         df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
-                                int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
+                                int(np.random.randint(0, 2, size=())))).toDF(["feature",
+                                                                              "label"])
 
         config = {
             "lr": 0.2

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf2estimator_ray_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf2estimator_ray_backend.py
@@ -744,7 +744,7 @@ class TestTF2EstimatorRayBackend(TestCase):
 
         from pyspark.ml.linalg import DenseVector
         data = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
-                                int(np.random.randint(0, 2, size=())))).collect()
+                                  int(np.random.randint(0, 2, size=())))).collect()
         df = spark.createDataFrame(data=data, schema=["feature", "label"])
 
         config = {
@@ -800,9 +800,9 @@ class TestTF2EstimatorRayBackend(TestCase):
         spark = OrcaContext.get_spark_session()
 
         from pyspark.ml.linalg import DenseVector
-        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
-                                int(np.random.randint(0, 2, size=())))).collect()
-        df = spark.createDataFrame(data=df, schema=["feature", "label"])
+        data = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
+                                  int(np.random.randint(0, 2, size=())))).collect()
+        df = spark.createDataFrame(data=data, schema=["feature", "label"])
 
         config = {
             "lr": 0.2
@@ -861,7 +861,7 @@ class TestTF2EstimatorRayBackend(TestCase):
 
         from pyspark.ml.linalg import DenseVector
         data = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
-                                int(np.random.randint(0, 2, size=())))).collect()
+                                  int(np.random.randint(0, 2, size=())))).collect()
         df = spark.createDataFrame(data=data, schema=["feature", "label"])
 
         config = {
@@ -909,7 +909,7 @@ class TestTF2EstimatorRayBackend(TestCase):
 
         from pyspark.ml.linalg import DenseVector
         data = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
-                                int(np.random.randint(0, 2, size=())))).collect()
+                                  int(np.random.randint(0, 2, size=())))).collect()
         df = spark.createDataFrame(data=data, schema=["feature", "label"])
 
         config = {

--- a/python/orca/test/bigdl/orca/learn/ray/tf/test_tf2estimator_ray_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/tf/test_tf2estimator_ray_backend.py
@@ -686,8 +686,9 @@ class TestTF2EstimatorRayBackend(TestCase):
         spark = OrcaContext.get_spark_session()
 
         from pyspark.ml.linalg import DenseVector
-        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
-                                int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
+        data = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
+                                  int(np.random.randint(0, 2, size=())))).collect()
+        df = spark.createDataFrame(data=data, schema=["feature", "label"])
 
         config = {
             "lr": 0.2
@@ -742,8 +743,9 @@ class TestTF2EstimatorRayBackend(TestCase):
         spark = OrcaContext.get_spark_session()
 
         from pyspark.ml.linalg import DenseVector
-        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
-                                int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
+        data = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
+                                int(np.random.randint(0, 2, size=())))).collect()
+        df = spark.createDataFrame(data=data, schema=["feature", "label"])
 
         config = {
             "lr": 0.2
@@ -799,8 +801,8 @@ class TestTF2EstimatorRayBackend(TestCase):
 
         from pyspark.ml.linalg import DenseVector
         df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
-                                int(np.random.randint(0, 2, size=())))).toDF(["feature",
-                                                                              "label"])
+                                int(np.random.randint(0, 2, size=())))).collect()
+        df = spark.createDataFrame(data=df, schema=["feature", "label"])
 
         config = {
             "lr": 0.2
@@ -858,8 +860,9 @@ class TestTF2EstimatorRayBackend(TestCase):
         spark = OrcaContext.get_spark_session()
 
         from pyspark.ml.linalg import DenseVector
-        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
-                                int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
+        data = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
+                                int(np.random.randint(0, 2, size=())))).collect()
+        df = spark.createDataFrame(data=data, schema=["feature", "label"])
 
         config = {
             "lr": 0.2
@@ -905,8 +908,9 @@ class TestTF2EstimatorRayBackend(TestCase):
         spark = OrcaContext.get_spark_session()
 
         from pyspark.ml.linalg import DenseVector
-        df = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
-                                int(np.random.randint(0, 2, size=())))).toDF(["feature", "label"])
+        data = rdd.map(lambda x: (DenseVector(np.random.randn(1, ).astype(np.float32)),
+                                int(np.random.randint(0, 2, size=())))).collect()
+        df = spark.createDataFrame(data=data, schema=["feature", "label"])
 
         config = {
             "lr": 0.2


### PR DESCRIPTION
## Description


### 1. Why the change?

This pr tries to remove the config for ray backend tests.

Related issue: https://github.com/intel-analytics/BigDL/issues/7761


### 2. How to test?

Nightly Test:

- [ ] Orca-Pytest-Ray-Py37-Spark3
- [ ] Orca-Pytest-Ray-Py38-Spark3
- [ ] Orca-Pytest-Ray-Py39-Spark3

Mac Test:

- [ ] Orca-Python-UT-Ray-Spark3
