### PR TITLE
Chronos: update information about python version in installation document 

### DIFF
--- a/docs/readthedocs/source/_static/js/chronos_installation_panel.js
+++ b/docs/readthedocs/source/_static/js/chronos_installation_panel.js
@@ -109,9 +109,9 @@ function refresh_cmd(){
                             }
                             else{
                                 if(version=="nightly"){
-                                    cmd="pip install --pre --upgrade bigdl-chronos[pytorch,distributed]";
+                                    cmd="pip install --pre --upgrade bigdl-chronos-spark3[pytorch,distributed]";
                                 }else if(version=="stable"){
-                                    cmd="pip install bigdl-chronos[pytorch,distributed]";
+                                    cmd="pip install bigdl-chronos-spark3[pytorch,distributed]";
                                 }
                             }
                         }
@@ -128,9 +128,9 @@ function refresh_cmd(){
                             }
                             else{
                                 if(version=="nightly"){
-                                    cmd="pip install --pre --upgrade bigdl-chronos[pytorch,distributed,automl]";
+                                    cmd="pip install --pre --upgrade bigdl-chronos-spark3[pytorch,distributed,automl]";
                                 }else if(version=="stable"){
-                                    cmd="pip install bigdl-chronos[pytorch,distributed,automl]";
+                                    cmd="pip install bigdl-chronos-spark3[pytorch,distributed,automl]";
                                 }
                             }
                         }
@@ -149,9 +149,9 @@ function refresh_cmd(){
                             }
                             else{
                                 if(version=="nightly"){
-                                    cmd="pip install --pre --upgrade bigdl-chronos[pytorch,distributed,inference]";
+                                    cmd="pip install --pre --upgrade bigdl-chronos-spark3[pytorch,distributed,inference]";
                                 }else if(version=="stable"){
-                                    cmd="pip install bigdl-chronos[pytorch,distributed,inference]";
+                                    cmd="pip install bigdl-chronos-spark3[pytorch,distributed,inference]";
                                 }
                             }
                         }
@@ -168,9 +168,9 @@ function refresh_cmd(){
                             }
                             else{
                                 if(version=="nightly"){
-                                    cmd="pip install --pre --upgrade bigdl-chronos[pytorch,distributed,automl,inference]";
+                                    cmd="pip install --pre --upgrade bigdl-chronos-spark3[pytorch,distributed,automl,inference]";
                                 }else if(version=="stable"){
-                                    cmd="pip install bigdl-chronos[pytorch,distributed,automl,inference]";
+                                    cmd="pip install bigdl-chronos-spark3[pytorch,distributed,automl,inference]";
                                 }
                             }
                         }
@@ -191,9 +191,9 @@ function refresh_cmd(){
                             }
                             else{
                                 if(version=="nightly"){
-                                    cmd="pip install --pre --upgrade bigdl-chronos[tensorflow,distributed]";
+                                    cmd="pip install --pre --upgrade bigdl-chronos-spark3[tensorflow,distributed]";
                                 }else if(version=="stable"){
-                                    cmd="pip install bigdl-chronos[tensorflow,distributed]";
+                                    cmd="pip install bigdl-chronos-spark3[tensorflow,distributed]";
                                 }
                             }
                         }
@@ -210,9 +210,9 @@ function refresh_cmd(){
                             }
                             else{
                                 if(version=="nightly"){
-                                    cmd="pip install --pre --upgrade bigdl-chronos[tensorflow,distributed,automl]";
+                                    cmd="pip install --pre --upgrade bigdl-chronos-spark3[tensorflow,distributed,automl]";
                                 }else if(version=="stable"){
-                                    cmd="pip install bigdl-chronos[tensorflow,distributed,automl]";
+                                    cmd="pip install bigdl-chronos-spark3[tensorflow,distributed,automl]";
                                 }
                             }
                         }
