### PR TITLE
Orca: avoid xpath injection detected by checkmarx

### DIFF
--- a/python/orca/src/bigdl/orca/data/image/voc_dataset.py
+++ b/python/orca/src/bigdl/orca/data/image/voc_dataset.py
@@ -62,14 +62,16 @@ class VOCDatasets:
         self._im_cache = {}  # type: Dict[str, "ndarray"]
 
     def _load_items(self, splits_names: List[Tuple[int, str]]) -> List[Tuple[str, str]]:
-
         img_ids = []
+        img_id_allow_list = list(range(1000000))
         for year, txtname in splits_names:
             vocfolder = osp.join(self._root, "VOC{}".format(year))
             txtpath = osp.join(vocfolder, 'ImageSets', 'Main', txtname + '.txt')
             try:
                 with open(txtpath, 'r', encoding='utf-8') as f:
-                    img_ids += [(vocfolder, line.strip()) for line in f.readlines()]
+                    for line in f.readlines():
+                        img_id = img_id_allow_list[int(line.strip())]
+                        img_ids += [(vocfolder, "{0:06d}".format(img_id))]
             except:
                 continue
         return img_ids


### PR DESCRIPTION
## Description
Fix the problem of potential xpath injection in Orca detected by checkmarx.

## Issues detected
![image](https://user-images.githubusercontent.com/42887453/228806571-b59b5b0b-4065-4525-9a24-311c124443b4.png)

## Solutions
- XPath injection
- [ ] `voc_dataset.py`: 
Check whether img_id is a valid numerical image ID . 


