### PR TITLE
Nano: further support tensorflow customized training loop with multi-process

### DIFF
--- a/python/nano/src/bigdl/nano/tf/keras/__init__.py
+++ b/python/nano/src/bigdl/nano/tf/keras/__init__.py
@@ -19,4 +19,5 @@ import tensorflow as tf
 from .Sequential import Sequential
 from .Model import V2Model as Model
 from .inference.optimizer import InferenceOptimizer
-from .customized_training_utils import nano_bf16, nano_multiprocessing, nano
+from .customized_training_utils import nano_bf16, nano_multiprocessing, nano, \
+    nano_multiprocessing_loss

--- a/python/nano/src/bigdl/nano/tf/keras/customized_training_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/customized_training_utils.py
@@ -25,6 +25,8 @@ import json
 
 from bigdl.nano.utils.common import schedule_processors
 from bigdl.nano.tf.keras.distributed_utils import _find_free_port
+from tensorflow.keras.losses import Loss
+import warnings
 
 
 def nano_bf16(func):
@@ -104,13 +106,27 @@ class _Nano_Customized_Training(object):
 
                 # serialize the dataset
                 if isinstance(arg, tf.data.Dataset):
-                    from tensorflow.python.distribute.coordinator.values import \
-                        serialize_dataset_to_graph
+                    warnings.warn('If dataset is created by `from_generator`, please initiate '
+                                  '`_GeneratorState` of the dataset first, that is '
+                                  'dataset._GeneratorState = dataset._GeneratorState(generator).' 
+                                  'Otherwise, there exists errors because of a known limitation: '
+                                  'https://www.tensorflow.org/api_docs/python/tf/data/Dataset'
+                                  '#from_generator')
+                    if hasattr(arg, '_GeneratorState') and \
+                        hasattr(arg._GeneratorState, '_generator'):
+                        # support dataset created by `from_generator`
+                        train_ds_gen = arg._GeneratorState._generator
+                        train_ds_signature = arg.element_spec
+                        new_args.append(("dataset", train_ds_gen, train_ds_signature))
+                        continue
+                    else:
+                        from tensorflow.python.distribute.coordinator.values import \
+                            serialize_dataset_to_graph
 
-                    train_ds_def = serialize_dataset_to_graph(arg).numpy()
-                    train_elem_spec = arg.element_spec
-                    new_args.append(("dataset", train_ds_def, train_elem_spec))
-                    continue
+                        train_ds_def = serialize_dataset_to_graph(arg).numpy()
+                        train_elem_spec = arg.element_spec
+                        new_args.append(("dataset", train_ds_def, train_elem_spec))
+                        continue
 
                 with open(os.path.join(temp_dir, f"args_{i}.pkl"), 'wb') as f:
                     cloudpickle.dump(arg, f)
@@ -142,7 +158,6 @@ class _Nano_Customized_Training(object):
                     'no_proxy': "localhost"
                 })
 
