### PR TITLE
[PPML] Add ENABLE_DCAP_ATTESTATION option to trusted-machine-learning

### DIFF
--- a/ppml/trusted-machine-learning/README.md
+++ b/ppml/trusted-machine-learning/README.md
@@ -40,7 +40,7 @@ export NFS_INPUT_PATH=/YOUR_DIR/data
 export KEYS_PATH=/YOUR_DIR/keys
 export SECURE_PASSWORD_PATH=/YOUR_DIR/password
 export KUBECONFIG_PATH=/YOUR_DIR/kubeconfig
-export LOCAL_IP=YOUT_LOCAL_IP
+export LOCAL_IP=YOUR_LOCAL_IP
 export DOCKER_IMAGE=YOUR_DOCKER_IMAGE
 sudo docker run -itd \
     --privileged \

--- a/ppml/trusted-machine-learning/README.md
+++ b/ppml/trusted-machine-learning/README.md
@@ -40,7 +40,7 @@ export NFS_INPUT_PATH=/YOUR_DIR/data
 export KEYS_PATH=/YOUR_DIR/keys
 export SECURE_PASSWORD_PATH=/YOUR_DIR/password
 export KUBECONFIG_PATH=/YOUR_DIR/kubeconfig
-export LOCAL_IP=$LOCAL_IP
+export LOCAL_IP=YOUT_LOCAL_IP
 export DOCKER_IMAGE=YOUR_DOCKER_IMAGE
 sudo docker run -itd \
     --privileged \
@@ -55,7 +55,7 @@ sudo docker run -itd \
     -v $SECURE_PASSWORD_PATH:/ppml/password \
     -v $KUBECONFIG_PATH:/root/.kube/config \
     -v $NFS_INPUT_PATH:/ppml/data \
-    -e RUNTIME_SPARK_MASTER=$K8S_MASTERK8S_MASTER \
+    -e RUNTIME_SPARK_MASTER=$K8S_MASTER \
     -e RUNTIME_K8S_SPARK_IMAGE=$DOCKER_IMAGE \
     -e RUNTIME_DRIVER_PORT=54321 \
     -e RUNTIME_DRIVER_MEMORY=10g \

--- a/ppml/trusted-machine-learning/README.md
+++ b/ppml/trusted-machine-learning/README.md
@@ -15,7 +15,7 @@ Before building your own base image, please modify the paths in `build-base-imag
 ```
 #### 1.2 Build Custom Image
 
