### PR TITLE
Friesian: two tower example update

### DIFF
--- a/python/friesian/example/two_tower/predict_2tower.py
+++ b/python/friesian/example/two_tower/predict_2tower.py
@@ -63,12 +63,12 @@ full_tbl = FeatureTable.read_parquet(os.path.join(args.data_dir, "user_item_parq
 print("Data size: " + str(full_tbl.size()))
 
 enaging_user_df = full_tbl.select(['enaging_user_id', 'enaging_user_is_verified',
-                                   'user_numeric']).drop_duplicates()\
+                                   'user_numeric'])\
                           .rename({'enaging_user_id': 'user_id',
                                    'enaging_user_is_verified': 'is_verified'})
 # the last 3 columns of "item_numeric" are engaged users' numeric features
 engaged_user_df = full_tbl.select(['engaged_with_user_id', 'engaged_with_user_is_verified',
-                                   'item_numeric']).drop_duplicates()\
+                                   'item_numeric'])\
                           .apply("item_numeric", "user_numeric",
                                  lambda item_numeric: item_numeric[-3:],
                                  dtype="array<float>")\
@@ -79,7 +79,7 @@ user_df = enaging_user_df.concat(engaged_user_df)
 user_embed = FeatureTable(user_est.predict(data=user_df.df,
                                            batch_size=args.batch_size,
                                            feature_cols=user_df.columns))\
-    .select(['user_id', 'prediction'])
+    .select(['user_id', 'prediction']).drop_duplicates()
 print("Embeddings of the first 5 users:")
 user_embed.show(5)
 user_embed.write_parquet(os.path.join(args.data_dir, 'user_ebd.parquet'))

--- a/python/friesian/example/two_tower/train_2tower.py
+++ b/python/friesian/example/two_tower/train_2tower.py
@@ -16,6 +16,7 @@
 
 import pickle
 import argparse
+import math
 from model import *
 from pyspark.sql.functions import array
 from bigdl.orca import init_orca_context, stop_orca_context
@@ -249,8 +250,8 @@ if __name__ == '__main__':
                           "cluster_mode should be one of 'local', 'yarn', 'standalone' and"
                           " 'spark-submit', but got " + args.cluster_mode)
 
-    train_tbl = FeatureTable.read_parquet(args.data_dir + "/train_parquet")
-    test_tbl = FeatureTable.read_parquet(args.data_dir + "/test_parquet")
+    train_tbl = FeatureTable.read_parquet(os.path.join(args.data_dir, "train_parquet"))
+    test_tbl = FeatureTable.read_parquet(os.path.join(args.data_dir, "test_parquet"))
     reindex_tbls = None
     if args.frequency_limit > 1:
         reindex_tbls = train_tbl.gen_reindex_mapping(embed_cols, freq_limit=args.frequency_limit)


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

This is a temporary workaround, the `drop_duplicates()` is put after `predict`

See https://github.com/intel-analytics/BigDL/issues/8053.