### PR TITLE
Support data_loader in pytorch_spark_estimator[WIP]

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/maincallback.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/maincallback.py
@@ -100,9 +100,6 @@ class MainCallback(Callback):
         Called during prediction.
         Any behavior inconsistent with the default prediction behavior should be overridden here.
         """
-        print("in main call back------------")
-        print(*runner.batch)
-        print(len(runner.batch))
         output = runner.model(*runner.batch)
 
         if len(output.size()) > 1:

--- a/python/orca/src/bigdl/orca/learn/pytorch/callbacks/maincallback.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/callbacks/maincallback.py
@@ -100,6 +100,9 @@ class MainCallback(Callback):
         Called during prediction.
         Any behavior inconsistent with the default prediction behavior should be overridden here.
         """
+        print("in main call back------------")
+        print(*runner.batch)
+        print(len(runner.batch))
         output = runner.model(*runner.batch)
 
         if len(output.size()) > 1:

--- a/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/pytorch_pyspark_worker.py
@@ -155,8 +155,10 @@ class PytorchPysparkWorker(TorchRunner):
                  wrap_dataloader=None, callbacks=None):
         """Evaluates the model on the validation data set."""
         self.load_state_dict(self.state_dict.value)
+        print("in pyspark_worer validate---- ")
         validation_stats = super().validate(data_creator, batch_size, num_steps, profile,
                                             wrap_dataloader, callbacks)
+        print(data_creator)
         if self.log_to_driver:
             LogMonitor.stop_log_monitor(self.log_path, self.logger_thread, self.thread_stop)
         return [validation_stats]
@@ -166,9 +168,11 @@ class PytorchPysparkWorker(TorchRunner):
         config = copy.copy(self.config)
         self._toggle_profiling(profile=profile)
 
-        partition = data_creator(config, batch_size)
+        # partition = data_creator(config, batch_size)
+        # print("in pytorch pyspark worker--------------------")
+        # print(partition)
         self.load_state_dict(self.state_dict.value)
-        result = super().predict(partition=partition, batch_size=batch_size,
+        result = super().predict(data_creator, batch_size=batch_size,
                                  profile=profile, callbacks=callbacks)
         if self.log_to_driver:
             LogMonitor.stop_log_monitor(self.log_path, self.logger_thread, self.thread_stop)

--- a/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/torch_runner.py
@@ -603,6 +603,9 @@ class TorchRunner(BaseRunner):
                 params[arg] = config[arg]
 
         def predict_fn(shard):
+            print("---- in predict_fn")
+            print(shard)
+            print(type(partition))
             if isinstance(partition, IterableDataset):
                 y = self._predict(shard, callbacks=callbacks)
             else:
@@ -622,6 +625,8 @@ class TorchRunner(BaseRunner):
             else:
                 new_part = [predict_fn(shard) for shard in partition]
         self.call_hook(callbacks, "after_pred_epoch")
+        print("new part-----------")
+        print(new_part)
         return new_part
 
     def _predict(self, pred_iterator, callbacks=None):

--- a/python/orca/test/bigdl/orca/learn/test_pytorch_basic.py
+++ b/python/orca/test/bigdl/orca/learn/test_pytorch_basic.py
@@ -47,6 +47,19 @@ np.random.seed(1337)  # for reproducibility
 resource_path = os.path.join(
     os.path.realpath(os.path.dirname(__file__)), "../../../resources")
 
+class FeatureDataset(torch.utils.data.Dataset):
+    """y = a * x + b"""
+
+    def __init__(self, size=1000):
+        X1 = torch.randn(size // 2, 5)
+        X2 = torch.randn(size // 2, 5) + 1.5
+        self.x = torch.cat([X1, X2], dim=0)
+
+    def __getitem__(self, index):
+        return self.x[index, None]
+
+    def __len__(self):
+        return len(self.x)
 
 class LinearDataset(torch.utils.data.Dataset):
     """y = a * x + b"""
@@ -237,6 +250,15 @@ def val_data_loader(config, batch_size):
         batch_size=batch_size
     )
     return validation_loader
+
+
+def predict_data_loader(config, batch_size):
+    dataset = FeatureDataset(size=config.get("data_size", 1000))
+    loader = torch.utils.data.DataLoader(
+        dataset,
+        batch_size=batch_size
+    )
+    return loader
 
 
 def get_model(config):
@@ -738,6 +760,15 @@ class TestPyTorchEstimatorBasic(TestCase):
             os.remove(path)
 
         assert np.array_equal(expected_result, result_after)
+
+    def test_predict_data_loader(self):
+        estimator = get_estimator()
+        loader = predict_data_loader()
+        result = estimator.predict(loader, batch_size=2)
+        print(result.count())
+        assert result.count() == 1000
+
+
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
Support data_loader in pytorch_spark_estimator
### 1. Why the change?

<!-- Provide the related github issue link if available -->
The current implementation of predict API only supports DataFrame or XShards, we need to support data loader. 

### 2. How to test?
- [ ] Unit test