### PR TITLE
[Nano] OpenVINO support reshape & cache

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -130,13 +130,13 @@ class OpenVINOModel:
                   model shapes.")
         else:
             start_time = datetime.utcnow()
-            print('Reshaping model: {}'.format(', '.join("'{}': {}".format(k, str(v))
-                                                        for k, v in shapes.items())))
+            print('Reshaping model: {}'
+                  .format(', '.join("'{}': {}".format(k, str(v)) for k, v in shapes.items())))
             try:
                 self.ie_network.reshape(shapes)
                 duration_ms = f"{(datetime.utcnow() - start_time).total_seconds() * 1000:.2f}"
                 print(f"Reshape model took {duration_ms} ms")
-            except:
+            except Exception:
                 print(f"Failed to reshape this model, compile the original model instead.")
 
         self.create_infer_request()

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -21,6 +21,7 @@ from bigdl.nano.utils.common import invalidInputError
 from openvino.runtime import Model
 from openvino.runtime import AsyncInferQueue
 import numpy as np
+from datetime import datetime
 from .utils import save, OpenVINO_LESS_2022_3
 
 
@@ -38,6 +39,8 @@ class OpenVINOModel:
 
     def on_forward_start(self, inputs):
         self._model_exists_or_err()
+        if self._infer_request is None:
+            self.create_infer_request()
         return inputs
 
     def forward_step(self, *inputs):
@@ -90,13 +93,77 @@ class OpenVINOModel:
         if self.additional_config is not None and self._device == 'CPU':
             # TODO: check addition config based on device
             config.update(self.additional_config)
-        self._compiled_model = self._ie.compile_model(model=self.ie_network,
-                                                      device_name=self._device,
-                                                      config=config)
-        self._infer_request = self._compiled_model.create_infer_request()
         self.final_config = config
+
+        self._compiled_model = None
+        self._infer_request = None
+        
         input_names = [t.any_name for t in self._ie_network.inputs]
         self._forward_args = input_names
