### PR TITLE
Fix serving and ppml vulnerabilities

### DIFF
--- a/scala/ppml/src/test/scala/com/intel/analytics/bigdl/ppml/fl/nn/CorrectnessSpec.scala
+++ b/scala/ppml/src/test/scala/com/intel/analytics/bigdl/ppml/fl/nn/CorrectnessSpec.scala
@@ -66,6 +66,8 @@ class CorrectnessSpec extends FLSpec {
       mockClient2.start()
       mockClient1.join()
       mockClient2.join()
+      mockClient1.testFlContext.getClient().shutdown()
+      mockClient2.testFlContext.getClient().shutdown()
       if (errorFlag) {
         throw new Exception("Test failed, check the log")
       }

--- a/scala/serving/pom.xml
+++ b/scala/serving/pom.xml
@@ -335,6 +335,11 @@
             <artifactId>avatica-core</artifactId>
             <version>1.22.0</version>
         </dependency>
+        <dependency>
+            <groupId>net.minidev</groupId>
+            <artifactId>json-smart</artifactId>
+            <version>2.4.9</version>
+        </dependency>
     </dependencies>
 
     <build>


### PR DESCRIPTION
## Description

* fix serving vulnerability: upgrade `net.minidev:json-smart` to 2.4.9
* add wait termination for gRPC clients in ppml vulnerability