-Follow [here](https://github.com/intel-analytics/BigDL/tree/main/ppml/trusted-bigdata#12-build-customer-image) to build a custom image with enclave signed by your private key.
+Follow [here](https://github.com/intel-analytics/BigDL/tree/main/ppml/trusted-bigdata#12-build-custom-image) to build a custom image with enclave signed by your private key.
 
 ### 2. Prepare SSL key and password
 

--- a/ppml/trusted-machine-learning/custom-image/Dockerfile
+++ b/ppml/trusted-machine-learning/custom-image/Dockerfile
@@ -8,12 +8,15 @@ ARG SGX_MEM_SIZE
 ARG SGX_LOG_LEVEL
 
 ADD ./enclave-key.pem /root/.config/gramine/enclave-key.pem
+ADD ./make-sgx.sh /ppml/make-sgx.sh
 
 # 1.1 make SGX and sign in a temp image
 RUN cd /ppml && \
     echo SGX_MEM_SIZE:$SGX_MEM_SIZE && \
     echo SGX_LOG_LEVEL:$SGX_LOG_LEVEL && \
-    make SGX=1 DEBUG=1 THIS_DIR=/ppml  SPARK_USER=root G_SGX_SIZE=$SGX_MEM_SIZE G_LOG_LEVEL=$SGX_LOG_LEVEL
+    make SGX=1 DEBUG=1 THIS_DIR=/ppml  SPARK_USER=root G_SGX_SIZE=$SGX_MEM_SIZE G_LOG_LEVEL=$SGX_LOG_LEVEL && \
+    chmod a+x make-sgx.sh && \
+    ./make-sgx.sh
 
 # stage 2. copy sign etc. secrets from temp into target image and generate AS secrets
 FROM $MACHINE_LEARNING_BASE_IMAGE_NAME:$MACHINE_LEARNING_BASE_IMAGE_TAG

--- a/ppml/trusted-machine-learning/custom-image/Dockerfile
+++ b/ppml/trusted-machine-learning/custom-image/Dockerfile
@@ -6,6 +6,7 @@ FROM $MACHINE_LEARNING_BASE_IMAGE_NAME:$MACHINE_LEARNING_BASE_IMAGE_TAG as temp
 
 ARG SGX_MEM_SIZE
 ARG SGX_LOG_LEVEL
+ARG ENABLE_DCAP_ATTESTATION
 
 ADD ./enclave-key.pem /root/.config/gramine/enclave-key.pem
 ADD ./make-sgx.sh /ppml/make-sgx.sh

--- a/ppml/trusted-machine-learning/custom-image/build-custom-image.sh
+++ b/ppml/trusted-machine-learning/custom-image/build-custom-image.sh
@@ -1,9 +1,9 @@
-export CUSTOM_IMAGE_NAME=ml-0331
+export CUSTOM_IMAGE_NAME=bigdl-ppml-trusted-machine-learning-gramine-custom
 export CUSTOM_IMAGE_TAG=2.3.0-SNAPSHOT
 export MACHINE_LEARNING_BASE_IMAGE_NAME=bigdl-ppml-trusted-machine-learning-gramine-base
 export MACHINE_LEARNING_BASE_IMAGE_TAG=2.3.0-SNAPSHOT
-export SGX_MEM_SIZE=16G
-export SGX_LOG_LEVEL=error
+export SGX_MEM_SIZE=memory_size_of_sgx_in_custom_image
+export SGX_LOG_LEVEL=log_level_of_sgx_in_custom_image
 export ENABLE_DCAP_ATTESTATION=true
 
 if [[ "$SGX_MEM_SIZE" == "memory_size_of_sgx_in_custom_image" ]] || [[ "$SGX_LOG_LEVEL" == "log_level_of_sgx_in_custom_image" ]]

--- a/ppml/trusted-machine-learning/custom-image/build-custom-image.sh
+++ b/ppml/trusted-machine-learning/custom-image/build-custom-image.sh
@@ -1,9 +1,10 @@
-export CUSTOM_IMAGE_NAME=bigdl-ppml-trusted-machine-learning-gramine-custom
+export CUSTOM_IMAGE_NAME=ml-0331
 export CUSTOM_IMAGE_TAG=2.3.0-SNAPSHOT
 export MACHINE_LEARNING_BASE_IMAGE_NAME=bigdl-ppml-trusted-machine-learning-gramine-base
 export MACHINE_LEARNING_BASE_IMAGE_TAG=2.3.0-SNAPSHOT
-export SGX_MEM_SIZE=memory_size_of_sgx_in_custom_image
-export SGX_LOG_LEVEL=log_level_of_sgx_in_custom_image
+export SGX_MEM_SIZE=16G
+export SGX_LOG_LEVEL=error
+export ENABLE_DCAP_ATTESTATION=true
 
 if [[ "$SGX_MEM_SIZE" == "memory_size_of_sgx_in_custom_image" ]] || [[ "$SGX_LOG_LEVEL" == "log_level_of_sgx_in_custom_image" ]]
 then
@@ -14,6 +15,7 @@ else
         --build-arg MACHINE_LEARNING_BASE_IMAGE_TAG=${MACHINE_LEARNING_BASE_IMAGE_TAG} \
         --build-arg SGX_MEM_SIZE=${SGX_MEM_SIZE} \
         --build-arg SGX_LOG_LEVEL=${SGX_LOG_LEVEL} \
+        --build-arg ENABLE_DCAP_ATTESTATION=${ENABLE_DCAP_ATTESTATION} \
         -t ${CUSTOM_IMAGE_NAME}:${CUSTOM_IMAGE_TAG} \
         -f ./Dockerfile .
 fi

--- a/ppml/trusted-machine-learning/custom-image/make-sgx.sh
+++ b/ppml/trusted-machine-learning/custom-image/make-sgx.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+echo SGX_MEM_SIZE:$SGX_MEM_SIZE
+echo SGX_LOG_LEVEL:$SGX_LOG_LEVEL
+echo ENABLE_DCAP_ATTESTATION:$ENABLE_DCAP_ATTESTATION
+if [[ "$ENABLE_DCAP_ATTESTATION" == "false" ]]; then
+   echo "Warning: Disable dcap! Do not use this in production!"
+   sed -i 's/"dcap"/"none"/g' bash.manifest.template
+fi
+cat bash.manifest.template|grep sgx.remote_attestation
+make SGX=1 DEBUG=1 THIS_DIR=/ppml/trusted-big-data-ml  SPARK_USER=root G_SGX_SIZE=$SGX_MEM_SIZE G_LOG_LEVEL=$SGX_LOG_LEVEL


### PR DESCRIPTION
## Description

added `ENABLE_DCAP_ATTESTATION` option, so that  attestation could be disabled if necessary.

### 1. Why the change?

to build `noattest` images that applies to the case where `aesmd` and `pccs` are not installed successfully.