+
+    def create_infer_request(self):
+        start_time = datetime.utcnow()
+        self._compiled_model = self._ie.compile_model(model=self.ie_network,
+                                                      device_name=self._device,
+                                                      config=self.final_config)
+        self._infer_request = self._compiled_model.create_infer_request()
+        duration_ms = f"{(datetime.utcnow() - start_time).total_seconds() * 1000:.2f}"
+        print(f"Compile model and create infer request took {duration_ms} ms")
+
+
+    def reshape(self, shapes):
+        """
+        Reshape the model to fit the inputs.Be aware that not all models support reshaping, 
+        and models that do, may not support all input shapes. The model accuracy may also 
+        suffer if you reshape the model.
+        :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]', '[1,3,224,224]'.
+               This parameter affect model Parameter shape, can be dynamic. For dynamic dimesions 
+               use symbol `?`, `-1` or range `low.. up`.'
+        """
+        invalidInputError(isinstance(shapes, str), "Shapes only supports string inputs " 
+                          "like 'input1[1,3,224,224],input2[1,4]', '[1,3,224,224]' but got "
+                           f"{shapes.__class__.__name__}.")
+        
+        shapes, reshape = self._get_reshape_info(shapes)
+        if not reshape:
+            print(f"Skip the reshape process since the input shapes are same as the current model shapes.")
+            return
+        
+        start_time = datetime.utcnow()
+        print('Reshaping model: {}'.format(', '.join("'{}': {}".format(k, str(v)) for k, v in shapes.items())))
+        self.ie_network.reshape(shapes)
+        duration_ms = f"{(datetime.utcnow() - start_time).total_seconds() * 1000:.2f}"
+        print(f"Reshape model took {duration_ms} ms")
+
+        self.create_infer_request()
+
+    def _get_reshape_info(self, shapes):
+        invalidInputError(isinstance(shapes, str), "`_get_reshape_info` only supports string input.")
+        from openvino.tools.benchmark.utils.utils import parse_input_parameters, get_node_names
+        from openvino.runtime import PartialShape
+        
+        inputs = self.ie_network.inputs
+        input_names = [port.any_name for port in inputs]
+        inputs_info = [(i.any_name, i.node.friendly_name, i.partial_shape) for i in inputs]
+        shape_map = parse_input_parameters(shapes, input_names=input_names)
+        reshape = False
+        input_shapes = {}
+        for name, node_name, shape in inputs_info:
+            new_shape = None
+            if name in shape_map:
+                new_shape = PartialShape(shape_map[name])
+            elif node_name in shape_map:
+                new_shape = PartialShape(shape_map[node_name])
+
+            if new_shape is None:
+                input_shapes[name] = shape
+            else:
+                if new_shape != shape:
+                    reshape = True
+                input_shapes[name] = new_shape
+
+        return input_shapes, reshape
+
 
     def _save(self, path):
         """
@@ -198,7 +265,7 @@ class OpenVINOModel:
 
     def _model_exists_or_err(self):
         invalidInputError(self.ie_network is not None, "self.ie_network shouldn't be None.")
-
+            
     def async_predict(self,
                       input_data: Union[List[np.ndarray], List[List[np.ndarray]]],
                       num_requests: int = 0) -> List[np.ndarray]:

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -89,9 +89,14 @@ class OpenVINOModel:
                 config = {"INFERENCE_NUM_THREADS": str(self.thread_num)}
         else:
             config = {}
-        if self.additional_config is not None and self._device == 'CPU':
-            # TODO: check addition config based on device
-            config.update(self.additional_config)
+        if self.additional_config is not None:
+            if self._device == 'CPU':
+                # TODO: check addition config based on device
+                config.update(self.additional_config)
+            else:
+                ov_cache_dir = self.additional_config.get("CACHE_DIR", None)
+                if ov_cache_dir:
+                    config["CACHE_DIR"] = ov_cache_dir
         self.final_config = config
 
         if self.shapes is None:

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -98,7 +98,7 @@ class OpenVINOModel:
             self.create_infer_request()
         else:
             self.reshape(self.shapes)
-        
+
         input_names = [t.any_name for t in self._ie_network.inputs]
         self._forward_args = input_names
 
@@ -118,18 +118,18 @@ class OpenVINOModel:
         and models that do, may not support all input shapes. The model accuracy may also 
         suffer if you reshape the model.
         :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]', '[1,3,224,224]'.
-               This parameter affect model Parameter shape, can be dynamic. For dynamic dimesions 
+               This parameter affect model Parameter shape, can be dynamic. For dynamic dimesions
                use symbol `?`, `-1` or range `low.. up`.'
         """
-        invalidInputError(isinstance(shapes, str), "Shapes only supports string inputs " 
+        invalidInputError(isinstance(shapes, str), "Shapes only supports string inputs "
                           "like 'input1[1,3,224,224],input2[1,4]', '[1,3,224,224]' but got "
                            f"{shapes.__class__.__name__}.")
-        
+
         shapes, reshape = self._get_reshape_info(shapes)
         if not reshape:
             print(f"Skip the reshape process since the input shapes are same as the current model shapes.")
             return
-        
+
         start_time = datetime.utcnow()
         print('Reshaping model: {}'.format(', '.join("'{}': {}".format(k, str(v)) for k, v in shapes.items())))
         self.ie_network.reshape(shapes)
@@ -139,10 +139,11 @@ class OpenVINOModel:
         self.create_infer_request()
 
     def _get_reshape_info(self, shapes):
-        invalidInputError(isinstance(shapes, str), "`_get_reshape_info` only supports string input.")
-        from openvino.tools.benchmark.utils.utils import parse_input_parameters, get_node_names
+        invalidInputError(isinstance(shapes, str), 
+                          "`_get_reshape_info` only supports string input.")
+        from openvino.tools.benchmark.utils.utils import parse_input_parameters
         from openvino.runtime import PartialShape
-        
+
         inputs = self.ie_network.inputs
         input_names = [port.any_name for port in inputs]
         inputs_info = [(i.any_name, i.node.friendly_name, i.partial_shape) for i in inputs]

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -111,11 +111,10 @@ class OpenVINOModel:
         duration_ms = f"{(datetime.utcnow() - start_time).total_seconds() * 1000:.2f}"
         print(f"Compile model and create infer request took {duration_ms} ms")
 
-
     def reshape(self, shapes):
         """
-        Reshape the model to fit the inputs.Be aware that not all models support reshaping, 
-        and models that do, may not support all input shapes. The model accuracy may also 
+        Reshape the model to fit the inputs.Be aware that not all models support reshaping,
+        and models that do, may not support all input shapes. The model accuracy may also
         suffer if you reshape the model.
         :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]', '[1,3,224,224]'.
                This parameter affect model Parameter shape, can be dynamic. For dynamic dimesions
@@ -123,15 +122,17 @@ class OpenVINOModel:
         """
         invalidInputError(isinstance(shapes, str), "Shapes only supports string inputs "
                           "like 'input1[1,3,224,224],input2[1,4]', '[1,3,224,224]' but got "
-                           f"{shapes.__class__.__name__}.")
+                          f"{shapes.__class__.__name__}.")
 
         shapes, reshape = self._get_reshape_info(shapes)
         if not reshape:
