### PR TITLE
[NANO] Add safe path check in multi-process worker

### DIFF
--- a/python/nano/src/bigdl/nano/automl/utils/parallel_worker.py
+++ b/python/nano/src/bigdl/nano/automl/utils/parallel_worker.py
@@ -21,9 +21,12 @@ import sys
 import cloudpickle
 
 from pytorch_lightning.utilities.seed import reset_seed
+from bigdl.nano.utils.common import invalidInputError
 
 if __name__ == '__main__':
     temp_dir = sys.argv[1]
+
+    invalidInputError(os.path.isdir(temp_dir), 'f{temp_dir} is not an available path')
 
     with open(os.path.join(temp_dir, "search_kwargs.pkl"), 'rb') as f:
         kwargs = cloudpickle.load(f)

--- a/python/nano/src/bigdl/nano/deps/horovod/horovod_worker.py
+++ b/python/nano/src/bigdl/nano/deps/horovod/horovod_worker.py
@@ -17,10 +17,13 @@
 import os
 import cloudpickle
 import sys
+from bigdl.nano.utils.common import invalidInputError
 
 
 if __name__ == '__main__':
     temp_dir = sys.argv[1]
+
+    invalidInputError(os.path.isdir(temp_dir), 'f{temp_dir} is not an available path')
 
     with open(os.path.join(temp_dir, "args.pkl"), 'rb') as f:
         args = cloudpickle.load(f)

--- a/python/nano/src/bigdl/nano/pytorch/strategies/worker.py
+++ b/python/nano/src/bigdl/nano/pytorch/strategies/worker.py
@@ -21,11 +21,13 @@ import cloudpickle
 import multiprocessing
 from torch.multiprocessing.spawn import _wrap
 from bigdl.nano.pytorch.dispatcher import patch_torch
-
+from bigdl.nano.utils.common import invalidInputError
 
 if __name__ == '__main__':
     temp_dir = sys.argv[1]
     process_idx = int(os.environ["PROCESS_IDX"])
+
+    invalidInputError(os.path.isdir(temp_dir), 'f{temp_dir} is not an available path')
 
     # set the same `multiprocessing.current_process().authkey` as the main process
     # so that we can load the `sys_path.pkl` and `args.pkl`

--- a/python/nano/src/bigdl/nano/utils/tf/subprocess_worker.py
+++ b/python/nano/src/bigdl/nano/utils/tf/subprocess_worker.py
@@ -18,9 +18,12 @@ import json
 import os
 import cloudpickle
 import sys
+from bigdl.nano.utils.common import invalidInputError
 
 if __name__ == '__main__':
     temp_dir = sys.argv[1]
+
+    invalidInputError(os.path.isdir(temp_dir), 'f{temp_dir} is not an available path')
 
     with open(os.path.join(temp_dir, "args.pkl"), 'rb') as f:
         args = cloudpickle.load(f)


### PR DESCRIPTION
## Description

* To prevent users from entering illegal paths.
* Add path available check before load model when multi-process invoking worker .






