### PR TITLE
Chronos: add normalization for `TCNForecaster` of tensorflow backend

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/base_forecaster.py
@@ -30,6 +30,8 @@ class BaseTF2Forecaster(Forecaster):
     def __init__(self, **kwargs):
         if self.seed:
             # TF seed can't be set to None, just to be consistent with torch.
+            warnings.warn("If users want to set the random seed for training, it's better to "
+                          f"call 'tf.keras.utils.set_random_seed({self.seed})' manually.")
             from tensorflow.keras.utils import set_random_seed
             set_random_seed(seed=self.seed)
         if self.distributed:

--- a/python/chronos/src/bigdl/chronos/forecaster/tf/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tf/tcn_forecaster.py
@@ -38,6 +38,7 @@ class TCNForecaster(BaseTF2Forecaster):
                  output_feature_num,
                  num_channels=[16]*3,
                  kernel_size=3,
+                 normalization=False,
                  repo_initialization=True,
                  dropout=0.1,
                  optimizer="Adam",
@@ -63,6 +64,10 @@ class TCNForecaster(BaseTF2Forecaster):
                TCN's encoder. This value defaults to [16]*3.
         :param kernel_size: Specify convolutional layer filter height in TCN's
                encoder. This value defaults to 3.
+        :param normalization: bool, Specify if to use normalization trick to
+               alleviate distribution shift. It first subtractes the last value
+               of the sequence and add back after the model forwarding.
+               This value defaults to False.
         :param repo_initialization: if to use framework default initialization,
                True to use paper author's initialization and False to use the
                framework's default initialization. The value defaults to True.
@@ -106,6 +111,7 @@ class TCNForecaster(BaseTF2Forecaster):
             "loss": loss,
             "lr": lr,
             "optim": optimizer,
+            "normalization": normalization,
         }
 
         # model creator settings

--- a/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/TCN_keras.py
@@ -45,6 +45,7 @@ import tensorflow as tf
 from bigdl.nano.tf.keras import Model
 from tensorflow.keras.layers import Conv1D, BatchNormalization,\
     Activation, Dropout, Input, Layer
+from bigdl.chronos.model.tf2.keras_model_wrapper import NormalizeTSModel
 
 
 class TemporalBlock(Layer):
@@ -196,6 +197,8 @@ def model_creator(config):
                             kernel_size=config.get("kernel_size", 7),
                             dropout=config.get("dropout", 0.2),
                             repo_initialization=config.get("repo_initialization", True))
+    if config.get("normalization", False):
+        model = NormalizeTSModel(model, config["output_feature_num"])
     inputs = np.zeros(shape=(1, config["past_seq_len"], config["input_feature_num"]))
     # init weights matrix
     model(inputs)

--- a/python/chronos/src/bigdl/chronos/model/tf2/keras_model_wrapper.py
+++ b/python/chronos/src/bigdl/chronos/model/tf2/keras_model_wrapper.py
@@ -1,0 +1,36 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from bigdl.nano.tf.keras import Model
+
+
+class NormalizeTSModel(Model):
+    def __init__(self, model, output_feature_dim):
+        """
+        Build a Normalization model wrapper.
+        param model: basic forecaster model.
+        :param output_feature_dim: Specify the output dimension.
+        """
+        super(NormalizeTSModel, self).__init__()
+        self.model = model
+        self.output_feature_dim = output_feature_dim
+
+    def call(self, x):
+        seq_last = x[:, -1:, :]
+        x = x - seq_last
+        y = self.model(x)
+        y = y + seq_last[:, :, :self.output_feature_dim]
+        return y

--- a/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/tf/test_tcn_keras_forecaster.py
@@ -106,6 +106,20 @@ class TestTCNForecaster(TestCase):
                                        multioutput="raw_values")
         assert mse[0].shape == test_data[1].shape[1:]
 
+    def test_tcn_forecaster_fit_predict_evaluate_normalization(self):
+        train_data, _, test_data = create_data()
+        forecaster = TCNForecaster(past_seq_len=10,
+                                   future_seq_len=2,
+                                   input_feature_num=10,
+                                   output_feature_num=2,
+                                   num_channels=[15]*7,
+                                   normalization=True)
+        forecaster.fit(train_data, epochs=2, batch_size=32)
+        yhat = forecaster.predict(test_data[0], batch_size=32)
+        assert yhat.shape == (400, 2, 2)
+        mse = forecaster.evaluate(test_data, batch_size=32, multioutput="raw_values")
+        assert mse[0].shape == test_data[1].shape[1:]
+
     def test_tcn_forecaster_evaluate(self):
         train_tsdata, _, test_tsdata = create_tsdataset()
         forecaster = TCNForecaster.from_tsdataset(train_tsdata, past_seq_len=24, future_seq_len=5)


### PR DESCRIPTION
## Description

### 1. Why the change?

similar reason as https://github.com/intel-analytics/BigDL/pull/6405. Experiment results on datasets (electricity and nyc_taxi) demonstrate the effectiveness of normalization extensions.

### 2. User API changes

a new parameter `normalization` when initiate TCNForecaster
```python
forecaster = TCNForecaster(past_seq_len = 96,
                           future_seq_len = 96,
                           input_feature_num = 1,
                           output_feature_num = 1,
                           normalization=True)
```


### 3. Summary of the change 

Add normalization model wrapper for TCN-keras.

### 4. How to test?
- [x] Unit test