-            print(f"Skip the reshape process since the input shapes are same as the current model shapes.")
+            print(f"Skip the reshape process since the input shapes are same as the current \
+                  model shapes.")
             return
 
         start_time = datetime.utcnow()
-        print('Reshaping model: {}'.format(', '.join("'{}': {}".format(k, str(v)) for k, v in shapes.items())))
+        print('Reshaping model: {}'.format(', '.join("'{}': {}".format(k, str(v)) 
+                                                     for k, v in shapes.items())))
         self.ie_network.reshape(shapes)
         duration_ms = f"{(datetime.utcnow() - start_time).total_seconds() * 1000:.2f}"
         print(f"Reshape model took {duration_ms} ms")
@@ -139,7 +140,7 @@ class OpenVINOModel:
         self.create_infer_request()
 
     def _get_reshape_info(self, shapes):
-        invalidInputError(isinstance(shapes, str), 
+        invalidInputError(isinstance(shapes, str),
                           "`_get_reshape_info` only supports string input.")
         from openvino.tools.benchmark.utils.utils import parse_input_parameters
         from openvino.runtime import PartialShape
@@ -165,7 +166,6 @@ class OpenVINOModel:
                 input_shapes[name] = new_shape
 
         return input_shapes, reshape
-
 
     def _save(self, path):
         """
@@ -267,7 +267,7 @@ class OpenVINOModel:
 
     def _model_exists_or_err(self):
         invalidInputError(self.ie_network is not None, "self.ie_network shouldn't be None.")
-            
+
     def async_predict(self,
                       input_data: Union[List[np.ndarray], List[List[np.ndarray]]],
                       num_requests: int = 0) -> List[np.ndarray]:

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -128,14 +128,16 @@ class OpenVINOModel:
         if not reshape:
             print(f"Skip the reshape process since the input shapes are same as the current \
                   model shapes.")
-            return
-
-        start_time = datetime.utcnow()
-        print('Reshaping model: {}'.format(', '.join("'{}': {}".format(k, str(v))
-                                                     for k, v in shapes.items())))
-        self.ie_network.reshape(shapes)
-        duration_ms = f"{(datetime.utcnow() - start_time).total_seconds() * 1000:.2f}"
-        print(f"Reshape model took {duration_ms} ms")
+        else:
+            start_time = datetime.utcnow()
+            print('Reshaping model: {}'.format(', '.join("'{}': {}".format(k, str(v))
+                                                        for k, v in shapes.items())))
+            try:
+                self.ie_network.reshape(shapes)
+                duration_ms = f"{(datetime.utcnow() - start_time).total_seconds() * 1000:.2f}"
+                print(f"Reshape model took {duration_ms} ms")
+            except:
+                print(f"Failed to reshape this model, compile the original model instead.")
 
         self.create_infer_request()
 

--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -131,7 +131,7 @@ class OpenVINOModel:
             return
 
         start_time = datetime.utcnow()
-        print('Reshaping model: {}'.format(', '.join("'{}': {}".format(k, str(v)) 
+        print('Reshaping model: {}'.format(', '.join("'{}': {}".format(k, str(v))
                                                      for k, v in shapes.items())))
         self.ie_network.reshape(shapes)
         duration_ms = f"{(datetime.utcnow() - start_time).total_seconds() * 1000:.2f}"

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -75,9 +75,9 @@ def load_openvino_model(path, framework='pytorch', device=None, cache_dir=None, 
     :param framework: Only support pytorch and tensorflow now
     :param device: A string represents the device of the inference.
     :param cache_dir: A directory for OpenVINO to cache the model. Default to None.
-    :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]', 
-               '[1,3,224,224]'. This parameter affect model Parameter shape, can be 
-               dynamic. For dynamic dimesions use symbol `?`, `-1` or range `low.. up`.'. 
+    :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]',
+               '[1,3,224,224]'. This parameter affect model Parameter shape, can be
+               dynamic. For dynamic dimesions use symbol `?`, `-1` or range `low.. up`.'.
                Only valid for openvino model, otherwise will be ignored.
     :return: PytorchOpenVINOModel model for OpenVINO inference.
     """

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -67,21 +67,26 @@ def PytorchOpenVINOModel(model, input_sample=None, precision='fp32',
                                 **kwargs)
 
 
-def load_openvino_model(path, framework='pytorch', device=None):
+def load_openvino_model(path, framework='pytorch', device=None, cache_dir=None):
     """
     Load an OpenVINO model for inference from directory.
 
     :param path: Path to model to be loaded.
     :param framework: Only support pytorch and tensorflow now
     :param device: A string represents the device of the inference.
+    :param cache_dir: A directory for OpenVINO to cache the model. Default to None.
     :return: PytorchOpenVINOModel model for OpenVINO inference.
     """
+    if cache_dir is not None:
+        from pathlib import Path
+        Path(cache_dir).mkdir(exist_ok=True)
+
     if framework == 'pytorch':
         from .pytorch.model import PytorchOpenVINOModel
-        return PytorchOpenVINOModel._load(path, device=device)
+        return PytorchOpenVINOModel._load(path, device=device, cache_dir=cache_dir)
     elif framework == 'tensorflow':
         from .tf.model import KerasOpenVINOModel
-        return KerasOpenVINOModel._load(path, device=device)
+        return KerasOpenVINOModel._load(path, device=device, cache_dir=cache_dir)
     else:
         invalidInputError(False,
                           "The value {} for framework is not supported."

--- a/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/openvino_api.py
@@ -67,7 +67,7 @@ def PytorchOpenVINOModel(model, input_sample=None, precision='fp32',
                                 **kwargs)
 
 
-def load_openvino_model(path, framework='pytorch', device=None, cache_dir=None):
+def load_openvino_model(path, framework='pytorch', device=None, cache_dir=None, shapes=None):
     """
     Load an OpenVINO model for inference from directory.
 
@@ -75,6 +75,10 @@ def load_openvino_model(path, framework='pytorch', device=None, cache_dir=None):
     :param framework: Only support pytorch and tensorflow now
     :param device: A string represents the device of the inference.
     :param cache_dir: A directory for OpenVINO to cache the model. Default to None.
+    :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]', 
+               '[1,3,224,224]'. This parameter affect model Parameter shape, can be 
+               dynamic. For dynamic dimesions use symbol `?`, `-1` or range `low.. up`.'. 
+               Only valid for openvino model, otherwise will be ignored.
     :return: PytorchOpenVINOModel model for OpenVINO inference.
     """
     if cache_dir is not None:
@@ -83,10 +87,10 @@ def load_openvino_model(path, framework='pytorch', device=None, cache_dir=None):
 
     if framework == 'pytorch':
         from .pytorch.model import PytorchOpenVINOModel
-        return PytorchOpenVINOModel._load(path, device=device, cache_dir=cache_dir)
+        return PytorchOpenVINOModel._load(path, device=device, cache_dir=cache_dir, shapes=shapes)
     elif framework == 'tensorflow':
         from .tf.model import KerasOpenVINOModel
-        return KerasOpenVINOModel._load(path, device=device, cache_dir=cache_dir)
+        return KerasOpenVINOModel._load(path, device=device, cache_dir=cache_dir, shapes=shapes)
     else:
         invalidInputError(False,
                           "The value {} for framework is not supported."

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -32,7 +32,7 @@ from bigdl.nano.utils.pytorch import patch_attrs_from_model_to_object
 class PytorchOpenVINOModel(AcceleratedLightningModule):
     def __init__(self, model, input_sample=None, precision='fp32',
                  thread_num=None, device='CPU', dynamic_axes=True,
-                 logging=True, config=None, output_tensors=True, 
+                 logging=True, config=None, output_tensors=True,
                  shapes=None, **kwargs):
         """
         Create a OpenVINO model from pytorch.
@@ -66,9 +66,9 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         :param config: The config to be inputted in core.compile_model.
         :param output_tensors: boolean, default to True and output of the model will be Tensors. If
                                output_tensors=False, output of the OpenVINO model will be ndarray.
-        :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]', 
-                       '[1,3,224,224]'. This parameter affect model Parameter shape, can be 
-                       dynamic. For dynamic dimesions use symbol `?`, `-1` or range `low.. up`.'. 
+        :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]',
+                       '[1,3,224,224]'. This parameter affect model Parameter shape, can be
+                       dynamic. For dynamic dimesions use symbol `?`, `-1` or range `low.. up`.'.
                        Only valid for openvino model, otherwise will be ignored.
         :param **kwargs: will be passed to torch.onnx.export function or model optimizer function.
         """
@@ -95,7 +95,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                                           device=device,
                                           precision=precision,
                                           thread_num=thread_num,
-                                          config=config, 
+                                          config=config,
                                           shapes=shapes)
             super().__init__(None)
         self._nano_context_manager = generate_context_manager(accelerator="openvino",
@@ -121,7 +121,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         elif len(outputs) == 1:
             outputs = outputs[0]
         return outputs
-    
+
     def reshape(self, shapes):
         return self.ov_model.reshape(shapes=shapes)
 
@@ -168,7 +168,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         return PytorchOpenVINOModel(xml_path,
                                     config=config,
                                     thread_num=thread_num,
-                                    device=device, 
+                                    device=device,
                                     shapes=shapes)
 
     def pot(self,

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -115,6 +115,9 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         elif len(outputs) == 1:
             outputs = outputs[0]
         return outputs
+    
+    def reshape(self, shapes):
+        return self.ov_model.reshape(shapes=shapes)
 
     @property
     def status(self):
@@ -130,7 +133,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         return self.ov_model.forward_args
 
     @staticmethod
-    def _load(path, device=None):
+    def _load(path, device=None, cache_dir=None):
         """
         Load an OpenVINO model for inference from directory.
 
@@ -152,6 +155,8 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
             thread_num = int(config["CPU_THREADS_NUM"])
         elif "INFERENCE_NUM_THREADS" in config:
             thread_num = int(config["INFERENCE_NUM_THREADS"])
+        if cache_dir is not None:
+            config["CACHE_DIR"] = cache_dir
         if device is None:
             device = status.get('device', 'CPU')
         return PytorchOpenVINOModel(xml_path,

--- a/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/pytorch/model.py
@@ -32,7 +32,8 @@ from bigdl.nano.utils.pytorch import patch_attrs_from_model_to_object
 class PytorchOpenVINOModel(AcceleratedLightningModule):
     def __init__(self, model, input_sample=None, precision='fp32',
                  thread_num=None, device='CPU', dynamic_axes=True,
-                 logging=True, config=None, output_tensors=True, **kwargs):
+                 logging=True, config=None, output_tensors=True, 
+                 shapes=None, **kwargs):
         """
         Create a OpenVINO model from pytorch.
 
@@ -65,6 +66,10 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         :param config: The config to be inputted in core.compile_model.
         :param output_tensors: boolean, default to True and output of the model will be Tensors. If
                                output_tensors=False, output of the OpenVINO model will be ndarray.
+        :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]', 
+                       '[1,3,224,224]'. This parameter affect model Parameter shape, can be 
+                       dynamic. For dynamic dimesions use symbol `?`, `-1` or range `low.. up`.'. 
+                       Only valid for openvino model, otherwise will be ignored.
         :param **kwargs: will be passed to torch.onnx.export function or model optimizer function.
         """
         ov_model_path = model
@@ -90,7 +95,8 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
                                           device=device,
                                           precision=precision,
                                           thread_num=thread_num,
-                                          config=config)
+                                          config=config, 
+                                          shapes=shapes)
             super().__init__(None)
         self._nano_context_manager = generate_context_manager(accelerator="openvino",
                                                               precision="fp32",
@@ -133,7 +139,7 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         return self.ov_model.forward_args
 
     @staticmethod
-    def _load(path, device=None, cache_dir=None):
+    def _load(path, device=None, cache_dir=None, shapes=None):
         """
         Load an OpenVINO model for inference from directory.
 
@@ -162,7 +168,8 @@ class PytorchOpenVINOModel(AcceleratedLightningModule):
         return PytorchOpenVINOModel(xml_path,
                                     config=config,
                                     thread_num=thread_num,
-                                    device=device)
+                                    device=device, 
+                                    shapes=shapes)
 
     def pot(self,
             dataloader,

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -141,7 +141,7 @@ class KerasOpenVINOModel(KerasOptimizedModel):
         return q_model
 
     @staticmethod
-    def _load(path, device=None):
+    def _load(path, device=None, cache_dir=None):
         """
         Load an OpenVINO model for inference from directory.
 
@@ -163,6 +163,8 @@ class KerasOpenVINOModel(KerasOptimizedModel):
             thread_num = int(config["CPU_THREADS_NUM"])
         elif "INFERENCE_NUM_THREADS" in config:
             thread_num = int(config["INFERENCE_NUM_THREADS"])
+        if cache_dir is not None:
+            config["CACHE_DIR"] = cache_dir
         if device is None:
             device = status.get('device', 'CPU')
         model = KerasOpenVINOModel(xml_path,

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -56,9 +56,9 @@ class KerasOpenVINOModel(KerasOptimizedModel):
                        inference. default: None.
         :param logging: whether to log detailed information of model conversion.
                         default: True.
-        :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]', 
-                       '[1,3,224,224]'. This parameter affect model Parameter shape, can be 
-                       dynamic. For dynamic dimesions use symbol `?`, `-1` or range `low.. up`.'. 
+        :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]',
+                       '[1,3,224,224]'. This parameter affect model Parameter shape, can be
+                       dynamic. For dynamic dimesions use symbol `?`, `-1` or range `low.. up`.'.
                        Only valid for openvino model, otherwise will be ignored.
         :param **kwargs: will be passed to model optimizer function.
         """

--- a/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/tf/model.py
@@ -38,7 +38,7 @@ from .metric import KerasOpenVINOMetric
 class KerasOpenVINOModel(KerasOptimizedModel):
     def __init__(self, model, input_spec=None, precision='fp32',
                  thread_num=None, device='CPU', config=None,
-                 logging=True, **kwargs):
+                 logging=True, shapes=None, **kwargs):
         """
         Create a OpenVINO model from Keras.
 
@@ -56,6 +56,10 @@ class KerasOpenVINOModel(KerasOptimizedModel):
                        inference. default: None.
         :param logging: whether to log detailed information of model conversion.
                         default: True.
+        :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]', 
+                       '[1,3,224,224]'. This parameter affect model Parameter shape, can be 
+                       dynamic. For dynamic dimesions use symbol `?`, `-1` or range `low.. up`.'. 
+                       Only valid for openvino model, otherwise will be ignored.
         :param **kwargs: will be passed to model optimizer function.
         """
         super().__init__()
@@ -80,7 +84,8 @@ class KerasOpenVINOModel(KerasOptimizedModel):
                                           device=device,
                                           precision=precision,
                                           thread_num=thread_num,
-                                          config=config)
+                                          config=config,
+                                          shapes=shapes)
 
     def preprocess(self, args: Sequence[Any], kwargs: Dict[str, Any]):
         self.ov_model._model_exists_or_err()
