### PR TITLE
upgrade json-smart to 2.4.10

### DIFF
--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -278,7 +278,8 @@
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
-            <artifactId>azure-identity</artifactId>
+	    <artifactId>azure-identity</artifactId>
+	    <version>1.81</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>

--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.10</version>
+                <version>1.2.11</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.11</version>
+                <version>1.2.4</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -28,7 +28,7 @@
             <dependency>
                 <groupId>com.azure</groupId>
                 <artifactId>azure-sdk-bom</artifactId>
-                <version>1.2.4</version>
+                <version>1.2.10</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -279,7 +279,6 @@
         <dependency>
             <groupId>com.azure</groupId>
 	    <artifactId>azure-identity</artifactId>
-	    <version>1.81</version>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>

--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -279,6 +279,12 @@
         <dependency>
             <groupId>com.azure</groupId>
 	    <artifactId>azure-identity</artifactId>
+	     <exclusions>
+                <exclusion>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>json-smart</artifactId>
+	        </exclusion>
+	     </exclusions>
         </dependency>
         <dependency>
             <groupId>com.azure</groupId>
@@ -309,6 +315,11 @@
                     <artifactId>reactor-core</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.4.10</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
## Description

upgrade azure-identity to 1.81 for security scan by upgrading azure-sdk-bom to 1.2.11

### 1. Why the change?

Low-version azure-identity cannot pass security scan, and thus switch to the 1.81 one in azure-sdk-bom 1.2.11

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

