### PR TITLE
[Friesian] Fix Friesian Vulnerabilities

### DIFF
--- a/scala/friesian/pom.xml
+++ b/scala/friesian/pom.xml
@@ -163,21 +163,43 @@
                 <exclusion>
                     <groupId>org.mortbay.jetty</groupId>
                     <artifactId>jetty</artifactId>
-	        </exclusion>
+	            </exclusion>
                 <exclusion>
                     <groupId>org.codehaus.jettison</groupId>
                     <artifactId>jettison</artifactId>
-	        </exclusion>
+	            </exclusion>
                 <exclusion>
                     <groupId>com.jcraft</groupId>
                     <artifactId>jsch</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>net.minidev</groupId>
+                    <artifactId>json-smart</artifactId>
+                </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.4.9</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-mllib_${scala.major.version}</artifactId>
             <version>${spark.version}</version>
+            <scope>${spark-scope}</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.10.0</version>
             <scope>${spark-scope}</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Description

Fix Friesian Vulnerabilities.

### 1. Why the change?

Related issue: https://github.com/analytics-zoo/arda-docker/issues/815

### 3. Summary of the change 

1. Upgrade commons-text to 1.10
2. Upgrade json-smart to 2.4.9

### 4. How to test?
- [x] Unit test

### 5. New dependencies

- [ ] New Java/Scala dependencies and their license
       - net.minidev:json-smart:2.4.9
       - org.apache.commons:commons-text:1.10.0
       - ...