@@ -141,7 +146,7 @@ class KerasOpenVINOModel(KerasOptimizedModel):
         return q_model
 
     @staticmethod
-    def _load(path, device=None, cache_dir=None):
+    def _load(path, device=None, cache_dir=None, shapes=None):
         """
         Load an OpenVINO model for inference from directory.
 
@@ -170,7 +175,8 @@ class KerasOpenVINOModel(KerasOptimizedModel):
         model = KerasOpenVINOModel(xml_path,
                                    config=status['config'],
                                    thread_num=thread_num,
-                                   device=device)
+                                   device=device,
+                                   shapes=shapes)
         with open(Path(path) / status['attr_path'], "rb") as f:
             attrs = pickle.load(f)
         for attr_name, attr_value in attrs.items():

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -1259,7 +1259,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
 
     @staticmethod
     def load(path, model: Optional[nn.Module] = None, input_sample=None,
-             inplace=False, device=None):
+             inplace=False, device=None, cache_dir=None):
         """
         Load a model from local.
 
@@ -1281,11 +1281,13 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param inplace: whether to perform inplace optimization. Default: ``False``.
         :param device: A string represents the device of the inference. Default to None.
                Only valid for openvino model, otherwise will be ignored.
+        :param cache_dir: A directory for OpenVINO to cache the model. Default to None. 
+               Only valid for openvino model, otherwise will be ignored.
         :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                  precision(FP32/FP16/BF16/INT8).
         """
         return load_model(path, model, input_sample=input_sample,
-                          inplace=inplace, device=device)
+                          inplace=inplace, device=device, cache_dir=cache_dir)
 
     @staticmethod
     def to_multi_instance(model: nn.Module, num_processes: int = 4,

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -1259,7 +1259,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
 
     @staticmethod
     def load(path, model: Optional[nn.Module] = None, input_sample=None,
-             inplace=False, device=None, cache_dir=None):
+             inplace=False, device=None, cache_dir=None, shapes=None):
         """
         Load a model from local.
 