-            # TODO: validation needs to be done on non-NoneType histories
             histrories = backend.run(target=_train_func,
                                      args=(target_path, *new_args),
                                      nprocs=self.nproc,
@@ -150,6 +165,7 @@ class _Nano_Customized_Training(object):
 
             main_model.load_weights('trained_model_weights')
 
+        return histrories[0]
 
 def _train_func(target_path, *args):
     mirrored_strategy = tf.distribute.MultiWorkerMirroredStrategy()
@@ -157,9 +173,8 @@ def _train_func(target_path, *args):
     actrual_args = [None] * len(args)
     new_model = None
 
-    for i, arg in enumerate(args):
-        with mirrored_strategy.scope():
-            # deserialize model
+    with mirrored_strategy.scope():
+        for i, arg in enumerate(args):
             if arg[0] == "model":
                 actrual_args[i] = tf.keras.models.load_model(arg[1])
                 new_model = actrual_args[i]
@@ -169,46 +184,80 @@ def _train_func(target_path, *args):
                 with open(arg[1], 'rb') as f:
                     actrual_args[i] = cloudpickle.load(f)
                 continue
-        # deserialize dataset
-        if arg[0] == "dataset":
-            # TODO: only dataset is supported here
-            # data generator is needed to be supported
-            # Dataset.from_generator could not be used due to a known limitation
-            # https://www.tensorflow.org/api_docs/python/tf/data/Dataset#from_generator
-            from tensorflow.python.distribute.coordinator.values import \
-                deserialize_dataset_from_graph
-            original_dataset = deserialize_dataset_from_graph(arg[1], arg[2])
-            actrual_args[i] = mirrored_strategy.experimental_distribute_dataset(original_dataset)
-            continue
-        # deserialize loss
-        if arg[0] == "loss":
-            with open(arg[1], 'rb') as f:
-                original_loss_object = cloudpickle.load(f)
-                original_loss_object.reduction = tf.keras.losses.Reduction.NONE
+            # deserialize dataset
+            if arg[0] == "dataset":
+                try:
+                    from tensorflow.python.distribute.coordinator.values import \
+                        deserialize_dataset_from_graph
+                    original_dataset = deserialize_dataset_from_graph(arg[1], arg[2])
+                except:
+                    original_dataset = tf.data.Dataset.from_generator(arg[1],
+                                                                      output_signature=arg[2])
+                actrual_args[i] = mirrored_strategy.experimental_distribute_dataset(
+                    original_dataset)
+                continue
 
-            def loss_object(*args, **kwargs):
-                per_example_loss = original_loss_object(*args, **kwargs)
-                size = per_example_loss.shape[0] * mirrored_strategy.num_replicas_in_sync
-                return tf.nn.compute_average_loss(per_example_loss, global_batch_size=size)
-            actrual_args[i] = loss_object
-            continue
-        # deserialize others
-        if arg[0] == "others":
-            with open(arg[1], 'rb') as f:
-                actrual_args[i] = cloudpickle.load(f)
-                if callable(actrual_args[i]) and isinstance(actrual_args[i], nano_multiprocessing):
-                    actrual_args[i] = partial(actrual_args[i], mirrored_strategy=mirrored_strategy)
+            if arg[0] == "loss":
+                with open(arg[1], 'rb') as f:
+                    original_loss_object = cloudpickle.load(f)
+                    original_loss_object.reduction = tf.keras.losses.Reduction.NONE
 
-    with open(target_path, 'rb') as f:
-        target_func = cloudpickle.load(f)
+                def loss_object(*args, **kwargs):
+                    per_example_loss = original_loss_object(*args, **kwargs)
+                    if per_example_loss.shape == []:
+                        size = mirrored_strategy.num_replicas_in_sync
+                        return tf.math.reduce_sum(per_example_loss) / size
+                    else:
+                        size = per_example_loss.shape[0] * mirrored_strategy.num_replicas_in_sync
+                        return tf.nn.compute_average_loss(per_example_loss, global_batch_size=size)
+                actrual_args[i] = loss_object
+                continue
+            # deserialize others
+            if arg[0] == "others":
+                with open(arg[1], 'rb') as f:
+                    actrual_args[i] = cloudpickle.load(f)
+                    if callable(actrual_args[i]) and \
+                        isinstance(actrual_args[i], nano_multiprocessing):
+                        actrual_args[i] = partial(actrual_args[i],
+                                                  mirrored_strategy=mirrored_strategy)
 
-    res = target_func(*actrual_args)
+        with open(target_path, 'rb') as f:
+            target_func = cloudpickle.load(f)
 
-    task_id = mirrored_strategy.cluster_resolver.task_id
-    # TODO: only task 0's model weight is stored
-    # could not understand why we need other task's weight
-    if task_id == 0:
-        path = os.path.join('trained_model_weights')
-        new_model.save_weights(path, overwrite=True)
+        res = target_func(*actrual_args)
 
+        task_id = mirrored_strategy.cluster_resolver.task_id
+        if task_id == 0:
+            path = os.path.join('trained_model_weights')
+            new_model.save_weights(path, overwrite=True)
+
+    # Related to https://github.com/tensorflow/tensorflow/issues/50487, to avoid such error
+    import atexit
+    atexit.register(mirrored_strategy._extended._cross_device_ops._pool.close)
+    atexit.register(mirrored_strategy._extended._host_cross_device_ops._pool.close)
     return res
+
+
+def nano_multiprocessing_loss(**kwargs):
+    """
+    A decorator to run customized loss on multiple processes.
+
+    """
+    def decorator(func):
+        return Nano_Customized_Loss(func, **kwargs)
+    return decorator
+
+
+class Nano_Customized_Loss(Loss):
+    """Wraps a loss function in the `Loss` class."""
+
+    def __init__(self, func, reduction=tf.keras.losses.Reduction.NONE, name=None, **kwargs):
+        """Initialize the loss function."""
+        super().__init__(reduction=reduction, name=name)
+        self.fn = func
+        self._fn_kwargs = kwargs
+
+    def call(self, y_true, y_pred):
+        """Run the loss function for multi-process training."""
+        return self.fn(y_true, y_pred, **self._fn_kwargs)
+

--- a/python/nano/src/bigdl/nano/tf/keras/customized_training_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/customized_training_utils.py
@@ -205,7 +205,7 @@ def _train_func(target_path, *args):
 
                 def loss_object(*args, **kwargs):
                     per_example_loss = original_loss_object(*args, **kwargs)
-                    if per_example_loss.shape == []:
+                    if per_example_loss.shape == [] or per_example_loss.shape[0] == 0:
                         size = mirrored_strategy.num_replicas_in_sync
                         return tf.math.reduce_sum(per_example_loss) / size
                     else:

--- a/python/nano/src/bigdl/nano/tf/keras/customized_training_utils.py
+++ b/python/nano/src/bigdl/nano/tf/keras/customized_training_utils.py
@@ -243,10 +243,7 @@ def _train_func(target_path, *args):
 
 
 def nano_multiprocessing_loss(**kwargs):
-    """
-    A decorator to run customized loss on multiple processes.
-
-    """
+    """A decorator to run customized loss on multiple processes."""
     def decorator(func):
         return Nano_Customized_Loss(func, **kwargs)
     return decorator

--- a/python/nano/src/bigdl/nano/utils/tf/backend.py
+++ b/python/nano/src/bigdl/nano/utils/tf/backend.py
@@ -59,8 +59,13 @@ class MultiprocessingBackend(Backend):
                 for key, val in os.environ.items():
                     if key not in envs[i]:
                         envs[i][key] = val
+                if 'OMP_NUM_THREADS' in envs[i]:
+                    set_op_thread = envs[i]['OMP_NUM_THREADS']
+                else:
+                    # 0 means the system picks an appropriate number
+                    set_op_thread = '0'
                 ex_list.append(subprocess.Popen([sys.executable, f"{cwd_path}/subprocess_worker.py",
-                                                 temp_dir], env=envs[i]))
+                                                 temp_dir, set_op_thread], env=envs[i]))
             for _, ex in enumerate(ex_list):
                 ex.wait()
 

