### PR TITLE
Orca: Deprecate `reload_dataloader` func in torch estimator

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/maincallback.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/maincallback.py
@@ -51,8 +51,9 @@ class MainCallback(Callback):
         this will be called during forward when training and validating.
         Any behavior inconsistent with the default forward behavior should be overridden here.
         """
-        # Forward features
+        # unpack features into features and targets
         *features, target = runner.batch
+        # Forward features
         runner.output = runner.model(*features)
         # Ensure `targetL` and `outputL` are always in a list format.
         targetL = [target] if not isinstance(target, (list, tuple)) else target

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_estimator.py
@@ -30,7 +30,7 @@ from bigdl.orca.learn.pytorch.pytorch_pyspark_worker import PytorchPysparkWorker
 from bigdl.orca.learn.pytorch.utils import process_stats
 from bigdl.orca.learn.utils import maybe_dataframe_to_xshards, dataframe_to_xshards, \
     convert_predict_xshards_to_dataframe, make_data_creator, update_predict_xshards, \
-    reload_dataloader_creator, process_xshards_of_pandas_dataframe, add_predict_to_pd_xshards
+    process_xshards_of_pandas_dataframe, add_predict_to_pd_xshards
 from bigdl.orca.data import SparkXShards
 from bigdl.orca import OrcaContext
 from bigdl.orca.learn.base_estimator import BaseEstimator
@@ -98,7 +98,7 @@ def partition_to_creator(partition):
         data_loader = DataLoader(dataset, **params)
         return data_loader
 
-    return reload_dataloader_creator(data_creator)
+    return data_creator
 
 
 def parse_model_dir(model_dir):
@@ -360,8 +360,8 @@ class PyTorchPySparkEstimator(BaseEstimator):
                                   "data should be either an instance of SparkXShards or a "
                                   "callable  function, but got type: {}".format(type(data)))
 
-            params["data_creator"] = reload_dataloader_creator(data)
-            params["validation_data_creator"] = reload_dataloader_creator(validation_data)
+            params["data_creator"] = data
+            params["validation_data_creator"] = validation_data
 
             def transform_func(iter, init_param, param):  # type:ignore
                 return PytorchPysparkWorker(**init_param).train_epochs(**param)
@@ -608,7 +608,7 @@ class PyTorchPySparkEstimator(BaseEstimator):
             res = data_rdd.barrier().mapPartitions(
                 lambda iter: transform_func(iter, init_params, params)).collect()
         else:
-            params["data_creator"] = reload_dataloader_creator(data)
+            params["data_creator"] = data
 
             def transform_func(iter, init_param, param):
                 return PytorchPysparkWorker(**init_param).validate(**param)

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_ray_estimator.py
@@ -23,8 +23,7 @@ from bigdl.orca.data.ray_xshards import RayXShards
 from bigdl.orca.learn.pytorch.pytorch_ray_worker import PytorchRayWorker
 from bigdl.orca.learn.utils import maybe_dataframe_to_xshards, dataframe_to_xshards, \
     convert_predict_xshards_to_dataframe, update_predict_xshards, \
-    process_xshards_of_pandas_dataframe, reload_dataloader_creator, \
-    add_predict_to_pd_xshards
+    process_xshards_of_pandas_dataframe, add_predict_to_pd_xshards
 from bigdl.orca.ray import OrcaRayContext
 from bigdl.orca.learn.pytorch.core.base_ray_estimator import BaseRayEstimator
 from bigdl.orca.learn.pytorch.utils import process_stats, check_for_failure
@@ -84,7 +83,7 @@ def partition_refs_to_creator(partition_refs):
         data_loader = DataLoader(dataset, **params)
         return data_loader
 
-    return reload_dataloader_creator(data_creator)
+    return data_creator
 
 
 class PyTorchRayEstimator(BaseRayEstimator):
@@ -314,8 +313,8 @@ class PyTorchRayEstimator(BaseRayEstimator):
                               " Ray Dataset or a callable function, but"
                               " got type: {}".format(type(data)))
 
-            params["data_creator"] = reload_dataloader_creator(data)
-            params["validation_data_creator"] = reload_dataloader_creator(validation_data)
+            params["data_creator"] = data
+            params["validation_data_creator"] = validation_data
             success, worker_stats = self._train_epochs(**params)
 
         epoch_stats = list(map(list, zip(*worker_stats)))  # type:ignore
@@ -506,7 +505,7 @@ class PyTorchRayEstimator(BaseRayEstimator):
                               "data should be either an instance of SparkXShards or a callable"
                               " function, but got type: {}".format(type(data)))
 
-            params["data_creator"] = reload_dataloader_creator(data)
+            params["data_creator"] = data
             worker_stats = ray.get([w.validate.remote(**params) for w in self.remote_workers])
 
         if reduce_results:

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -422,18 +422,7 @@ class TorchRunner(BaseRunner):
                 calculate averages.
 
         """