@@ -1283,11 +1283,17 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                Only valid for openvino model, otherwise will be ignored.
         :param cache_dir: A directory for OpenVINO to cache the model. Default to None. 
                Only valid for openvino model, otherwise will be ignored.
+        :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]', 
+               '[1,3,224,224]'. This parameter affect model Parameter shape, can be 
+               dynamic. For dynamic dimesions use symbol `?`, `-1` or range `low.. up`.'. 
+               Default to None, which means you don't want to reshape the model inputs. 
+               Only valid for openvino model, otherwise will be ignored. 
         :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                  precision(FP32/FP16/BF16/INT8).
         """
         return load_model(path, model, input_sample=input_sample,
-                          inplace=inplace, device=device, cache_dir=cache_dir)
+                          inplace=inplace, device=device, cache_dir=cache_dir, 
+                          shapes=shapes)
 
     @staticmethod
     def to_multi_instance(model: nn.Module, num_processes: int = 4,

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -1281,18 +1281,18 @@ class InferenceOptimizer(BaseInferenceOptimizer):
         :param inplace: whether to perform inplace optimization. Default: ``False``.
         :param device: A string represents the device of the inference. Default to None.
                Only valid for openvino model, otherwise will be ignored.
-        :param cache_dir: A directory for OpenVINO to cache the model. Default to None. 
+        :param cache_dir: A directory for OpenVINO to cache the model. Default to None.
                Only valid for openvino model, otherwise will be ignored.
-        :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]', 
-               '[1,3,224,224]'. This parameter affect model Parameter shape, can be 
-               dynamic. For dynamic dimesions use symbol `?`, `-1` or range `low.. up`.'. 
-               Default to None, which means you don't want to reshape the model inputs. 
-               Only valid for openvino model, otherwise will be ignored. 
+        :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]',
+               '[1,3,224,224]'. This parameter affect model Parameter shape, can be
+               dynamic. For dynamic dimesions use symbol `?`, `-1` or range `low.. up`.'.
+               Default to None, which means you don't want to reshape the model inputs.
+               Only valid for openvino model, otherwise will be ignored.
         :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                  precision(FP32/FP16/BF16/INT8).
         """
         return load_model(path, model, input_sample=input_sample,
-                          inplace=inplace, device=device, cache_dir=cache_dir, 
+                          inplace=inplace, device=device, cache_dir=cache_dir,
                           shapes=shapes)
 
     @staticmethod

