### PR TITLE
[Nano] Support dict/tuple output by saving output signature

### DIFF
--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -78,7 +78,6 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
         self.output_metadata = output_metadata
         with TemporaryDirectory() as tmpdir:
             if isinstance(model, torch.nn.Module):
-                print("self output metadata: ", self.output_metadata)
                 onnx_path = os.path.join(tmpdir, "tmp.onnx")
                 # Typically, when model is fp32, we use this path
                 export_to_onnx(model, input_sample=input_sample, onnx_path=onnx_path,
@@ -99,7 +98,6 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
                 else:
                     output = model(input_sample)
                 self.output_metadata = MetaData.construct_matadata(output)
-                print("self output metadata: ", self.output_metadata)
             else:
                 onnx_path = model
             AcceleratedLightningModule.__init__(self, None)

--- a/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
+++ b/python/nano/src/bigdl/nano/deps/onnxruntime/pytorch/pytorch_onnxruntime_model.py
@@ -23,7 +23,7 @@ from bigdl.nano.pytorch.model import AcceleratedLightningModule
 from bigdl.nano.utils.pytorch import export_to_onnx, get_input_example, \
     get_forward_args
 from bigdl.nano.utils.common import invalidInputError
-from bigdl.nano.pytorch.context_manager import generate_context_manager
+from bigdl.nano.pytorch.context_manager import generate_context_manager, BaseContextManager
 from bigdl.nano.utils.pytorch import patch_attrs_from_model_to_object, \
     MetaData
 import pickle
@@ -91,13 +91,14 @@ class PytorchONNXRuntimeModel(ONNXRuntimeModel, AcceleratedLightningModule):
                         pass
 
                 # test run to get output metadata
-                forward_args = get_forward_args(model)
-                input_sample = get_input_example(model, input_sample, forward_args)
-                if isinstance(input_sample, (tuple, list)):
-                    output = model(*input_sample)
-                else:
-                    output = model(input_sample)
-                self.output_metadata = MetaData.construct_matadata(output)
+                with BaseContextManager():
+                    forward_args = get_forward_args(model)
+                    input_sample = get_input_example(model, input_sample, forward_args)
+                    if isinstance(input_sample, (tuple, list)):
+                        output = model(*input_sample)
+                    else:
+                        output = model(input_sample)
+                    self.output_metadata = MetaData.construct_matadata(output)
             else:
                 onnx_path = model
             AcceleratedLightningModule.__init__(self, None)

--- a/python/nano/src/bigdl/nano/utils/pytorch/__init__.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/__init__.py
@@ -56,3 +56,5 @@ from .load import load_model
 from .xpu import apply_data_to_xpu, apply_data_to_half
 
 from .jit_method import jit_convert
+
+from .metadata import MetaData

--- a/python/nano/src/bigdl/nano/utils/pytorch/metadata.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/metadata.py
@@ -1,0 +1,121 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+from ..common import invalidInputError
+
+
+class BaiscMetaDataInfo(object):
+    """Meta info class for basic type like int, float, str
+    """
+    def __init__(self, input_element):
+        self.type = type(input_element)
+        self.reconstruct = False
+
+
+class TensorMetaDataInfo(object):
+    """Meta info class for torch.Tensor
+    """
+    def __init__(self, input_element):
+        self.type = type(input_element)
+        self.shape = input_element.shape
+        self.reconstruct = False
+
+
+class DictMetaDataInfo(object):
+    """Meta info class for dict
+    """
+    def __init__(self, input_element):
+        self.type = type(input_element)
+        self.length = len(input_element)
+        self.keys = list(input_element.keys())
+        self.infos = []
+        for k in self.keys:
+            v = input_element[k]
+            info = get_meta_info_from_input(v)
+            self.infos.append(info)
+        self.reconstruct = True
+
+
+class ListMetaDataInfo(object):
+    """Meta info class for list
+    """
+    def __init__(self, input_element):
+        self.type = type(input_element)
+        self.length = len(input_element)
+        self.reconstruct = False
+        self.infos = []
+        for ele in input_element:
+            info = get_meta_info_from_input(ele)
+            self.infos.append(info)
+            self.reconstruct |= info.reconstruct
+
+
+def get_meta_info_from_input(input_element):
+    if isinstance(input_element, torch.Tensor):
+        return TensorMetaDataInfo(input_element)
+    elif isinstance(input_element, (tuple, list)):
+        return ListMetaDataInfo(input_element)
+    elif isinstance(input_element, dict):
+        return DictMetaDataInfo(input_element)
+    else:
+        return BaiscMetaDataInfo(input_element)
+
+
+class MetaData(object):
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def construct_matadata(output):
+        return get_meta_info_from_input(output)
+
+    @staticmethod
+    def reconstruct_output(output, metadata):
+        # TODO: support more cases
+        if not metadata.reconstruct:
+            return output
+        elif isinstance(metadata, DictMetaDataInfo):
+            # single dict
+            if not isinstance(output, (tuple, list)):
+                output = [output]
+            new_output = {}
+            elem_idx = 0
+            for idx, k in enumerate(metadata.keys):
+                meta = metadata.infos[idx]
+                if meta not in (DictMetaDataInfo, ListMetaDataInfo):
+                    new_output[k] = output[elem_idx]
+                    elem_idx += 1
+                else:
+                    # TODO: dict contain list
+                    pass
+            return new_output
+        else:
+            # ListMetaDataInfo
+            new_output = []
+            ind_out = 0
+            ind_meta = 0
+            for index in range(metadata.length):
+                meta = metadata.infos[index]
+                if not meta.reconstruct:
+                    new_output.append(output[ind_out])
+                    ind_out += 1
+                else:
+                    # convert output based on current matadata, recursive call
+                    new_output.append(MetaData.reconstruct_output(
+                        output[ind_out:], meta))
+                    ind_out += meta.length
+            return new_output

--- a/python/nano/test/onnx/pytorch/test_inc_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_inc_onnx.py
@@ -453,6 +453,19 @@ class TestOnnx(TestCase):
             forward_res_numpy = test_onnx_model(x)
             assert isinstance(forward_res_numpy, np.ndarray)
             np.testing.assert_almost_equal(forward_res_tensor, forward_res_numpy, decimal=5)
+        
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(onnx_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(test_onnx_model, tmp_dir_name)
+            test_load_model = InferenceOptimizer.load(tmp_dir_name)
+
+        for x, y in train_loader:
+            forward_res_tensor = load_model(x).numpy()
+            forward_res_numpy = test_load_model(x)
+            assert isinstance(forward_res_numpy, np.ndarray)
+            np.testing.assert_almost_equal(forward_res_tensor, forward_res_numpy, decimal=5)
 
     def test_onnx_quantize_kwargs(self):
         model = MultiInputModel()
@@ -472,7 +485,7 @@ class TestOnnx(TestCase):
 
         dataset = CustomDataset()
         loader = DataLoader(dataset, batch_size=1, collate_fn=None)
-        
+
         # TODO: below code works after we solve wrong dataloader transform issue
         # onnx_model = InferenceOptimizer.quantize(model,
         #                                          accelerator='onnxruntime',

--- a/python/nano/test/onnx/pytorch/test_onnx.py
+++ b/python/nano/test/onnx/pytorch/test_onnx.py
@@ -134,6 +134,155 @@ class DictTensorOutputModel1(nn.Module):
         return output, x3
 
 
+class MultiDictOutputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+    
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        x3 = self.layer_3(x)
+        output1 = {"x1": x1, "x2": x2, "x3": x3}
+        output2 = {"x3": x3, "x1": x1, "x2": x2}
+        return output1, output2
+
+
+class MultiDictTensorOutputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+    
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        x3 = self.layer_3(x)
+        output1 = {"x1": x1, "x2": x2, "x3": x3}
+        output2 = {"x3": x3, "x1": x1, "x2": x2}
+        return x3, output1, output2
+
+
+
+class ListOutputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        output = self.layer_3(x)
+        return [x1, x2, output]
+
+
+class TupleTensorOutputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+    
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        output = self.layer_3(x)
+        return output, (x1, x2, x)
+
+
+class MultiTupleOutputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        output = self.layer_3(x)
+        return [x1,x2], (output, x)
+
+
+class MultiTupleTensorOutputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+    
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        output = self.layer_3(x)
+        return output, [x1,x2], (output, x)
+
+
+
+class TupleDictOutputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+    
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        output = self.layer_3(x)
+        return [x1,x2], {"x":x, "output":output}
+
+
+class TupleDictOutputModel2(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+    
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        output = self.layer_3(x)
+        return [x1,x2,{"x":x, "output":output}]
+
+class TupleDictOutputModel3(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+    
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        output = self.layer_3(x)
+        return {"intermediate": [x1,x2], "x":x, "output":output}
+
+
 class TestOnnx(TestCase):
     def test_trace_onnx(self):
         model = ResNet18(10, pretrained=False, include_top=False, freeze=True)
@@ -485,11 +634,11 @@ class TestOnnx(TestCase):
             np.testing.assert_almost_equal(output4.numpy(), output4.numpy(), decimal=5)
 
     def test_onnxruntime_dict_output(self):
+        x1 = torch.randn(10, 28 * 28)
+        x2 = torch.randn(10, 28 * 28)
         # test1: output is a single dict
         for Model in [DictOutputModel, DictOutputModel2]:
             model = Model()
-            x1 = torch.randn(10, 28 * 28)
-            x2 = torch.randn(10, 28 * 28)
             output = model(x1, x2)
             assert isinstance(output, dict)
 
@@ -514,8 +663,6 @@ class TestOnnx(TestCase):
 
         # test2: output is a dict with other non-list items
         model = DictTensorOutputModel1()
-        x1 = torch.randn(10, 28 * 28)
-        x2 = torch.randn(10, 28 * 28)
         dic, out = model(x1, x2)
         assert isinstance(dic, dict)
         onnx_model = InferenceOptimizer.trace(model, accelerator='onnxruntime', input_sample=(x1, x2))
@@ -532,6 +679,211 @@ class TestOnnx(TestCase):
             dic2, out2 = load_model(x1, x2)
         assert dic2.keys() == dic1.keys()
         np.testing.assert_almost_equal(out2.detach().numpy(), out1.detach().numpy(), decimal=5)
+        
+        # test3: test multi dict, output are 2 dicts
+        model = MultiDictOutputModel()
+        dic1, dic2 = model(x1, x2)
+        assert isinstance(dic1, dict)
+        assert isinstance(dic2, dict)
+        ov_model = InferenceOptimizer.trace(model, accelerator='openvino', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(ov_model):
+            output_dic1, output_dic2 = ov_model(x1, x2)
+        assert dic1.keys() == output_dic1.keys()
+        assert dic2.keys() == output_dic2.keys()
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(ov_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+
+        with InferenceOptimizer.get_context(load_model):
+            output2_dic1, output2_dic2 = load_model(x1, x2)
+        assert dic1.keys() == output2_dic1.keys()
+        assert dic2.keys() == output2_dic2.keys()
+        
+        # test4: test multi dict with non-list item, output is a tensor with 2 dicts
+        model = MultiDictTensorOutputModel()
+        output, dic1, dic2 = model(x1, x2)
+        assert isinstance(dic1, dict)
+        assert isinstance(dic2, dict)
+        ov_model = InferenceOptimizer.trace(model, accelerator='openvino', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(ov_model):
+            output1, output1_dic1, output1_dic2 = ov_model(x1, x2)
+        assert dic1.keys() == output_dic1.keys()
+        assert dic2.keys() == output_dic2.keys()
+        np.testing.assert_almost_equal(output.detach().numpy(), output1.detach().numpy(), decimal=5)
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(ov_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+
+        with InferenceOptimizer.get_context(load_model):
+            output2, output2_dic1, output2_dic2 = load_model(x1, x2)
+        assert dic1.keys() == output2_dic1.keys()
+        assert dic2.keys() == output2_dic2.keys()
+        np.testing.assert_almost_equal(output.detach().numpy(), output1.detach().numpy(), decimal=5)
+
+    def test_onnxruntime_list_output(self):
+        x1 = torch.randn(10, 28 * 28)
+        x2 = torch.randn(10, 28 * 28)
+        # test1: output is a single list
+        model = ListOutputModel()
+        output = model(x1, x2)
+        assert isinstance(output, list)
+
+        onnx_model = InferenceOptimizer.trace(model, accelerator='onnxruntime', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(onnx_model):
+            output1 = onnx_model(x1, x2)
+        
+        assert len(output) == len(output1)
+        for k in range(len(output)):
+            np.testing.assert_almost_equal(output[k].detach().numpy(), output1[k].detach().numpy(), decimal=5)
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(onnx_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+
+        with InferenceOptimizer.get_context(load_model):
+            output2 = load_model(x1, x2)
+
+        assert len(output) == len(output2)
+        for k in range(len(output)):
+            np.testing.assert_almost_equal(output[k].detach().numpy(), output2[k].detach().numpy(), decimal=5)
+
+        # test2: output is a tuple with other non-list items
+        model = TupleTensorOutputModel()
+        out, list_out = model(x1, x2)
+        assert isinstance(list_out, tuple)
+        onnx_model = InferenceOptimizer.trace(model, accelerator='onnxruntime', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(onnx_model):
+            out1, list_out1 = onnx_model(x1, x2)
+        assert len(list_out) == len(list_out1)
+        np.testing.assert_almost_equal(out.detach().numpy(), out1.detach().numpy(), decimal=5)
+        for k in range(len(list_out)):
+            np.testing.assert_almost_equal(list_out[k].detach().numpy(), list_out1[k].detach().numpy(), decimal=5)
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(onnx_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+
+        with InferenceOptimizer.get_context(load_model):
+            out2, list_out2 = load_model(x1, x2)
+        assert len(list_out) == len(list_out2)
+        np.testing.assert_almost_equal(out2.detach().numpy(), out1.detach().numpy(), decimal=5)
+        for k in range(len(list_out1)):
+            np.testing.assert_almost_equal(list_out1[k].detach().numpy(), list_out2[k].detach().numpy(), decimal=5)
+
+        # test3: test multi list/tuple, output are 2 lists
+        model = MultiTupleOutputModel()
+        list1, list2 = model(x1, x2)
+        assert isinstance(list1, list)
+        assert isinstance(list2, tuple)
+        onnx_model = InferenceOptimizer.trace(model, accelerator='onnxruntime', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(onnx_model):
+            output_list1, output_list2 = onnx_model(x1, x2)
+        assert len(output_list1) == len(list1)
+        assert len(output_list2) == len(list2)
+        for k in range(len(list1)):
+            np.testing.assert_almost_equal(list1[k].detach().numpy(), output_list1[k].detach().numpy(), decimal=5)
+        for k in range(len(list2)):
+            np.testing.assert_almost_equal(list2[k].detach().numpy(), output_list2[k].detach().numpy(), decimal=5)
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(onnx_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+
+        with InferenceOptimizer.get_context(load_model):
+            output2_list1, output2_list2 = load_model(x1, x2)
+        assert len(output2_list1) == len(list1)
+        assert len(output2_list2) == len(list2)
+        for k in range(len(list1)):
+            np.testing.assert_almost_equal(list1[k].detach().numpy(), output2_list1[k].detach().numpy(), decimal=5)
+        for k in range(len(list2)):
+            np.testing.assert_almost_equal(list2[k].detach().numpy(), output2_list2[k].detach().numpy(), decimal=5)
+
+        # test4: test multi list/tuple with non-list item, output is a tensor with 2list/tuples
+        model = MultiTupleTensorOutputModel()
+        output, list1, list2 = model(x1, x2)
+        assert isinstance(list1, list)
+        assert isinstance(list2, tuple)
+        onnx_model = InferenceOptimizer.trace(model, accelerator='onnxruntime', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(onnx_model):
+            output1, output1_list1, output1_list2 = onnx_model(x1, x2)
+        assert len(output1_list1) == len(list1)
+        assert len(output1_list2) == len(list2)
+        for k in range(len(list1)):
+            np.testing.assert_almost_equal(list1[k].detach().numpy(), output1_list1[k].detach().numpy(), decimal=5)
+        for k in range(len(list2)):
+            np.testing.assert_almost_equal(list2[k].detach().numpy(), output1_list2[k].detach().numpy(), decimal=5)
+        np.testing.assert_almost_equal(output.detach().numpy(), output1.detach().numpy(), decimal=5)
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(onnx_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+
+        with InferenceOptimizer.get_context(load_model):
+            output2, output2_list1, output2_list2 = load_model(x1, x2)
+        assert len(output2_list1) == len(list1)
+        assert len(output2_list2) == len(list2)
+        for k in range(len(list1)):
+            np.testing.assert_almost_equal(list1[k].detach().numpy(), output2_list1[k].detach().numpy(), decimal=5)
+        for k in range(len(list2)):
+            np.testing.assert_almost_equal(list2[k].detach().numpy(), output2_list2[k].detach().numpy(), decimal=5)
+        np.testing.assert_almost_equal(output2.detach().numpy(), output1.detach().numpy(), decimal=5)
+
+
+    def test_onnxruntime_list_dict_output(self):
+        x1 = torch.randn(10, 28 * 28)
+        x2 = torch.randn(10, 28 * 28)
+        # test1: test single dict and a single list
+        model = TupleDictOutputModel()
+        output, dic = model(x1, x2)
+        assert isinstance(output, list)
+        assert isinstance(dic, dict)
+        onnx_model = InferenceOptimizer.trace(model, accelerator='onnxruntime', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(onnx_model):
+            output1, dic1 = onnx_model(x1, x2)
+        assert isinstance(output1, list)
+        assert isinstance(dic1, dict)
+        assert dic.keys() == dic1.keys()
+        for k in range(len(output)):
+            np.testing.assert_almost_equal(output[k].detach().numpy(), output1[k].detach().numpy(), decimal=5)
+        for k in dic.keys():
+            np.testing.assert_almost_equal(dic[k].detach().numpy(), dic1[k].detach().numpy(), decimal=5)
+
+        # test2: test list contains dict
+        model = TupleDictOutputModel2()
+        output = model(x1, x2)
+        assert isinstance(output, list)
+        assert isinstance(output[2], dict)
+        onnx_model = InferenceOptimizer.trace(model, accelerator='onnxruntime', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(onnx_model):
+            output1 = onnx_model(x1, x2)
+        assert isinstance(output1, list)
+        assert isinstance(output1[2], dict)
+        assert len(output1) == len(output)
+        for i in range(2):
+            np.testing.assert_almost_equal(output[i].detach().numpy(), output1[i].detach().numpy(), decimal=5)
+        assert output[2].keys() == output1[2].keys()
+        for k in output[2].keys():
+            np.testing.assert_almost_equal(output[2][k].detach().numpy(), output1[2][k].detach().numpy(), decimal=5)
+
+        # test3: test dict contains list
+        model = TupleDictOutputModel3()
+        output = model(x1, x2)
+        assert isinstance(output, dict)
+        assert isinstance(output["intermediate"], list)
+        onnx_model = InferenceOptimizer.trace(model, accelerator='onnxruntime', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(onnx_model):
+            output1 = onnx_model(x1, x2)
+        assert isinstance(output1, dict)
+        assert isinstance(output1["intermediate"], list)
+        assert output1.keys() == output.keys()
+        for k in output.keys():
+            if k != "intermediate":
+                np.testing.assert_almost_equal(output[k].detach().numpy(), output1[k].detach().numpy(), decimal=5)
+            else:
+                for i in range(2):
+                    np.testing.assert_almost_equal(output["intermediate"][i].detach().numpy(), output1["intermediate"][i].detach().numpy(), decimal=5)
 
 
 if __name__ == '__main__':

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -111,6 +111,153 @@ class DictTensorOutputModel1(nn.Module):
         return output, x3
 
 
+class MultiDictOutputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+    
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        x3 = self.layer_3(x)
+        output1 = {"x1": x1, "x2": x2, "x3": x3}
+        output2 = {"x3": x3, "x1": x1, "x2": x2}
+        return output1, output2
+
+
+class MultiDictTensorOutputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+    
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        x3 = self.layer_3(x)
+        output1 = {"x1": x1, "x2": x2, "x3": x3}
+        output2 = {"x3": x3, "x1": x1, "x2": x2}
+        return x3, output1, output2
+
+
+class ListOutputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        output = self.layer_3(x)
+        return [x1, x2, output]
+
+
+class TupleTensorOutputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+    
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        output = self.layer_3(x)
+        return output, (x1, x2, x)
+
+
+class MultiTupleOutputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        output = self.layer_3(x)
+        return [x1,x2], (output, x)
+
+
+class MultiTupleTensorOutputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+    
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        output = self.layer_3(x)
+        return output, [x1,x2], (output, x)
+
+
+class TupleDictOutputModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+    
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        output = self.layer_3(x)
+        return [x1,x2], {"x":x, "output":output}
+
+
+class TupleDictOutputModel2(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+    
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        output = self.layer_3(x)
+        return [x1,x2,{"x":x, "output":output}]
+
+class TupleDictOutputModel3(nn.Module):
+    def __init__(self):
+        super().__init__()
+
+        self.layer_1 = nn.Linear(28 * 28, 12)
+        self.layer_2 = nn.Linear(28 * 28, 12)
+        self.layer_3 = nn.Linear(24, 1)
+    
+    def forward(self, x1, x2):
+        x1 = self.layer_1(x1)
+        x2 = self.layer_2(x2)
+        x = torch.cat([x1, x2], axis=1)
+        output = self.layer_3(x)
+        return {"intermediate": [x1,x2], "x":x, "output":output}
+
+
 class TestOpenVINO(TestCase):
     def test_trace_openvino(self):
         trainer = Trainer(max_epochs=1)
@@ -628,11 +775,11 @@ class TestOpenVINO(TestCase):
                 ov_model(x1, x1=x2)
 
     def test_openvino_dict_output(self):
+        x1 = torch.randn(10, 28 * 28)
+        x2 = torch.randn(10, 28 * 28)
         # test1: output is a single dict
         for Model in [DictOutputModel, DictOutputModel2]:
             model = Model()
-            x1 = torch.randn(10, 28 * 28)
-            x2 = torch.randn(10, 28 * 28)
             output = model(x1, x2)
             assert isinstance(output, dict)
 
@@ -657,8 +804,6 @@ class TestOpenVINO(TestCase):
 
         # test2: output is a dict with other non-list items
         model = DictTensorOutputModel1()
-        x1 = torch.randn(10, 28 * 28)
-        x2 = torch.randn(10, 28 * 28)
         dic, out = model(x1, x2)
         assert isinstance(dic, dict)
         ov_model = InferenceOptimizer.trace(model, accelerator='openvino', input_sample=(x1, x2))
@@ -675,3 +820,207 @@ class TestOpenVINO(TestCase):
             dic2, out2 = load_model(x1, x2)
         assert dic2.keys() == dic1.keys()
         np.testing.assert_almost_equal(out2.detach().numpy(), out1.detach().numpy(), decimal=5)
+
+        # test3: test multi dict, output are 2 dicts
+        model = MultiDictOutputModel()
+        dic1, dic2 = model(x1, x2)
+        assert isinstance(dic1, dict)
+        assert isinstance(dic2, dict)
+        ov_model = InferenceOptimizer.trace(model, accelerator='openvino', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(ov_model):
+            output_dic1, output_dic2 = ov_model(x1, x2)
+        assert dic1.keys() == output_dic1.keys()
+        assert dic2.keys() == output_dic2.keys()
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(ov_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+
+        with InferenceOptimizer.get_context(load_model):
+            output2_dic1, output2_dic2 = load_model(x1, x2)
+        assert dic1.keys() == output2_dic1.keys()
+        assert dic2.keys() == output2_dic2.keys()
+        
+        # test4: test multi dict with non-list item, output is a tensor with 2 dicts
+        model = MultiDictTensorOutputModel()
+        output, dic1, dic2 = model(x1, x2)
+        assert isinstance(dic1, dict)
+        assert isinstance(dic2, dict)
+        ov_model = InferenceOptimizer.trace(model, accelerator='openvino', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(ov_model):
+            output1, output1_dic1, output1_dic2 = ov_model(x1, x2)
+        assert dic1.keys() == output_dic1.keys()
+        assert dic2.keys() == output_dic2.keys()
+        np.testing.assert_almost_equal(output.detach().numpy(), output1.detach().numpy(), decimal=5)
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(ov_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+
+        with InferenceOptimizer.get_context(load_model):
+            output2, output2_dic1, output2_dic2 = load_model(x1, x2)
+        assert dic1.keys() == output2_dic1.keys()
+        assert dic2.keys() == output2_dic2.keys()
+        np.testing.assert_almost_equal(output.detach().numpy(), output1.detach().numpy(), decimal=5)
+
+    def test_openvino_list_output(self):
+        x1 = torch.randn(10, 28 * 28)
+        x2 = torch.randn(10, 28 * 28)
+        # test1: output is a single list
+        model = ListOutputModel()
+        output = model(x1, x2)
+        assert isinstance(output, list)
+
+        ov_model = InferenceOptimizer.trace(model, accelerator='openvino', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(ov_model):
+            output1 = ov_model(x1, x2)
+        
+        assert len(output) == len(output1)
+        for k in range(len(output)):
+            np.testing.assert_almost_equal(output[k].detach().numpy(), output1[k].detach().numpy(), decimal=5)
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(ov_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+
+        with InferenceOptimizer.get_context(load_model):
+            output2 = load_model(x1, x2)
+
+        assert len(output) == len(output2)
+        for k in range(len(output)):
+            np.testing.assert_almost_equal(output[k].detach().numpy(), output2[k].detach().numpy(), decimal=5)
+
+        # test2: output is a tuple with other non-list items
+        model = TupleTensorOutputModel()
+        out, list_out = model(x1, x2)
+        assert isinstance(list_out, tuple)
+        ov_model = InferenceOptimizer.trace(model, accelerator='openvino', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(ov_model):
+            out1, list_out1 = ov_model(x1, x2)
+        assert len(list_out) == len(list_out1)
+        np.testing.assert_almost_equal(out.detach().numpy(), out1.detach().numpy(), decimal=5)
+        for k in range(len(list_out)):
+            np.testing.assert_almost_equal(list_out[k].detach().numpy(), list_out1[k].detach().numpy(), decimal=5)
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(ov_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+
+        with InferenceOptimizer.get_context(load_model):
+            out2, list_out2 = load_model(x1, x2)
+        assert len(list_out) == len(list_out2)
+        np.testing.assert_almost_equal(out2.detach().numpy(), out1.detach().numpy(), decimal=5)
+        for k in range(len(list_out1)):
+            np.testing.assert_almost_equal(list_out1[k].detach().numpy(), list_out2[k].detach().numpy(), decimal=5)
+
+        # test3: test multi list/tuple, output are 2 lists
+        model = MultiTupleOutputModel()
+        list1, list2 = model(x1, x2)
+        assert isinstance(list1, list)
+        assert isinstance(list2, tuple)
+        ov_model = InferenceOptimizer.trace(model, accelerator='openvino', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(ov_model):
+            output_list1, output_list2 = ov_model(x1, x2)
+        assert len(output_list1) == len(list1)
+        assert len(output_list2) == len(list2)
+        for k in range(len(list1)):
+            np.testing.assert_almost_equal(list1[k].detach().numpy(), output_list1[k].detach().numpy(), decimal=5)
+        for k in range(len(list2)):
+            np.testing.assert_almost_equal(list2[k].detach().numpy(), output_list2[k].detach().numpy(), decimal=5)
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(ov_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+
+        with InferenceOptimizer.get_context(load_model):
+            output2_list1, output2_list2 = load_model(x1, x2)
+        assert len(output2_list1) == len(list1)
+        assert len(output2_list2) == len(list2)
+        for k in range(len(list1)):
+            np.testing.assert_almost_equal(list1[k].detach().numpy(), output2_list1[k].detach().numpy(), decimal=5)
+        for k in range(len(list2)):
+            np.testing.assert_almost_equal(list2[k].detach().numpy(), output2_list2[k].detach().numpy(), decimal=5)
+
+        # test4: test multi list/tuple with non-list item, output is a tensor with 2list/tuples
+        model = MultiTupleTensorOutputModel()
+        output, list1, list2 = model(x1, x2)
+        assert isinstance(list1, list)
+        assert isinstance(list2, tuple)
+        ov_model = InferenceOptimizer.trace(model, accelerator='openvino', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(ov_model):
+            output1, output1_list1, output1_list2 = ov_model(x1, x2)
+        assert len(output1_list1) == len(list1)
+        assert len(output1_list2) == len(list2)
+        for k in range(len(list1)):
+            np.testing.assert_almost_equal(list1[k].detach().numpy(), output1_list1[k].detach().numpy(), decimal=5)
+        for k in range(len(list2)):
+            np.testing.assert_almost_equal(list2[k].detach().numpy(), output1_list2[k].detach().numpy(), decimal=5)
+        np.testing.assert_almost_equal(output.detach().numpy(), output1.detach().numpy(), decimal=5)
+
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(ov_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+
+        with InferenceOptimizer.get_context(load_model):
+            output2, output2_list1, output2_list2 = load_model(x1, x2)
+        assert len(output2_list1) == len(list1)
+        assert len(output2_list2) == len(list2)
+        for k in range(len(list1)):
+            np.testing.assert_almost_equal(list1[k].detach().numpy(), output2_list1[k].detach().numpy(), decimal=5)
+        for k in range(len(list2)):
+            np.testing.assert_almost_equal(list2[k].detach().numpy(), output2_list2[k].detach().numpy(), decimal=5)
+        np.testing.assert_almost_equal(output2.detach().numpy(), output1.detach().numpy(), decimal=5)
+
+    def test_openvino_list_dict_output(self):
+        x1 = torch.randn(10, 28 * 28)
+        x2 = torch.randn(10, 28 * 28)
+        # test1: test single dict and a single list
+        model = TupleDictOutputModel()
+        output, dic = model(x1, x2)
+        assert isinstance(output, list)
+        assert isinstance(dic, dict)
+        ov_model = InferenceOptimizer.trace(model, accelerator='openvino', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(ov_model):
+            output1, dic1 = ov_model(x1, x2)
+        assert isinstance(output1, list)
+        assert isinstance(dic1, dict)
+        assert dic.keys() == dic1.keys()
+        for k in range(len(output)):
+            np.testing.assert_almost_equal(output[k].detach().numpy(), output1[k].detach().numpy(), decimal=5)
+        for k in dic.keys():
+            np.testing.assert_almost_equal(dic[k].detach().numpy(), dic1[k].detach().numpy(), decimal=5)
+
+        # test2: test list contains dict
+        model = TupleDictOutputModel2()
+        output = model(x1, x2)
+        assert isinstance(output, list)
+        assert isinstance(output[2], dict)
+        ov_model = InferenceOptimizer.trace(model, accelerator='openvino', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(ov_model):
+            output1 = ov_model(x1, x2)
+        assert isinstance(output1, list)
+        assert isinstance(output1[2], dict)
+        assert len(output1) == len(output)
+        for i in range(2):
+            np.testing.assert_almost_equal(output[i].detach().numpy(), output1[i].detach().numpy(), decimal=5)
+        assert output[2].keys() == output1[2].keys()
+        for k in output[2].keys():
+            np.testing.assert_almost_equal(output[2][k].detach().numpy(), output1[2][k].detach().numpy(), decimal=5)
+
+        # test3: test dict contains list
+        model = TupleDictOutputModel3()
+        output = model(x1, x2)
+        assert isinstance(output, dict)
+        assert isinstance(output["intermediate"], list)
+        ov_model = InferenceOptimizer.trace(model, accelerator='openvino', input_sample=(x1, x2))
+        with InferenceOptimizer.get_context(ov_model):
+            output1 = ov_model(x1, x2)
+        assert isinstance(output1, dict)
+        assert isinstance(output1["intermediate"], list)
+        assert output1.keys() == output.keys()
+        for k in output.keys():
+            if k != "intermediate":
+                np.testing.assert_almost_equal(output[k].detach().numpy(), output1[k].detach().numpy(), decimal=5)
+            else:
+                for i in range(2):
+                    np.testing.assert_almost_equal(output["intermediate"][i].detach().numpy(), output1["intermediate"][i].detach().numpy(), decimal=5)

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -541,10 +541,7 @@ class TestOpenVINO(TestCase):
             new_model_inputs = {i.any_name: i.shape for i in new_model.ov_model.ie_network.inputs}
             assert list(new_model_inputs["sample"]) == [1, 4, 8, 8]
             assert list(new_model_inputs["encoder_hidden_states"]) == [1, 12, 10]
-
-        output1 = new_model(image_latents, torch.Tensor([980]).long(), encoder_hidden_states)
         output2 = new_model(image_latents2, torch.Tensor([980]).long(), encoder_hidden_states2)
-        np.testing.assert_almost_equal(output1["sample"].detach().numpy(), target_sample1.sample.detach().numpy(), decimal=5)
         np.testing.assert_almost_equal(output2["sample"].detach().numpy(), target_sample2.sample.detach().numpy(), decimal=5)
 
     def test_openvino_trace_output_tensors(self):

--- a/python/nano/test/openvino/pytorch/test_openvino_quantize.py
+++ b/python/nano/test/openvino/pytorch/test_openvino_quantize.py
@@ -429,6 +429,19 @@ class TestOpenVINO(TestCase):
             forward_model_numpy = test_openvino_model(x)
             assert isinstance(forward_model_numpy, np.ndarray)
             np.testing.assert_almost_equal(forward_model_tensor, forward_model_numpy, decimal=5)
+        
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(openvino_model, tmp_dir_name)
+            load_model = InferenceOptimizer.load(tmp_dir_name)
+        with tempfile.TemporaryDirectory() as tmp_dir_name:
+            InferenceOptimizer.save(test_openvino_model, tmp_dir_name)
+            test_load_model = InferenceOptimizer.load(tmp_dir_name)
+
+        for x, y in dataloader:
+            forward_model_tensor = load_model(x).numpy()
+            forward_model_numpy = test_load_model(x)
+            assert isinstance(forward_model_numpy, np.ndarray)
+            np.testing.assert_almost_equal(forward_model_tensor, forward_model_numpy, decimal=5)
 
     def test_openvino_quantize_keyword_argument(self):
         model = mobilenet_v3_small(num_classes=10)


### PR DESCRIPTION
## Description

Prior to this PR, the output of the models accelerated by OpenVINO and ONNXRuntime could only be tensor or tensor list. However, during our development process, we encountered many situations where the output could actually be dictionaries, tuples, custom dictionaries, and some combinations.
We plan to support a series of output formats by saving the output metadata format:
- [x] 1. only 1 dict
- [x] 2. 1 dict with other non-list items
- [x] 3. multiple dicts
- [x] 4. multiple dicts with other non-list items
- [x] 5. 1 list/tuple
- [x] 6. 1 list/tuple with other non-list items
- [x] 7. multiple list/tuple
- [x] 8. multiple list/tuple with other non-list items
- [x] 9. dict and list/tuple
- [x] 10. list/tuple contains dict
- [x] 11. dict contains list/tuple
- [ ] 12. custom class

This PR will implement the first 11 cases.

### 1. Why the change?

Support **2.2 Support this by get the output signature in test run in trace/quantize and use preforward-callback and postforward-callback** of https://github.com/analytics-zoo/nano/issues/330

### 2. User API changes
No change, but now traced model will output in its original form
```python
class DictOutputModel(nn.Module):
    def __init__(self):
        super().__init__()

        self.layer_1 = nn.Linear(28 * 28, 12)
        self.layer_2 = nn.Linear(28 * 28, 12)
        self.layer_3 = nn.Linear(24, 1)
    
    def forward(self, x1, x2):
        x1 = self.layer_1(x1)
        x2 = self.layer_2(x2)
        x = torch.cat([x1, x2], axis=1)
        x3 = self.layer_3(x)
        output = {"x1": x1, "x2": x2, "x3": x3}
        return output

onnx_model = InferenceOptimizer.trace(model, accelerator='onnxruntime', input_sample=(x1, x2))
with InferenceOptimizer.get_context(onnx_model):
    output_dict = onnx_model(x1, x2)
```

### 3. Summary of the change 

- Support first 11 cases for OpenVINO and ONNXRuntime's trace, add related UT
- Fix missing `output_tensors` in save&load function of OpenVINO and ONNXRuntime, update related UT

### 4. How to test?
- [ ] Unit test