--- a/python/nano/src/bigdl/nano/utils/tf/subprocess_worker.py
+++ b/python/nano/src/bigdl/nano/utils/tf/subprocess_worker.py
@@ -18,8 +18,12 @@ import json
 import os
 import cloudpickle
 import sys
+import tensorflow as tf
 
 if __name__ == '__main__':
+    # Set number of threads in subprocess
+    tf.config.threading.set_inter_op_parallelism_threads(int(sys.argv[2]))
+    tf.config.threading.set_intra_op_parallelism_threads(int(sys.argv[2]))
     temp_dir = sys.argv[1]
 
     with open(os.path.join(temp_dir, "args.pkl"), 'rb') as f:


### PR DESCRIPTION
## Description

Complete remaining TODOs after https://github.com/intel-analytics/BigDL/pull/7766.

### 1. Why the change?

In previous work (https://github.com/intel-analytics/BigDL/pull/7766), we start to support tensorflow multi-process training with customized training loop.
In fact, some critical questions still need to solve and validate.

Proof points has been carried out on model of special use-case, and it does solve remaining problems and speed-up the training process.

### 2. User API changes

Users will have a decorator to handle customized loss function
```bash
from bigdl.nano.tf.keras import nano_multiprocessing_loss

@nano_multiprocessing_loss(**kwargs)
def loss_object(x, pred, **kwargs):
    xxxx
```
nano_multiprocessing_loss: users need to add this decorator to their loss function.

### 3. Summary of the change 

- add a new decorator @nano_multiprocessing_loss to handle customized loss function
- support thread settings for core affinity for stock tensorflow
- fix loss computation and other operations within `MultiWorkerMirroredStrategy`
- support dataset created by `from_generator`

### 4. How to test?
- [x] Unit test