--- a/python/nano/src/bigdl/nano/utils/pytorch/load.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/load.py
@@ -45,11 +45,11 @@ def load_model(path, model: nn.Module = None, input_sample=None,
     :param inplace: whether to perform inplace optimization. Default: ``False``.
     :param device: A string represents the device of the inference. Default to None.
                    Only valid for openvino model, otherwise will be ignored.
-    :param cache_dir: A directory for OpenVINO to cache the model. Default to None. 
+    :param cache_dir: A directory for OpenVINO to cache the model. Default to None.
                       Only valid for openvino model, otherwise will be ignored.
-    :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]', 
-               '[1,3,224,224]'. This parameter affect model Parameter shape, can be 
-               dynamic. For dynamic dimesions use symbol `?`, `-1` or range `low.. up`.'. 
+    :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]',
+               '[1,3,224,224]'. This parameter affect model Parameter shape, can be
+               dynamic. For dynamic dimesions use symbol `?`, `-1` or range `low.. up`.'.
                Only valid for openvino model, otherwise will be ignored.
     :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                 precision(FP32/FP16/BF16/INT8).

--- a/python/nano/src/bigdl/nano/utils/pytorch/load.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/load.py
@@ -28,7 +28,7 @@ from bigdl.nano.utils.pytorch import patch_attrs_from_model_to_object, \
 
 
 def load_model(path, model: nn.Module = None, input_sample=None,
-               inplace=False, device=None, cache_dir=None):
+               inplace=False, device=None, cache_dir=None, shapes=None):
     """
     Load a model from local.
 
@@ -47,6 +47,10 @@ def load_model(path, model: nn.Module = None, input_sample=None,
                    Only valid for openvino model, otherwise will be ignored.
     :param cache_dir: A directory for OpenVINO to cache the model. Default to None. 
                       Only valid for openvino model, otherwise will be ignored.
+    :param shapes: input shape. For example, 'input1[1,3,224,224],input2[1,4]', 
+               '[1,3,224,224]'. This parameter affect model Parameter shape, can be 
+               dynamic. For dynamic dimesions use symbol `?`, `-1` or range `low.. up`.'. 
+               Only valid for openvino model, otherwise will be ignored.
     :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                 precision(FP32/FP16/BF16/INT8).
     """
