### PR TITLE
Orca: Enable models and optimizers setter in torchrunner

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -804,10 +804,23 @@ class TorchRunner(BaseRunner):
             if self.models:
                 return self.models[0]
 
+    @model.setter
+    def model(self, value):
+        if self._model == 'train':
+            if self.training_models:
+                self.training_models[0] = value
+        else:
+            if self.models:
+                self.models[0] = value
+
     @property
     def optimizer(self):
         """First or only optimizer(s) created by the ``optimizer_creator``."""
         return self.optimizers[0]
+
+    @optimizer.setter
+    def optimizer(self, value):
+        self.optimizers[0] = value
 
     @property
     def scheduler(self):


### PR DESCRIPTION
## Description

In this PR we add attribute setters to model and optimizer, and users can make external operations on these attributes in callbacks:
```python
            runner.model, runner.optimizer = ipex.optimize(
                runner.model, dtype=dtype, optimizer=runner.optimizer, inplace=True, level="O1"
            )
```  