### PR TITLE
[Nano] Fix missing `enable_onednn` paramater for `PytorchIPEXJITBF16Model`

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -77,7 +77,7 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
                                      channels_last_available=channels_last_available,
                                      from_load=from_load, inplace=inplace, jit_strict=jit_strict,
                                      jit_method=jit_method, weights_prepack=weights_prepack,
-                                     compression=compression)
+                                     enable_onednn=enable_onednn, compression=compression)
         _accelerator = "jit" if use_jit is True else None
         self._nano_context_manager = generate_context_manager(accelerator=_accelerator,
                                                               precision="bf16",

--- a/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
@@ -349,6 +349,20 @@ class Pytorch1_11:
         with InferenceOptimizer.get_context(new_model):
             new_model(x)
             assert new_model.enable_onednn is True
+        
+        model = InferenceOptimizer.quantize(model, precision='bf16',
+                                            accelerator="jit",
+                                            use_ipex=True,
+                                            input_sample=x,
+                                            enable_onednn=False)
+        with InferenceOptimizer.get_context(model):
+            model(x)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(model, tmp_dir_name)
+            new_model = InferenceOptimizer.load(tmp_dir_name)
+        with InferenceOptimizer.get_context(new_model):
+            new_model(x)
+            assert new_model.enable_onednn is False
 
     def test_ipex_jit_channels_last_3d_inference(self):
         model = DummyModelWith3d()


### PR DESCRIPTION
## Description

Fix missing `enable_onednn` paramater for `PytorchIPEXJITBF16Model` which causes loaded `PytorchIPEXJITBF16Model` always 
`enable_onednn = True`.

### How to test?
- [x] Unit test