@@ -70,7 +74,7 @@ def load_model(path, model: nn.Module = None, input_sample=None,
     model_type = metadata.get('ModelType', None)
     result = None
     if model_type == 'PytorchOpenVINOModel':
-        result = load_openvino_model(path, device=device, cache_dir=cache_dir)
+        result = load_openvino_model(path, device=device, cache_dir=cache_dir, shapes=shapes)
     if model_type == 'PytorchONNXRuntimeModel':
         result = load_onnxruntime_model(path)
     if model_type == 'PytorchQuantizedModel':

--- a/python/nano/src/bigdl/nano/utils/pytorch/load.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/load.py
@@ -28,7 +28,7 @@ from bigdl.nano.utils.pytorch import patch_attrs_from_model_to_object, \
 
 
 def load_model(path, model: nn.Module = None, input_sample=None,
-               inplace=False, device=None):
+               inplace=False, device=None, cache_dir=None):
     """
     Load a model from local.
 
@@ -45,6 +45,8 @@ def load_model(path, model: nn.Module = None, input_sample=None,
     :param inplace: whether to perform inplace optimization. Default: ``False``.
     :param device: A string represents the device of the inference. Default to None.
                    Only valid for openvino model, otherwise will be ignored.
+    :param cache_dir: A directory for OpenVINO to cache the model. Default to None. 
+                      Only valid for openvino model, otherwise will be ignored.
     :return: Model with different acceleration(None/OpenVINO/ONNX Runtime/JIT) or
                 precision(FP32/FP16/BF16/INT8).
     """