-        # unpack features into list to support multiple inputs model
-        # and restore batch to what it should be.
-        features, target = batch
-        if torch.is_tensor(features) or \
-                (isinstance(features, np.ndarray) and torch.is_tensor(features[0])):
-            self.batch = features, target
-        elif isinstance(features, (tuple, list)):
-            self.batch = *features, target
-        else:
-            invalidInputError(False,
-                              "Features should be tensor or list/tuple, "
-                              "but got {}".format(type(features)))
+        self.batch = batch
         self.call_hook(callbacks=callbacks, fn_name="before_train_iter")
 
         # Compute output.
@@ -445,7 +434,7 @@ class TorchRunner(BaseRunner):
             self.call_hook(callbacks=callbacks, fn_name="on_iter_backward")
 
         loss_item = self.loss.item()
-        self.metrics_stats = {"train_loss": loss_item, NUM_SAMPLES: get_batchsize(features)}
+        self.metrics_stats = {"train_loss": loss_item, NUM_SAMPLES: get_batchsize(batch)}
 
         self.global_step += 1
 
@@ -570,15 +559,7 @@ class TorchRunner(BaseRunner):
         """
         # unpack features into list to support multiple inputs model
         # and restore batch to what it should be.
-        features, target = batch
-        if torch.is_tensor(features):
-            self.batch = features, target
-        elif isinstance(features, (tuple, list)):
-            self.batch = *features, target
-        else:
-            invalidInputError(False,
-                              "Features should be tensor, list/tuple, "
-                              "but got {}".format(type(features)))
+        self.batch = batch
         self.call_hook(callbacks=callbacks, fn_name="before_val_iter")
 
         # compute output

--- a/python/orca/src/bigdl/orca/learn/utils.py
+++ b/python/orca/src/bigdl/orca/learn/utils.py
@@ -573,29 +573,6 @@ def get_arrow_hex_str(batched_data, names):
     return pred_arrow
 
 
-def make_dataloader_list_wrapper(func):
-    import torch
-
-    def make_feature_list(batch):
-        if func is not None:
-            batch = func(batch)
-        *features, target = batch
-        if len(features) == 1 and torch.is_tensor(features[0]):
-            features = features[0]
-        return features, target
-
-    return make_feature_list
-
-
-def reload_dataloader_creator(dataloader_func):
-    def reload_dataloader(config, batch_size):
-        dataloader = dataloader_func(config, batch_size)
-        dataloader.collate_fn = make_dataloader_list_wrapper(dataloader.collate_fn)
-        return dataloader
-
-    return reload_dataloader if dataloader_func else None
-
-
 def data_length(data):
     x = data["x"]
     if isinstance(x, np.ndarray):


### PR DESCRIPTION
## Description

In this PR we deprecate `reload_dataloader` in torch estimator and abandon batch format limitation, so we can support any kind of format in batches.
