### PR TITLE
Orca: Support Multiple Model in Torch Estimator

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/maincallback.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/maincallback.py
@@ -86,6 +86,13 @@ class MainCallback(Callback):
         Any behavior inconsistent with the default training behavior should be overridden here.
         """
         self.on_iter_forward(runner)
+    
+    def on_train_backward(self, runner):
+        """
+        this will be called during backward when training.
+        Any behavior inconsistent with the default backward behavior should be overridden here.
+        """
+        self.on_iter_backward(runner)
 
     def on_val_forward(self, runner):
         """

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -41,6 +41,7 @@ import torch
 import torch.nn as nn
 import numpy as np
 from torch.utils.data import DataLoader, IterableDataset
+from torch.distributed.algorithms.join import Join
 from bigdl.orca.learn.metrics import Metric
 from bigdl.orca import OrcaContext
 from bigdl.orca.learn.pytorch import utils
@@ -123,7 +124,7 @@ class TorchRunner(BaseRunner):
         self.timers = utils.TimerCollection()
         self.epochs = 0
         self.global_step = 0
-        self.models = None
+        self._models = None
         self.optimizers = None
         self.metrics = metrics
         self.criterion = None
@@ -163,12 +164,12 @@ class TorchRunner(BaseRunner):
 
         self.logger.debug("Creating model")
         if self.model_creator:
-            self.models = self.model_creator(self.config)
+            self._models = self.model_creator(self.config)
 
-            if isinstance(self.models, nn.Sequential) or not isinstance(self.models, Iterable):
-                self.models = [self.models]
-            invalidInputError(all(isinstance(model, nn.Module) for model in self.models),
-                                 ("All models must be PyTorch models: {}.".format(self.models)))
+            if isinstance(self._models, nn.Sequential) or not isinstance(self._models, Iterable):
+                self._models = [self._models]
+            invalidInputError(all(isinstance(model, nn.Module) for model in self._models),
+                                 ("All models must be PyTorch models: {}.".format(self._models)))
 
             if self.optimizer_creator:
                 self.logger.debug("Creating optimizer.")
@@ -184,11 +185,11 @@ class TorchRunner(BaseRunner):
         from torch.nn.parallel import DistributedDataParallel
         self.training_models = [
             DistributedDataParallel(model)
-            for model in self.models
+            for model in self._models
         ]
-        self.setup_operator(self.training_models)
+        self.setup_operator()
 
-    def setup_operator(self, training_models):
+    def setup_operator(self):
         """Create the training operator."""
         if self.backend == "horovod":
             self.dist_backend = HorovodDistBackend()
@@ -282,7 +283,7 @@ class TorchRunner(BaseRunner):
             data_loader.sampler.set_epoch(self.epochs)
         self.logger.debug("Begin Training Step {}".format(self.epochs + 1))
 
-        if not self.models:
+        if not self._models:
             invalidInputError(False,
                               "You must provide a model for train and evaluate.")
 
@@ -363,11 +364,12 @@ class TorchRunner(BaseRunner):
 
         # TODO: Discuss the situation when there are multiple components,
         #       It is best for the user to write this part of the logic in a hook func.
-        self.model.train()
+        [model.train() for model in self.training_models]
         # self.training_models may not be DDP if horovod.
         from torch.nn.parallel import DistributedDataParallel as DDP
-        if isinstance(self.model, DDP):
-            with self.model.join():
+        # In train mode, self.model points to training_models[0]
+        if isinstance(self.training_models[0], DDP):
+            with Join(self.training_models):
                 self._train_loop(iterator, metric_meters, callbacks)
         else:
             self._train_loop(iterator, metric_meters, callbacks)
@@ -431,7 +433,7 @@ class TorchRunner(BaseRunner):
 
         # Compute gradients in a backward pass.
         with self.timers.record("bwd"):
-            self.call_hook(callbacks=callbacks, fn_name="on_iter_backward")
+            self.call_hook(callbacks=callbacks, fn_name="on_train_backward")
 
         loss_item = self.loss.item()
         self.metrics_stats = {"train_loss": loss_item, NUM_SAMPLES: get_batchsize(batch)}
