### PR TITLE
[Nano] Nightly-build UT issue: fix tfds version to less than 4.9

### DIFF
--- a/.github/actions/nano/setup-tensorflow-env/action.yml
+++ b/.github/actions/nano/setup-tensorflow-env/action.yml
@@ -85,6 +85,6 @@ runs:
         pip install ConfigSpace optuna
 
         # required by NoteBook and Tutorial test
-        pip install tensorflow-datasets jinja2 jupyter nbconvert nbmake
+        pip install tensorflow-datasets<4.9 jinja2 jupyter nbconvert nbmake
       env:
         OS: ${{ inputs.os }}

--- a/.github/actions/nano/setup-tensorflow-env/action.yml
+++ b/.github/actions/nano/setup-tensorflow-env/action.yml
@@ -85,6 +85,6 @@ runs:
         pip install ConfigSpace optuna
 
         # required by NoteBook and Tutorial test
-        pip install tensorflow-datasets<4.9 jinja2 jupyter nbconvert nbmake
+        pip install "tensorflow-datasets<4.9" jinja2 jupyter nbconvert nbmake
       env:
         OS: ${{ inputs.os }}


### PR DESCRIPTION
According to the issue posted here, we should restrict tensorflow-datasets version as less than 4.9
