### PR TITLE
Chronos: fix thread num error when use `get_context` and `predict_with_onnx` together

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -842,9 +842,7 @@ class BasePytorchForecaster(Forecaster):
                                                   output_tensor=self.optimized_model_output_tensor)
             else:
                 if self.accelerate_method != "onnxruntime_fp32":
-                    self.build_onnx()
-                    self.thread_num = set_pytorch_thread(self.optimized_model_thread_num,
-                                                         self.thread_num)
+                    self.build_onnx(self.thread_num)
                 return _pytorch_fashion_inference(model=self.accelerated_model,
                                                   input_data=data,
                                                   batch_size=batch_size,
@@ -1237,7 +1235,7 @@ class BasePytorchForecaster(Forecaster):
                                                   output_tensor=self.optimized_model_output_tensor)
             else:
                 if self.accelerate_method != "onnxruntime_fp32":
-                    self.build_onnx()
+                    self.build_onnx(self.thread_num)
                 yhat = _pytorch_fashion_inference(model=self.accelerated_model,
                                                   input_data=input_data,
                                                   batch_size=batch_size,
@@ -1677,7 +1675,7 @@ class BasePytorchForecaster(Forecaster):
                               "an up-to-date quantized model")
         if dirname:
             if self.accelerate_method != "onnxruntime_fp32":
-                self.build_onnx()
+                self.build_onnx(self.thread_num)
             InferenceOptimizer.save(self.accelerated_model, dirname)
 
     def export_openvino_file(self, dirname="fp32_openvino",

--- a/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/base_forecaster.py
@@ -920,9 +920,7 @@ class BasePytorchForecaster(Forecaster):
                                                   output_tensor=self.optimized_model_output_tensor)
             else:
                 if self.accelerate_method != "openvino_fp32":
-                    self.build_openvino()
-                    self.thread_num = set_pytorch_thread(self.optimized_model_thread_num,
-                                                         self.thread_num)
+                    self.build_openvino(self.thread_num)
                 return _pytorch_fashion_inference(model=self.accelerated_model,
                                                   input_data=data,
                                                   batch_size=batch_size,
@@ -1700,7 +1698,7 @@ class BasePytorchForecaster(Forecaster):
                               "an up-to-date quantized model")
         if dirname:
             if self.accelerate_method != "openvino_fp32":
-                self.build_openvino()
+                self.build_openvino(self.thread_num)
             InferenceOptimizer.save(self.accelerated_model, dirname)
 
     def export_torchscript_file(self, dirname="fp32_torchscript",

--- a/python/chronos/src/bigdl/chronos/pytorch/context_manager.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/context_manager.py
@@ -57,6 +57,8 @@ class ForecasterContextManager(object):
         # call `torch.set_num_threads` at most once
         self.forecaster.thread_num = set_pytorch_thread(self.thread_num,
                                                         self.forecaster.thread_num)
+        self.forecaster.optimized_model_thread_num = \
+            set_pytorch_thread(self.thread_num, self.forecaster.optimized_model_thread_num)
         self.forecaster.context_enabled = True
         self.infer_mode.__enter__()
         if self.bf16_enable:

--- a/python/chronos/src/bigdl/chronos/pytorch/context_manager.py
+++ b/python/chronos/src/bigdl/chronos/pytorch/context_manager.py
@@ -57,8 +57,9 @@ class ForecasterContextManager(object):
         # call `torch.set_num_threads` at most once
         self.forecaster.thread_num = set_pytorch_thread(self.thread_num,
                                                         self.forecaster.thread_num)
-        self.forecaster.optimized_model_thread_num = \
-            set_pytorch_thread(self.thread_num, self.forecaster.optimized_model_thread_num)
+        if hasattr(self.forecaster, 'optimized_model_thread_num'):
+            self.forecaster.optimized_model_thread_num = \
+                set_pytorch_thread(self.thread_num, self.forecaster.optimized_model_thread_num)
         self.forecaster.context_enabled = True
         self.infer_mode.__enter__()
         if self.bf16_enable:

--- a/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_autoformer_forecaster.py
@@ -479,6 +479,6 @@ class TestChronosModelAutoformerForecaster(TestCase):
         num = max(1, original_thread//2)
         with forecaster.get_context(thread_num=num):
             assert forecaster.context_enabled == True
+            pred = forecaster.predict(test_loader)
             current_thread = torch.get_num_threads()
             assert current_thread == num
-            pred = forecaster.predict(test_loader)

--- a/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_lstm_forecaster.py
@@ -852,8 +852,11 @@ class TestChronosModelLSTMForecaster(TestCase):
             assert forecaster.context_enabled == True
             current_thread = torch.get_num_threads()
             assert current_thread == num
-            for x, y in test_loader:
-                yhat = forecaster.predict(x.numpy())
+            yhat = forecaster.predict(test_loader)
+            yhat = forecaster.predict_with_onnx(test_loader)
+            yhat = forecaster.predict_with_openvino(test_loader)
+            current_thread = torch.get_num_threads()
+            assert current_thread == num
 
     @op_inference
     def test_lstm_forecaster_numpy_inference(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_nbeats_forecaster.py
@@ -782,8 +782,11 @@ class TestChronosNBeatsForecaster(TestCase):
             assert forecaster.context_enabled == True
             current_thread = torch.get_num_threads()
             assert current_thread == num
-            for x, y in test_loader:
-                yhat = forecaster.predict(x.numpy())
+            yhat = forecaster.predict(test_loader)
+            yhat = forecaster.predict_with_onnx(test_loader)
+            yhat = forecaster.predict_with_openvino(test_loader)
+            current_thread = torch.get_num_threads()
+            assert current_thread == num
 
     @op_automl
     def test_nbeats_forecaster_tune(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_seq2seq_forecaster.py
@@ -740,8 +740,11 @@ class TestChronosModelSeq2SeqForecaster(TestCase):
             assert forecaster.context_enabled == True
             current_thread = torch.get_num_threads()
             assert current_thread == num
-            for x, y in test_loader:
-                yhat = forecaster.predict(x.numpy())
+            yhat = forecaster.predict(test_loader)
+            yhat = forecaster.predict_with_onnx(test_loader)
+            yhat = forecaster.predict_with_openvino(test_loader)
+            current_thread = torch.get_num_threads()
+            assert current_thread == num
 
     @op_inference
     def test_s2s_forecaster_numpy_inference(self):

--- a/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
+++ b/python/chronos/test/bigdl/chronos/forecaster/test_tcn_forecaster.py
@@ -1501,8 +1501,11 @@ class TestChronosModelTCNForecaster(TestCase):
             assert forecaster.context_enabled == True
             current_thread = torch.get_num_threads()
             assert current_thread == num
-            for x, y in test_loader:
-                yhat = forecaster.predict(x.numpy())
+            yhat = forecaster.predict(test_loader)
+            yhat = forecaster.predict_with_onnx(test_loader)
+            yhat = forecaster.predict_with_openvino(test_loader)
+            current_thread = torch.get_num_threads()
+            assert current_thread == num
 
     @op_inference
     def test_tcn_forecaster_numpy_inference(self):


### PR DESCRIPTION
## Description

When we call `forecaster.get_context(thread_num=4)` and `forecaster.predict_with_onnx`, we receive warning to set OMP_NUM_THREADS=1. Obviously, it's incorrect.
In this pr, fix it.

### 2. User API changes

None

### 4. How to test?
- [x] Unit test
