### PR TITLE
Chronos: fix implementation of TCNForecaster of tensorflow backend

### DIFF
--- a/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
@@ -151,9 +151,9 @@ class TemporalConvNet(Model):
         for i in range(num_levels):
             dilation_rate = 2 ** i
             self.network.add(TemporalBlock(dilation_rate, num_channels[i], kernel_size,
-                                              padding='causal', dropout_rate=dropout))
+                                           padding='causal', dropout_rate=dropout))
         self.network.add(TemporalBlock(dilation_rate, self.output_feature_num, kernel_size,
-                                          padding='causal', dropout_rate=dropout))
+                                       padding='causal', dropout_rate=dropout))
 
         self.linear = tf.keras.layers.Dense(future_seq_len, kernel_initializer=init)
         self.permute = tf.keras.layers.Permute((2, 1))

--- a/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
@@ -144,23 +144,22 @@ class TemporalConvNet(Model):
             init = tf.keras.initializers.HeUniform()
 
         # initialize model
-        self.network = []
+        self.network = tf.keras.Sequential()
 
         # The model contains "num_levels" TemporalBlock
         num_levels = len(num_channels)
         for i in range(num_levels):
             dilation_rate = 2 ** i
-            self.network.append(TemporalBlock(dilation_rate, num_channels[i], kernel_size,
+            self.network.add(TemporalBlock(dilation_rate, num_channels[i], kernel_size,
                                               padding='causal', dropout_rate=dropout))
-        self.network.append(TemporalBlock(dilation_rate, self.output_feature_num, kernel_size,
+        self.network.add(TemporalBlock(dilation_rate, self.output_feature_num, kernel_size,
                                           padding='causal', dropout_rate=dropout))
 
         self.linear = tf.keras.layers.Dense(future_seq_len, kernel_initializer=init)
         self.permute = tf.keras.layers.Permute((2, 1))
 
     def call(self, x, training=False):
-        for layer in self.network:
-            y = layer(x, training=training)
+        y = self.network(x, training=training)
         y = self.permute(y)
         y = self.linear(y)
         y = self.permute(y)


### PR DESCRIPTION
## Description

In previous accuracy experiment on `TCNForecaster` of tensorflow backend, mse of scaled test data is even 0.2 (lookback 96, horizon 1), which is unreasonable.
In this PR, fix the implementation of internal network.

### 2. User API changes

None

### 3. Summary of the change 

modify `TemporalConvNet.network` to Sequential

### 4. How to test?
- [x] Unit test
