### PR TITLE
Chronos: support context manager in AutoformerForecaster

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -30,6 +30,8 @@ from bigdl.chronos.data import TSDataset
 from bigdl.nano.automl.hpo.space import Space
 from bigdl.chronos.forecaster.utils_hpo import GenericTSTransformerLightningModule, \
     _config_has_search_space
+from bigdl.chronos.pytorch.context_manager import DummyForecasterContextManager,\
+    ForecasterContextManager
 
 from .utils_hpo import _format_metric_str
 import warnings
@@ -182,6 +184,8 @@ class AutoformerForecaster(Forecaster):
 
         self.model_creator = model_creator
         self.loss_creator = loss_creator
+        self.cxt_manager = DummyForecasterContextManager()
+        self.context_enabled = False
 
     def _build_automodel(self, data, validation_data=None, batch_size=32, epochs=1):
         """Build a Generic Model using config parameters."""
@@ -476,6 +480,15 @@ class AutoformerForecaster(Forecaster):
                         self.trainer.move_metrics_to_cpu)
                     return fit_out
 
+    def get_context(self, thread_num=None):
+        """
+        Obtain context manager from forecaster.
+        :param thread_num: int, the num of thread limit. The value is set to None by
+               default where no limit is set.
+        :return: a context manager.
+        """
+        return ForecasterContextManager(self, thread_num, optimize=False)
+
     def predict(self, data, batch_size=32):
         """
         Predict using a trained forecaster.
@@ -517,7 +530,10 @@ class AutoformerForecaster(Forecaster):
                                             torch.from_numpy(data[3]),),
                               batch_size=batch_size,
                               shuffle=False)
-        return self.trainer.predict(self.internal, data)
+        if not self.context_enabled:
+            self.cxt_manager = ForecasterContextManager(self, self.thread_num, acceleration)
+        with self.cxt_manager:
+            return self.trainer.predict(self.internal, data)
 
     def evaluate(self, data, batch_size=32):
         """

--- a/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/autoformer_forecaster.py
@@ -186,6 +186,9 @@ class AutoformerForecaster(Forecaster):
         self.loss_creator = loss_creator
         self.cxt_manager = DummyForecasterContextManager()
         self.context_enabled = False
+        current_num_threads = torch.get_num_threads()
+        self.thread_num = current_num_threads
+        self.accelerate_method = None
 
     def _build_automodel(self, data, validation_data=None, batch_size=32, epochs=1):
         """Build a Generic Model using config parameters."""

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -461,3 +461,23 @@ class TestChronosModelAutoformerForecaster(TestCase):
         forecaster.tune(train_data, validation_data=val_data, n_trials=2,
                         study_name=name, sampler=SamplerType.Grid,
                         storage=storage, n_parallels=2)
+
+    def test_autoformer_forecaster_ctx_manager(self):
+        train_loader, val_loader, test_loader = create_data(loader=True)
+        forecaster = AutoformerForecaster(past_seq_len=24,
+                                          future_seq_len=5,
+                                          input_feature_num=2,
+                                          output_feature_num=2,
+                                          label_len=12,
+                                          freq='s')
+        forecaster.fit(train_loader, epochs=1, batch_size=32)
+
+        original_thread = torch.get_num_threads()
+        assert forecaster.thread_num == original_thread
+
+        num = max(1, original_thread//2)
+        with forecaster.get_context(thread_num=num):
+            assert forecaster.context_enabled == True
+            current_thread = torch.get_num_threads()
+            assert current_thread == num
+            pred = forecaster.predict(test_loader)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -20,6 +20,7 @@ import tempfile
 import os
 
 from bigdl.chronos.utils import LazyImport
+torch = LazyImport('torch')
 AutoformerForecaster = LazyImport('bigdl.chronos.forecaster.autoformer_forecaster.AutoformerForecaster')
 from bigdl.chronos.data import TSDataset
 from unittest import TestCase


### PR DESCRIPTION
## Description

In previous work, we have supported context manager in `BaseForecaster`.
According to some benchmark experiments, with context manager, inference latency of `AutoformerForecaster` can reduced 5%-10%.
In this pr, also support context manager in `AutoformerForecaster`.

### 1. Why the change?

Similar to https://github.com/intel-analytics/BigDL/pull/7279.

### 2. User API changes

Provide a new `get_context` method for forecasters to implement thread control and inference_mode.
```python
with forecaster.get_context(thread_num=xxx):
    for _ in range(n):
        forecaster.predict(data)
```
It's recommend to use above context manager in inference loop.

But, if users don't use context manager, the following loop still works. (first call is much slower)
```python
for _ in range(n):
    forecaster.predict(data)
```

### 3. Summary of the change 

- `get_context` method
- In `predict`, we will generate `ForecasterContextManager` if users don't use context manager; otherwise, just use `DummyForecasterContextManager`

### 4. How to test?
- [x] Unit test
