### PR TITLE
[ORCA] Fix for TF2 Pyspark Estimator Getting Stuck on Kubernetes

### DIFF
--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -109,14 +109,19 @@ class SparkTFEstimator():
 
     def _get_cluster_info(self, sc):
         def get_worker_address(iter):
+            res = []
             worker_ip = get_node_ip()
             worker_port = find_free_port()
-            res = []
-            res.append(f"{worker_ip}:{worker_port}")
+            address = [f"{worker_ip}:{worker_port}"]
+            address.extend(find_ip_and_free_port(iter))
+            res.append(address)
             return res
+
         worker_info = self.workerRDD.barrier().mapPartitions(get_worker_address).collect()
-        cluster_info = self.workerRDD.barrier().mapPartitions(find_ip_and_free_port).collect()
-        return worker_info, cluster_info
+        address_info = [info[0] for info in worker_info]
+        cluster_info = [info[1] for info in worker_info]
+
+        return address_info, cluster_info
 
     def fit(self,
             data: Union["SparkXShards", "SparkDataFrame", Callable],

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -108,8 +108,15 @@ class SparkTFEstimator():
             self.log_server_thread = start_log_server(self.ip, self.port)
 
     def _get_cluster_info(self, sc):
+        def get_worker_address(iter):
+            worker_ip = get_node_ip()
+            worker_port = find_free_port()
+            res = []
+            res.append(f"{worker_ip}:{worker_port}")
+            return res
+        worker_info = self.workerRDD.barrier().mapPartitions(get_worker_address).collect()
         cluster_info = self.workerRDD.barrier().mapPartitions(find_ip_and_free_port).collect()
-        return cluster_info
+        return worker_info, cluster_info
 
     def fit(self,
             data: Union["SparkXShards", "SparkDataFrame", Callable],

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -109,12 +109,10 @@ class SparkTFEstimator():
 
     def _get_cluster_info(self, sc):
         def get_worker_address(iter):
-            res = []
             worker_ip = get_node_ip()
             worker_port = find_free_port()
-            address = [f"{worker_ip}:{worker_port}"]
-            address.extend(find_ip_and_free_port(iter))
-            res.append(address)
+            addresses = find_ip_and_free_port(iter)
+            res = [(f"{worker_ip}:{worker_port}", address) for address in addresses]
             return res
 
         worker_info = self.workerRDD.barrier().mapPartitions(get_worker_address).collect()

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -313,16 +313,17 @@ class SparkRunner:
         """
         Sets up TensorFLow distributed environment and initializes the model.
         """
-        self.rank = get_rank(cluster)
-        logger.info("cluster is: {}".format(cluster))
+        worker_cluster, node_cluster = cluster
+        self.rank = get_rank(node_cluster)
+        logger.info("cluster is: {}".format(node_cluster))
 
         os.environ["TF_CONFIG"] = json.dumps({
             'cluster': {
-                'worker': cluster
+                'worker': worker_cluster
             },
             'task': {'type': 'worker', 'index': self.rank}
         })
-        ips = set([node.split(":")[0] for node in cluster])
+        ips = set([node.split(":")[0] for node in worker_cluster])
         os.environ["no_proxy"] = ",".join(ips)
 
         self.strategy = tf.distribute.experimental.MultiWorkerMirroredStrategy()


### PR DESCRIPTION
## Description
Fix issue with the description in https://github.com/analytics-zoo/arda-docker/issues/808.

### 1. Why the change?
Change the method to get current worker ip, which could support getting k8s pods' addresses instead of only reaching nodes' addresses in cluster.

### 2. User API changes
N/A

### 3. Summary of the change 
Re-write the part to get workers' addressed to init Grpc group.
1. Divide worker address into `worker address` and `executor address`.
2. `executor address` is mainly used for getting the global rank.
3. `worker address` is mainly used for allocating pod or node's ip to grpc group. 

### 4. How to test?
- [x] Unit test
- [x] Test on K8s
- [x] Test on Yarn
- [x] Test on Local