@@ -68,7 +70,7 @@ def load_model(path, model: nn.Module = None, input_sample=None,
     model_type = metadata.get('ModelType', None)
     result = None
     if model_type == 'PytorchOpenVINOModel':
-        result = load_openvino_model(path, device=device)
+        result = load_openvino_model(path, device=device, cache_dir=cache_dir)
     if model_type == 'PytorchONNXRuntimeModel':
         result = load_onnxruntime_model(path)
     if model_type == 'PytorchQuantizedModel':


### PR DESCRIPTION
## Description

1. Support model reshaping in nano OpenVINO models.
2. Support model caching in nano OpenVINO models.

TODOs:

- [x] Reshape error handling
- [x] UT

### 1. Why the change?

Stable diffusion requirements.

### 2. User API changes

1. Users can pass cache_dir & shapes when loading an OpenVINO model.
```python
ov = InferenceOptimizer.load(path=path, cache_dir=cache_path, shapes="sample[2,4,64,64],encoder_hidden_states[2,77,768]")
```
2. Users can runtime reshape the model inputs
```python
ov.reshape("sample[2,4,32,32],encoder_hidden_states[2,512,768]")
```


### 3. Summary of the change 

1. Support model reshaping in nano OpenVINO models.
2. Support model caching in nano OpenVINO models.

### 4. How to test?
- [x] Unit test

