### PR TITLE
Pytorch Estimator Evaluation support customer input

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/maincallback.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/maincallback.py
@@ -93,6 +93,7 @@ class MainCallback(Callback):
         Any behavior inconsistent with the default training behavior should be overridden here.
         """
         self.on_iter_forward(runner)
+        runner.target = runner.batch[-1]
 
     def on_pred_forward(self, runner):
         """

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -576,7 +576,8 @@ class TorchRunner(BaseRunner):
 
         # User should not see batch from last iteration
         # Assume target is always the last one in a batch.
-        target = self.batch[-1]
+        if hasattr(self, "target"):
+            target = self.target
         del self.batch
 
         if hasattr(self, "loss"):


### PR DESCRIPTION
In pytorch estimator evaluation, , the input format is hardcoded  to (features, target). When user give different input,  target=self.batch[-1] would throw error. 

So change to support custom input. And the default data input support will move to MainCallback class.

See issue: https://github.com/analytics-zoo/orca-llm/issues/1#issuecomment-1496569468

