### PR TITLE
[Doc] Mock `prophet` as doc building failed

### DIFF
--- a/docs/readthedocs/source/conf.py
+++ b/docs/readthedocs/source/conf.py
@@ -18,7 +18,7 @@ import glob
 import shutil
 import urllib
 
-autodoc_mock_imports = ["openvino", "pytorch_lightning", "keras", "cpuinfo", "sigfig"]
+autodoc_mock_imports = ["openvino", "pytorch_lightning", "keras", "cpuinfo", "sigfig", "prophet"]
 
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, '.')


### PR DESCRIPTION
## Description

Mock `prophet` as doc building failed:  https://readthedocs.org/projects/bigdl/builds/20161263/
Also remove the requirements of `prophet` in  https://github.com/analytics-zoo/gha-cicd-env/pull/10

This PR should be merged after this pr https://github.com/analytics-zoo/gha-cicd-env/pull/10

### 4. How to test?
- [x] Document test: https://yuwentestdocs.readthedocs.io/en/doc-failure-fix/doc/PythonAPI/Chronos/forecasters.html#prophetforecaster