### PR TITLE
[Nano] Support tuple input for openvino

### DIFF
--- a/python/nano/src/bigdl/nano/deps/onnxruntime/core/onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/core/onnxruntime_model.py
@@ -16,16 +16,8 @@
 from pathlib import Path
 import onnxruntime as ort
 import onnx
-from bigdl.nano.utils.common import invalidInputError
+from bigdl.nano.utils.common import invalidInputError, _flatten
 import numpy as np
-
-
-def _flatten(inputs, result):
-    for x in inputs:
-        if isinstance(x, np.ndarray) or np.isscalar(x):
-            result.append(x)
-        else:
-            _flatten(x, result)
 
 
 class ONNXRuntimeModel:

--- a/python/nano/src/bigdl/nano/utils/common/__init__.py
+++ b/python/nano/src/bigdl/nano/utils/common/__init__.py
@@ -52,3 +52,5 @@ from .env import _find_library
 from .env import EnvContext
 
 from .optimizer import *
+
+from .function import _flatten

--- a/python/nano/src/bigdl/nano/utils/common/function.py
+++ b/python/nano/src/bigdl/nano/utils/common/function.py
@@ -16,6 +16,7 @@
 
 import numpy as np
 
+
 def _flatten(inputs, result):
     for x in inputs:
         if isinstance(x, np.ndarray) or np.isscalar(x):

--- a/python/nano/src/bigdl/nano/utils/common/function.py
+++ b/python/nano/src/bigdl/nano/utils/common/function.py
@@ -1,0 +1,24 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import numpy as np
+
+def _flatten(inputs, result):
+    for x in inputs:
+        if isinstance(x, np.ndarray) or np.isscalar(x):
+            result.append(x)
+        else:
+            _flatten(x, result)

--- a/python/nano/test/onnx/pytorch/test_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_onnx.py
@@ -383,19 +383,19 @@ class TestOnnx(TestCase):
         x3 = 5
         target = model(x1, x2, x3)
 
-        ov_model = InferenceOptimizer.trace(model, accelerator='onnxruntime', input_sample=(x1, x2, x3))
-        with InferenceOptimizer.get_context(ov_model):
+        onnx_model = InferenceOptimizer.trace(model, accelerator='onnxruntime', input_sample=(x1, x2, x3))
+        with InferenceOptimizer.get_context(onnx_model):
             # TODO: handle int and float
-            output1 = ov_model(x1, x2, np.array(x3))
+            output1 = onnx_model(x1, x2, np.array(x3))
             np.testing.assert_almost_equal(target.numpy(), output1.numpy(), decimal=5)
         
         with tempfile.TemporaryDirectory() as tmp_dir_name:
-            InferenceOptimizer.save(ov_model, tmp_dir_name)
+            InferenceOptimizer.save(onnx_model, tmp_dir_name)
             load_model = InferenceOptimizer.load(tmp_dir_name)
         
         with InferenceOptimizer.get_context(load_model):
             output2 = load_model(x1, x2, np.array(x3))
-            np.testing.assert_almost_equal(target.numpy(), output2.numpy(), decimal=5)
+            np.testing.assert_almost_equal(output1.numpy(), output2.numpy(), decimal=5)
 
 
 if __name__ == '__main__':

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -29,6 +29,27 @@ import tempfile
 import pytest
 
 
+class TupleInputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 128)
+        self.layer_2 = nn.Linear(28 * 28, 128)
+        self.layer_3 = nn.Linear(256, 1)
+    
+    def forward(self, x1, x2, x3):
+        x1 = self.layer_1(x1)
+        x2_ = None
+        for x in x2:
+            if x2_ is None:
+                x2_ = self.layer_2(x)
+            else:
+                x2_ += self.layer_2(x)
+        x = torch.cat([x1, x2_], axis=1)
+
+        return self.layer_3(x) + x3
+
+
 class TestOpenVINO(TestCase):
     def test_trace_openvino(self):
         trainer = Trainer(max_epochs=1)
@@ -406,3 +427,23 @@ class TestOpenVINO(TestCase):
             forward_model_numpy = test_openvino_model(x)
             assert isinstance(forward_model_numpy, np.ndarray)
             np.testing.assert_almost_equal(forward_model_tensor, forward_model_numpy, decimal=5)
