### PR TITLE
[Nano] multiprocessing support for pipeline

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/inference/pipeline.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/pipeline.py
@@ -45,8 +45,8 @@ class Pipeline():
         For example,
         ```
             pipeline = Pipeline([
-                ("preprocess", preprocess, {"core_num": 4, 'worker_num': 1}),
-                ("inference", model, {"core_num": 8, 'worker_num': 1}),
+                ("preprocess", preprocess, {"cores_per_worker": 4, 'worker_num': 1}),
+                ("inference", model, {"cores_per_worker": 8, 'worker_num': 1}),
             ])
         ```
         will create a pipeline which has stage "preprocess" and "inference",
@@ -103,13 +103,13 @@ class Pipeline():
                           f' but get {type(worker_num)}')
         process_list = []
 
-        core_num = config.get("core_num", None)
+        cores_per_worker = config.get("cores_per_worker", None)
         for _ in range(worker_num):
-            if isinstance(core_num, int):
-                cores = self.cores[:core_num]
-                self.cores = self.cores[core_num:]
-                if len(cores) < core_num:
-                    warnings.warn(f"stage {name} requires {core_num} cores,"
+            if isinstance(cores_per_worker, int):
+                cores = self.cores[:cores_per_worker]
+                self.cores = self.cores[cores_per_worker:]
+                if len(cores) < cores_per_worker:
+                    warnings.warn(f"stage {name} requires {cores_per_worker} cores,"
                                   f" but there are only {len(cores)} cores left")
                 subprocess_env["KMP_AFFINITY"] = (
                     f"granularity=fine,proclist"

--- a/python/nano/src/bigdl/nano/pytorch/inference/pipeline.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/pipeline.py
@@ -88,9 +88,9 @@ class Pipeline():
             self.send_.put((idx, value))
             outputs.append(None)
 
-        outputs = [self.recv_.get() for _ in outputs]
-        outputs = list(map(lambda output: output[1],
-                           sorted(outputs, key=lambda output: output[0])))
+        for _ in range(len(outputs)):
+            idx, output = self.recv_.get()
+            outputs[idx] = output
         return outputs
 
     def _launch_stage(self, stage: Tuple, recv_: mp.Queue, send_: mp.Queue):

--- a/python/nano/src/bigdl/nano/pytorch/inference/pipeline.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/pipeline.py
@@ -111,8 +111,9 @@ class Pipeline():
                 if len(cores) < core_num:
                     warnings.warn(f"stage {name} requires {core_num} cores,"
                                   f" but there are only {len(cores)} cores left")
-                subprocess_env["KMP_AFFINITY"] = (f"granularity=fine,proclist"
-                                                  f"=[{','.join([str(i) for i in cores])}],explicit")
+                subprocess_env["KMP_AFFINITY"] = (
+                    f"granularity=fine,proclist"
+                    f"=[{','.join([str(i) for i in cores])}],explicit")
                 subprocess_env["OMP_NUM_THREADS"] = str(len(cores))
 
             with EnvContext(env=subprocess_env):

--- a/python/nano/test/pytorch/tests/inference/test_pipeline.py
+++ b/python/nano/test/pytorch/tests/inference/test_pipeline.py
@@ -15,11 +15,12 @@
 #
 
 import platform
+from unittest import TestCase
+
 import pytest
 import torch
-from unittest import TestCase
-from torchvision.models import resnet18
 from bigdl.nano.pytorch import Pipeline
+from torchvision.models import resnet18
 
 
 def empty_stage():
@@ -54,15 +55,16 @@ class TestPipeline(TestCase):
         def preprocess(_i):
             import os
             return os.sched_getaffinity(0)
+
         def inference(i):
             import os
             return (i, os.sched_getaffinity(0))
+
         model = resnet18(num_classes=10)
         pipeline = Pipeline([
-            ("preprocess", preprocess, {"core_num": 1}),
-            ("inference", inference, {"core_num": 1}),
+            ("preprocess", preprocess, {"cores_per_worker": 1, 'worker_num': 1}),
+            ("inference", inference, {"cores_per_worker": 1, 'worker_num': 1}),
         ])
         output = pipeline.run([None])[0]
         # The first stage's affinity should be {0}, and the second stage's affinity should be {1}
         assert output == (set([0]), set([1]))
-


### PR DESCRIPTION
## Description

Add multiprocessing support for Nano pipeline API. It can be useful in Alphafold optimization.

```python
pipeline = Pipeline([
    ("preprocess", preprocess, {"core_num": 8, 'worker_num': 8}),
    ("inference", model, {"core_num": 8, 'worker_num': 8}),
])
pipeline.run(input_list)
```