@@ -231,9 +231,9 @@ function refresh_cmd(){
                             }
                             else{
                                 if(version=="nightly"){
-                                    cmd="pip install --pre --upgrade bigdl-chronos[tensorflow,distributed,inference]";
+                                    cmd="pip install --pre --upgrade bigdl-chronos-spark3[tensorflow,distributed,inference]";
                                 }else if(version=="stable"){
-                                    cmd="pip install bigdl-chronos[tensorflow,distributed,inference]";
+                                    cmd="pip install bigdl-chronos-spark3[tensorflow,distributed,inference]";
                                 }
                             }
                         }
@@ -250,9 +250,9 @@ function refresh_cmd(){
                             }
                             else{
                                 if(version=="nightly"){
-                                    cmd="pip install --pre --upgrade bigdl-chronos[tensorflow,distributed,automl,inference]";
+                                    cmd="pip install --pre --upgrade bigdl-chronos-spark3[tensorflow,distributed,automl,inference]";
                                 }else if(version=="stable"){
-                                    cmd="pip install bigdl-chronos[tensorflow,distributed,automl,inference]";
+                                    cmd="pip install bigdl-chronos-spark3[tensorflow,distributed,automl,inference]";
                                 }
                             }
                         }
@@ -282,9 +282,9 @@ function refresh_cmd(){
                             }
                         }else if(hardware=="cluster"){
                             if(version=="nightly"){
-                                cmd="pip install --pre --upgrade bigdl-chronos[distributed]; pip install prophet==1.1.0";
+                                cmd="pip install --pre --upgrade bigdl-chronos-spark3[distributed]; pip install prophet==1.1.0";
                             }else if(version=="stable"){
-                                cmd="pip install bigdl-chronos[distributed]; pip install prophet==1.1.0";
+                                cmd="pip install bigdl-chronos-spark3[distributed]; pip install prophet==1.1.0";
                             }
                         }
                     }