@@ -453,7 +455,7 @@ class TorchRunner(BaseRunner):
     def validate(self, data_creator, batch_size=32, num_steps=None, profile=False,
                  wrap_dataloader=None, callbacks=None):
         """Evaluates the model on the validation data set."""
-        if not self.models:
+        if not self._models:
             invalidInputError(False,
                               "You must provide a model for train and evaluate.")
 
@@ -509,7 +511,7 @@ class TorchRunner(BaseRunner):
         """
         # switch to evaluate mode
         self._mode = 'val'
-        self.model.eval()
+        [model.eval() for model in self._models()]
         metrics = Metric.convert_metrics_dict(metrics, backend="pytorch")
         losses = []
         total_samples = 0
@@ -590,7 +592,7 @@ class TorchRunner(BaseRunner):
         config = copy.copy(self.config)
         self._toggle_profiling(profile=profile)
 
-        if not self.models:
+        if not self._models:
             invalidInputError(False,
                               "You must provide a model for predict.")
 
@@ -626,7 +628,7 @@ class TorchRunner(BaseRunner):
     def _predict(self, pred_iterator, callbacks=None):
         # switch to evaluate mode
         self._mode = 'predict'
-        self.model.eval()
+        [model.eval() for model in self._models()]
         result = []
         with torch.no_grad():
             for batch_idx, batch in enumerate(pred_iterator):
@@ -667,7 +669,7 @@ class TorchRunner(BaseRunner):
         """Returns the state of the runner."""
         state = {
             "epoch": self.epochs,
-            "models": [model.state_dict() for model in self.models]
+            "models": [model.state_dict() for model in self._models]
         }
         if self.optimizers:
             state.update({
@@ -687,14 +689,14 @@ class TorchRunner(BaseRunner):
         """Sets the state of the model."""
         import collections
         if isinstance(state, collections.OrderedDict):
-            for model, state_dict in zip(self.models, [state]):
+            for model, state_dict in zip(self._models, [state]):
                 model.load_state_dict(state_dict)
         else:
             if "models" in state:
-                for model, state_dict in zip(self.models, state["models"]):
+                for model, state_dict in zip(self._models, state["models"]):
                     model.load_state_dict(state_dict)
             else:
-                for model, state_dict in zip(self.models, state):
+                for model, state_dict in zip(self._models, state):
                     model.load_state_dict(state_dict)
         if self.optimizers and "optimizers" in state:
             for optimizer, state_dict in zip(self.optimizers, state["optimizers"]):
@@ -711,7 +713,7 @@ class TorchRunner(BaseRunner):
             if save_weights_only:
                 checkpoint = {
                     "epoch": self.epochs,
-                    "models": [model.state_dict() for model in self.models],
+                    "models": [model.state_dict() for model in self._models],
                 }
             else:
                 checkpoint = self.get_state_dict()
@@ -739,7 +741,7 @@ class TorchRunner(BaseRunner):
         del self.train_loader
         del self.criterion
         del self.optimizers
-        del self.models
+        del self._models
 
     def call_hook(self, callbacks, fn_name: str) -> None:
         """Call all hooks.
@@ -778,10 +780,10 @@ class TorchRunner(BaseRunner):
 
     @property
     def given_models(self):
-        if len(self.models) > 1:
-            return self.models
+        if len(self._models) > 1:
+            return self._models
         else:
-            return self.models[0]
+            return self._models[0]
 
     @property
     def given_optimizers(self):
@@ -800,8 +802,21 @@ class TorchRunner(BaseRunner):
             if self.training_models:
                 return self.training_models[0]
         else:
-            if self.models:
-                return self.models[0]
+            if self._models:
+                return self._models[0]
+
+    @property
+    def models(self):
+        """
+        First or only model(s) created by the ``model_creator``.
+        Discuss whether to return ddp model depending on the mode.
+        """
+        if self._mode == 'train':
+            if self.training_models:
+                return self.training_models
+        else:
+            if self._models:
+                return self._models
 
     @property
     def optimizer(self):

--- a/python/orca/test/bigdl/orca/learn/test_pytorch_basic.py
+++ b/python/orca/test/bigdl/orca/learn/test_pytorch_basic.py
@@ -88,6 +88,56 @@ class Net(nn.Module):
         return y
 
 
