### PR TITLE
upgrade parquet and remove deprecated jackson in ppml

### DIFF
--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -41,6 +41,14 @@
             <version>${spark.version}</version>
             <scope>${spark-scope}</scope>
 	    <exclusions>
+	       <exclusion>
+		    <groupId>org.codehaus.jackson</groupId>
+		    <artifactId>jackson-core-asl</artifactId>
+	       </exclusion>
+	       <exclusion>
+		     <groupId>org.codehaus.jackson</groupId>
+		     <artifactId>jackson-mapper-asl</artifactId>
+	       </exclusion>
 		<exclusion>
 	            <groupId>org.apache.commons</groupId>
 		    <artifactId>commons-text</artifactId>
@@ -96,18 +104,21 @@
         </dependency>
         <dependency>
             <groupId>org.apache.parquet</groupId>
-            <artifactId>parquet-hadoop</artifactId>
+	    <artifactId>parquet-hadoop</artifactId>
+	    <version>1.13.0</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.parquet</groupId>
-            <artifactId>parquet-hadoop</artifactId>
+	    <artifactId>parquet-hadoop</artifactId>
+	    <version>1.13.0</version>
             <scope>${spark-scope}</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.parquet</groupId>
-            <artifactId>parquet-column</artifactId>
+	    <artifactId>parquet-column</artifactId>
+	    <version>1.13.0</version>
             <scope>${spark-scope}</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
## Description

1. remove `org.codehaus.jackson` as it is deprecated and unsafe, replaced with databind.
2. upgrade **parquet-{hadoop, column}** to 1.13.0, which do not use `org.codehaus.jackson` anymore.

### 1. Why the change?

To pass security scan

### 2. User API changes

no

### 3. Summary of the change 

upgrade parquet and remove deprecated jackson in ppml

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

parquet-{hadoop, column} 1.13.0