@@ -295,9 +295,9 @@ function refresh_cmd(){
                     else{
                         if(hardware=="singlenode"){
                             if(version=="nightly"){
-                                cmd="pip install --pre --upgrade bigdl-chronos[distributed]; pip install prophet==1.1.0";
+                                cmd="pip install --pre --upgrade bigdl-chronos-spark3[distributed]; pip install prophet==1.1.0";
                             }else if(version=="stable"){
-                                cmd="pip install bigdl-chronos[distributed]; pip install prophet==1.1.0";
+                                cmd="pip install bigdl-chronos-spark3[distributed]; pip install prophet==1.1.0";
                             }
                         }else if(hardware=="cluster"){
                             if(os=="win"){
@@ -305,9 +305,9 @@ function refresh_cmd(){
                             }
                             else{
                                 if(version=="nightly"){
-                                    cmd="pip install --pre --upgrade bigdl-chronos[distributed]; pip install prophet==1.1.0";
+                                    cmd="pip install --pre --upgrade bigdl-chronos-spark3[distributed]; pip install prophet==1.1.0";
                                 }else if(version=="stable"){
-                                    cmd="pip install bigdl-chronos[distributed]; pip install prophet==1.1.0";
+                                    cmd="pip install bigdl-chronos-spark3[distributed]; pip install prophet==1.1.0";
                                 }
                             }
                         }
@@ -335,9 +335,9 @@ function refresh_cmd(){
                             }
                         }else if(hardware=="cluster"){
                             if(version=="nightly"){
-                                cmd="pip install --pre --upgrade bigdl-chronos[distributed]; pip install prophet==1.1.0";
+                                cmd="pip install --pre --upgrade bigdl-chronos-spark3[distributed]; pip install prophet==1.1.0";
                             }else if(version=="stable"){
-                                cmd="pip install bigdl-chronos[distributed]; pip install prophet==1.1.0";
+                                cmd="pip install bigdl-chronos-spark3[distributed]; pip install prophet==1.1.0";
                             }
                         }
                     }
@@ -348,9 +348,9 @@ function refresh_cmd(){
                     else{
                         if(hardware=="singlenode"){
                             if(version=="nightly"){
-                                cmd="pip install --pre --upgrade bigdl-chronos[distributed]; pip install prophet==1.1.0";
+                                cmd="pip install --pre --upgrade bigdl-chronos-spark3[distributed]; pip install prophet==1.1.0";
                             }else if(version=="stable"){
-                                cmd="pip install bigdl-chronos[distributed]; pip install prophet==1.1.0";
+                                cmd="pip install bigdl-chronos-spark3[distributed]; pip install prophet==1.1.0";
                             }
                         }else if(hardware=="cluster"){
                             if(os=="win"){
@@ -358,9 +358,9 @@ function refresh_cmd(){
                             }
                             else{
                                 if(version=="nightly"){
-                                    cmd="pip install --pre --upgrade bigdl-chronos[distributed]; pip install prophet==1.1.0";
+                                    cmd="pip install --pre --upgrade bigdl-chronos-spark3[distributed]; pip install prophet==1.1.0";
                                 }else if(version=="stable"){
-                                    cmd="pip install bigdl-chronos[distributed]; pip install prophet==1.1.0";
+                                    cmd="pip install bigdl-chronos-spark3[distributed]; pip install prophet==1.1.0";
                                 }
                             }
                         }
@@ -382,9 +382,9 @@ function refresh_cmd(){
                         }
                         else{
                             if(version=="nightly"){
-                                cmd="pip install --pre --upgrade bigdl-chronos[distributed]; pip install pmdarima==1.8.5";
+                                cmd="pip install --pre --upgrade bigdl-chronos-spark3[distributed]; pip install pmdarima==1.8.5";
                             }else if(version=="stable"){
-                                cmd="pip install bigdl-chronos[distributed]; pip install pmdarima==1.8.5";
+                                cmd="pip install bigdl-chronos-spark3[distributed]; pip install pmdarima==1.8.5";
                             }
                         }
                     }
@@ -395,15 +395,15 @@ function refresh_cmd(){
                     else{
                         if(hardware=="singlenode"){
                             if(version=="nightly"){
-                                cmd="pip install --pre --upgrade bigdl-chronos[distributed]; pip install pmdarima==1.8.5";
+                                cmd="pip install --pre --upgrade bigdl-chronos-spark3[distributed]; pip install pmdarima==1.8.5";
                             }else if(version=="stable"){
-                                cmd="pip install bigdl-chronos[distributed]; pip install pmdarima==1.8.5";
+                                cmd="pip install bigdl-chronos-spark3[distributed]; pip install pmdarima==1.8.5";
                             }
                         }else if(hardware=="cluster"){
                             if(version=="nightly"){
-                                cmd="pip install --pre --upgrade bigdl-chronos[distributed]; pip install pmdarima==1.8.5";
+                                cmd="pip install --pre --upgrade bigdl-chronos-spark3[distributed]; pip install pmdarima==1.8.5";
                             }else if(version=="stable"){
-                                cmd="pip install bigdl-chronos[distributed]; pip install pmdarima==1.8.5";
+                                cmd="pip install bigdl-chronos-spark3[distributed]; pip install pmdarima==1.8.5";
                             }
                         }
                     } 
@@ -422,9 +422,9 @@ function refresh_cmd(){
                         }
                         else{
                             if(version=="nightly"){
-                                cmd="pip install --pre --upgrade bigdl-chronos[distributed]; pip install pmdarima==1.8.5";
+                                cmd="pip install --pre --upgrade bigdl-chronos-spark3[distributed]; pip install pmdarima==1.8.5";
                             }else if(version=="stable"){
-                                cmd="pip install bigdl-chronos[distributed]; pip install pmdarima==1.8.5";
+                                cmd="pip install bigdl-chronos-spark3[distributed]; pip install pmdarima==1.8.5";
                             }
                         }
                     }
@@ -435,15 +435,15 @@ function refresh_cmd(){
                     else{
                         if(hardware=="singlenode"){
                             if(version=="nightly"){
-                                cmd="pip install --pre --upgrade bigdl-chronos[distributed]; pip install pmdarima==1.8.5";
+                                cmd="pip install --pre --upgrade bigdl-chronos-spark3[distributed]; pip install pmdarima==1.8.5";
                             }else if(version=="stable"){
-                                cmd="pip install bigdl-chronos[distributed]; pip install pmdarima==1.8.5";
+                                cmd="pip install bigdl-chronos-spark3[distributed]; pip install pmdarima==1.8.5";
                             }
                         }else if(hardware=="cluster"){
                             if(version=="nightly"){
-                                cmd="pip install --pre --upgrade bigdl-chronos[distributed]; pip install pmdarima==1.8.5";
+                                cmd="pip install --pre --upgrade bigdl-chronos-spark3[distributed]; pip install pmdarima==1.8.5";
                             }else if(version=="stable"){
-                                cmd="pip install bigdl-chronos[distributed]; pip install pmdarima==1.8.5";
+                                cmd="pip install bigdl-chronos-spark3[distributed]; pip install pmdarima==1.8.5";
                             }
                         }
                     } 

--- a/docs/readthedocs/source/doc/Chronos/Overview/install.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/install.md
@@ -21,9 +21,9 @@
 
     **Supported Python Version**:
 
-    Chronos supports all installation options on Python 3.7.2 ~ latest 3.7.x. For details about different installation options, refer to `here <#install-using-conda>`_.
+    Chronos supports all installation options on Python 3.7 ~ 3.9. For details about different installation options, refer to `here <#install-using-conda>`_.
 
-    Moreover, ``bigdl-chronos[pytorch]``, ``bigdl-chronos[tensorflow]``, ``bigdl-chronos[automl]`` and ``bigdl-chronos[inference]`` are supported on Python 3.8.
+    But if you need to use Chronos with Python >= 3.8 in cluster, you must install `bigdl-chronos-spark3`.
 ```
 
 
@@ -120,7 +120,7 @@ Select your preferences in the panel below to find the proper install command. T
 
 ```bash
 # create a conda environment for chronos
-conda create -n my_env python=3.7 setuptools=58.0.4
+conda create -n my_env python=3.8 setuptools=58.0.4
 conda activate my_env
 
 # select your preference in above panel to find the proper command to replace the below command, e.g.

--- a/python/chronos/src/setup.py
+++ b/python/chronos/src/setup.py
@@ -67,7 +67,7 @@ def setup_package():
                         'tensorflow': ['bigdl-nano[tensorflow_27]=='+VERSION],
                         'automl': ['optuna<=2.10.1', 'configspace<=0.5.0', 'SQLAlchemy<=1.4.27'],
                         'distributed:platform_system!="Windows"': ['bigdl-orca[automl]=='+VERSION,
-                                                                   'grpcio<=1.51.1', 'pyarrow'],
+                                                                   'grpcio<=1.51.1'],
                         'inference': ['bigdl-nano[inference]==' + VERSION],
                         'all': ['bigdl-nano[pytorch]==' + VERSION,
                                 'bigdl-nano[tensorflow_27]=='+VERSION,

--- a/python/chronos/src/setup.py
+++ b/python/chronos/src/setup.py
@@ -67,7 +67,7 @@ def setup_package():
                         'tensorflow': ['bigdl-nano[tensorflow_27]=='+VERSION],
                         'automl': ['optuna<=2.10.1', 'configspace<=0.5.0', 'SQLAlchemy<=1.4.27'],
                         'distributed:platform_system!="Windows"': ['bigdl-orca[automl]=='+VERSION,
-                                                                   'grpcio<=1.51.1'],
+                                                                   'grpcio<=1.51.1', 'pyarrow'],
                         'inference': ['bigdl-nano[inference]==' + VERSION],
                         'all': ['bigdl-nano[pytorch]==' + VERSION,
                                 'bigdl-nano[tensorflow_27]=='+VERSION,


### PR DESCRIPTION
## Description

In fact, Chronos now supports all installation options on python 3.8 and python 3.9. Update related information.

### 4. How to test?
- [ ] Document test
https://binbin-doc.readthedocs.io/en/update-doc/doc/Chronos/Overview/install.html