+
+    def test_openvino_tuple_input(self):
+        model = TupleInputModel()
+        x1 = torch.randn(100, 28 * 28)
+        x2 = [torch.randn(100, 28 * 28), torch.randn(100, 28 * 28), torch.randn(100, 28 * 28)]  # tuple
+        x3 = 5
+        target = model(x1, x2, x3)
+
+        ov_model = InferenceOptimizer.trace(model, accelerator='openvino', input_sample=(x1, x2, x3))
+        with InferenceOptimizer.get_context(ov_model):
+            output1 = ov_model(x1, x2, x3)
+            np.testing.assert_almost_equal(target.numpy(), output1.numpy(), decimal=5)
+        
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(ov_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+        
+        with InferenceOptimizer.get_context(load_model):
+            output2 = load_model(x1, x2, x3)
+            np.testing.assert_almost_equal(target.numpy(), output2.numpy(), decimal=5)

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -28,27 +28,6 @@ import pytest
 import numpy as np
 
 
-class TupleInputModel(nn.Module):
-    def __init__(self):
-        super().__init__()
-
-        self.layer_1 = nn.Linear(28 * 28, 128)
-        self.layer_2 = nn.Linear(28 * 28, 128)
-        self.layer_3 = nn.Linear(256, 1)
-    
-    def forward(self, x1, x2, x3):
-        x1 = self.layer_1(x1)
-        x2_ = None
-        for x in x2:
-            if x2_ is None:
-                x2_ = self.layer_2(x)
-            else:
-                x2_ += self.layer_2(x)
-        x = torch.cat([x1, x2_], axis=1)
-
-        return self.layer_3(x) + x3
-
-
 class TestOpenVINO(TestCase):
     def test_quantize_openvino(self):
         trainer = Trainer()
@@ -450,24 +429,3 @@ class TestOpenVINO(TestCase):
             forward_model_numpy = test_openvino_model(x)
             assert isinstance(forward_model_numpy, np.ndarray)
             np.testing.assert_almost_equal(forward_model_tensor, forward_model_numpy, decimal=5)
-
-    def test_openvino_quantize_tuple_input(self):
-        model = TupleInputModel()
-        x1 = torch.randn(100, 28 * 28)
-        x2 = [torch.randn(100, 28 * 28), torch.randn(100, 28 * 28), torch.randn(100, 28 * 28)]  # tuple
-        x3 = 5
-        target = model(x1, x2, x3)
-
-        ov_model = InferenceOptimizer.quantize(model, accelerator='openvino',
-                                               calib_data=(x1, x2, x3))
-        with InferenceOptimizer.get_context(ov_model):
-            output1 = ov_model(x1, x2, x3)
-            np.testing.assert_almost_equal(target.numpy(), output1.numpy(), decimal=5)
-        
-        with tempfile.TemporaryDirectory() as tmp_dir_name:
-            InferenceOptimizer.save(ov_model, tmp_dir_name)
-            load_model = InferenceOptimizer.load(tmp_dir_name)
-        
-        with InferenceOptimizer.get_context(load_model):
-            output2 = load_model(x1, x2, x3)
-            np.testing.assert_almost_equal(target.numpy(), output2.numpy(), decimal=5)

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -28,6 +28,27 @@ import pytest
 import numpy as np
 
 
+class TupleInputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 128)
+        self.layer_2 = nn.Linear(28 * 28, 128)
+        self.layer_3 = nn.Linear(256, 1)
+    
+    def forward(self, x1, x2, x3):
+        x1 = self.layer_1(x1)
+        x2_ = None
+        for x in x2:
+            if x2_ is None:
+                x2_ = self.layer_2(x)
+            else:
+                x2_ += self.layer_2(x)
+        x = torch.cat([x1, x2_], axis=1)
+
+        return self.layer_3(x) + x3
+
+
 class TestOpenVINO(TestCase):
     def test_quantize_openvino(self):
         trainer = Trainer()
@@ -429,3 +450,24 @@ class TestOpenVINO(TestCase):
             forward_model_numpy = test_openvino_model(x)
             assert isinstance(forward_model_numpy, np.ndarray)
             np.testing.assert_almost_equal(forward_model_tensor, forward_model_numpy, decimal=5)
+
+    def test_openvino_quantize_tuple_input(self):
+        model = TupleInputModel()
+        x1 = torch.randn(100, 28 * 28)
+        x2 = [torch.randn(100, 28 * 28), torch.randn(100, 28 * 28), torch.randn(100, 28 * 28)]  # tuple
+        x3 = 5
+        target = model(x1, x2, x3)
+
+        ov_model = InferenceOptimizer.quantize(model, accelerator='openvino',
+                                               calib_data=(x1, x2, x3))
+        with InferenceOptimizer.get_context(ov_model):
+            output1 = ov_model(x1, x2, x3)
+            np.testing.assert_almost_equal(target.numpy(), output1.numpy(), decimal=5)
+        
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(ov_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+        
+        with InferenceOptimizer.get_context(load_model):
+            output2 = load_model(x1, x2, x3)
+            np.testing.assert_almost_equal(target.numpy(), output2.numpy(), decimal=5)


### PR DESCRIPTION
## Description

Support tuple input for OpenVINO's trace, and add related ut for OpenVINO and ONNXRuntime.

### 1. Why the change?

To fix issue1 of https://github.com/analytics-zoo/nano/issues/327 (tuple input of openvino)

### 2. User API changes
Now user can pass tuple/list as input directly:
```python
model = TupleInputModel()
x1 = torch.randn(100, 28 * 28)
x2 = [torch.randn(100, 28 * 28), torch.randn(100, 28 * 28), torch.randn(100, 28 * 28)]  # tuple
x3 = 5
target = model(x1, x2, x3)

ov_model = InferenceOptimizer.trace(model, accelerator='openvino', input_sample=(x1, x2, x3))
with InferenceOptimizer.get_context(ov_model):
    output1 = ov_model(x1, x2, x3)
```

### 3. Summary of the change 

- support tuple input for OpenVINO's trace
- add tuple input related UT for OpenVINO's trace
- add tuple input related UT for ONNXRuntime's trace

### 4. How to test?
- [x] Unit test