+class Net_1(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc1 = nn.Linear(50, 50)
+        self.relu1 = nn.ReLU()
+        self.dout = nn.Dropout(0.2)
+
+    def forward(self, input_):
+        a1 = self.fc1(input_)
+        h1 = self.relu1(a1)
+        dout = self.dout(h1)
+        return dout
+
+
+class Net_2(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fc2 = nn.Linear(50, 100)
+        self.prelu = nn.PReLU(1)
+        self.out = nn.Linear(100, 1)
+        self.out_act = nn.Sigmoid()
+
+    def forward(self, input_):
+        a2 = self.fc2(input_)
+        h2 = self.prelu(a2)
+        a3 = self.out(h2)
+        y = self.out_act(a3)
+        return y
+
+
+class MultiModelCallback(MainCallback):
+    def on_iter_forward(self, runner):
+        """
+        If `on_train_forward` and `on_val_forward` are not overridden,
+        this will be called during forward when training and validating.
+        Any behavior inconsistent with the default forward behavior should be overridden here.
+        """
+        # unpack features into features and targets
+        *features, target = runner.batch
+        # Forward features
+        dout = runner.model[0](*features)
+        runner.output = runner.model[1](dout)
+
+        # Ensure `targetL` and `outputL` are always in a list format.
+        targetL = [target] if not isinstance(target, (list, tuple)) else target
+        outputL = [runner.output] if not isinstance(runner.output, (list, tuple)) else runner.output
+        # Compute loss
+        runner.loss = runner.criterion(*outputL, *targetL)
+
+
 class ComplicatedOutputNet(nn.Module):
     def __init__(self):
         super().__init__()
@@ -540,6 +590,34 @@ class TestPyTorchEstimatorBasic(TestCase):
                                    output_cols=['scalar', 'dict'])
         result.collect()
         assert "scalar" and "dict" in result.columns
+
+    def test_multi_model_train_eval(self):
+
+        sc = init_nncontext()
+        spark = SparkSession.builder.getOrCreate()
+        rdd = sc.range(0, 100)
+        data = rdd.map(lambda x: (np.random.randn(50).astype(np.float32).tolist(),
+                                  [float(np.random.randint(0, 2, size=()))])
+                       )
+        schema = StructType([
+            StructField("feature", ArrayType(FloatType()), True),
+            StructField("label", ArrayType(FloatType()), True)
+        ])
+
+        df = spark.createDataFrame(data=data, schema=schema)
+
+        estimator = get_estimator(workers_per_node=2,
+                                  model_fn=lambda config: [Net_1(), Net_2()])
+        estimator.fit(df, batch_size=4, epochs=2,
+                      validation_data=df,
+                      feature_cols=["feature"],
+                      label_cols=["label"],
+                      callbacks=[MultiModelCallback()])
+        estimator.evaluate(df, batch_size=4,
+                           feature_cols=["feature"],
+                           label_cols=["label"],
+                           callbacks=[MultiModelCallback()])
+        estimator.shutdown()
 
     def test_data_parallel_sgd_correctness(self):
         sc = init_nncontext()


### PR DESCRIPTION
# Note: This PR may need Pytorch2.0

### 1. Why the change?

Prior to this update, our orca estimator only supported single-model operations. With this PR, we aim to enable multi-model input for our users. Users can now produce multiple models in the model_creator and process them in a distributed manner using Torchrunner. This allows for the simultaneous processing of multiple models, providing users with greater flexibility to operate on multiple models at once.

### 2. User API changes

`model_creator` could return models more than single one.

### 3. Summary of the change 

We provide the variable "models" for users to handle situations involving multiple models. Users may pass a custom callback to achieve this:
```
class MultiModelCallback(MainCallback):
    def on_iter_forward(self, runner):
        # unpack features into features and targets
        *features, target = runner.batch
        # Forward features
        dout = runner.model[0](*features)
        runner.output = runner.model[1](dout)
        ...
```


### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Pytorch 2.0(`from torch.distributed.algorithms.join import Join` only exits in Pytorch2.0)