### PR TITLE
Nano: fix ppml related nano issues (env settings)

### DIFF
--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -36,6 +36,11 @@ function enable-perf-var {
     PERF_VAR=1
 }
 
+function enable-sgx-var {
+    echo "Option: Enable sgx specific performance variables"
+    SGX_ENABLED=1
+}
+
 function enable-dgpu-var {
     echo "Option: Enable OneAPI vars"
     ONEAPI_VAR=1
@@ -114,6 +119,7 @@ function display-help {
         echo "    -c, --disable-allocator   Use the system default allocator"
         echo "    -p, --perf                Use performance mode"
         echo "    -g, --gpu                 Enable OneAPI and other settings for dGPU support"
+        echo "    -s, --sgx                 Enable SGX specific performance variables"
         echo "    -r <num_cores>,           Force computing resource to <num_cores> CPU"
         echo "    -d, --debug               Print all internal and exported variables (for debug)"
 }
@@ -143,6 +149,7 @@ unset DISABLE_OPENMP_VAR
 unset PERF_VAR
 unset ONEAPI_VAR
 unset FORCED_CORE_NUM
+unset SGX_ENABLED
 
 # Init exported variables
 export TF_ENABLE_ONEDNN_OPTS=1
@@ -150,7 +157,7 @@ export ONEAPI_VAR=0
 
 OPTIND=1
 
-while getopts "ojhtcpgdr:-:" opt; do
+while getopts "ojhtcpgdsr:-:" opt; do
     case ${opt} in
         - )
             case "${OPTARG}" in
@@ -171,6 +178,9 @@ while getopts "ojhtcpgdr:-:" opt; do
                     ;;
                 gpu)
                     enable-dgpu-var
+                    ;;
+                sgx)
+                    enable-sgx-var
                     ;;
                 help)
                     display-help
@@ -204,6 +214,9 @@ while getopts "ojhtcpgdr:-:" opt; do
             ;;
         g )
             enable-dgpu-var
+            ;;
+        s )
+            enable-sgx-var
             ;;
         h )
             display-help
@@ -288,8 +301,12 @@ if [ "${OPENMP}" -eq 1 ]; then
         let cores_per_socket=$core_/$sockets_
         export OMP_NUM_THREADS=$core_
         export MKL_NUM_THREADS=$core_
-        export OMP_PROC_BIND="close"
-        export OMP_SCHEDULE="STATIC"
+        unset OMP_PROC_BIND  # to avoid affinity issue
+        unset OMP_SCHEDULE  # to avoid affinity issue
+        if [[ ! -z "${SGX_ENABLED:-}" ]]; then
+            export OMP_PROC_BIND="close"
+            export OMP_SCHEDULE="STATIC"
+        fi
     elif [ $OS = "macos" ]; then
         export OMP_NUM_THREADS=$(sysctl -n hw.physicalcpu)
     else

--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -113,7 +113,8 @@ function display-help {
         echo "    -t, --enable-tcmalloc     Enable tcmalloc and set related variables"
         echo "    -c, --disable-allocator   Use the system default allocator"
         echo "    -p, --perf                Use performance mode"
-        echo "    -g, --gpu                Enable OneAPI and other settings for dGPU support"
+        echo "    -g, --gpu                 Enable OneAPI and other settings for dGPU support"
+        echo "    -r <num_cores>,           Force computing resource to <num_cores> CPU"
         echo "    -d, --debug               Print all internal and exported variables (for debug)"
 }
 
@@ -141,6 +142,7 @@ unset ENABLE_TCMALLOC_VAR
 unset DISABLE_OPENMP_VAR
 unset PERF_VAR
 unset ONEAPI_VAR
+unset FORCED_CORE_NUM
 
 # Init exported variables
 export TF_ENABLE_ONEDNN_OPTS=1
@@ -148,7 +150,7 @@ export ONEAPI_VAR=0
 
 OPTIND=1
 
-while getopts "ojhtcpgd-:" opt; do
+while getopts "ojhtcpgdr:-:" opt; do
     case ${opt} in
         - )
             case "${OPTARG}" in
@@ -210,6 +212,9 @@ while getopts "ojhtcpgd-:" opt; do
         d )
             display-var
             return 0
+            ;;
+        r )
+            FORCED_CORE_NUM=${OPTARG}
             ;;
         \? )
             display-error $OPTARG
@@ -282,6 +287,8 @@ if [ "${OPENMP}" -eq 1 ]; then
         let threads_per_core=$cpu_/$core_
         let cores_per_socket=$core_/$sockets_
         export OMP_NUM_THREADS=$core_
+        export OMP_PRC_BIND="close"
+        export OMP_SCHEDULE="STATIC"
     elif [ $OS = "macos" ]; then
         export OMP_NUM_THREADS=$(sysctl -n hw.physicalcpu)
     else
@@ -298,6 +305,12 @@ if [ "${OPENMP}" -eq 1 ]; then
 
     echo "Setting KMP_BLOCKTIME..."
     export KMP_BLOCKTIME=1
+fi
+
+# Set forced core num
+if [[ ! -z "${FORCED_CORE_NUM:-}" ]]; then
+    export OMP_NUM_THREADS=$FORCED_CORE_NUM
+    export MKL_NUM_THREADS=$FORCED_CORE_NUM
 fi
 
 # Set allocator
@@ -358,6 +371,8 @@ elif [ $OS = "macos" ]; then
 fi
 echo "MALLOC_CONF           = ${MALLOC_CONF}"
 echo "OMP_NUM_THREADS       = ${OMP_NUM_THREADS}"
+echo "OMP_PRC_BIND          = ${OMP_PRC_BIND}"
+echo "OMP_SCHEDULE          = ${OMP_SCHEDULE}"
 echo "KMP_AFFINITY          = ${KMP_AFFINITY}"
 echo "KMP_BLOCKTIME         = ${KMP_BLOCKTIME}"
 echo "TF_ENABLE_ONEDNN_OPTS = ${TF_ENABLE_ONEDNN_OPTS}"

--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -287,7 +287,8 @@ if [ "${OPENMP}" -eq 1 ]; then
         let threads_per_core=$cpu_/$core_
         let cores_per_socket=$core_/$sockets_
         export OMP_NUM_THREADS=$core_
-        export OMP_PRC_BIND="close"
+        export MKL_NUM_THREADS=$core_
+        export OMP_PROC_BIND="close"
         export OMP_SCHEDULE="STATIC"
     elif [ $OS = "macos" ]; then
         export OMP_NUM_THREADS=$(sysctl -n hw.physicalcpu)
@@ -331,7 +332,7 @@ else
         echo "nano_vars.sh already exists"
     elif [ ! -f $CONDA_PREFIX/bin/bigdl-nano-init ]; then
         echo "It seems that you are using bidl-nano installed by system's pip, "
-        echo "you may need to 'source bgidl-nano-init' before using bigdl-nano "
+        echo "you may need to 'source bigdl-nano-init' before using bigdl-nano "
         echo "and 'source bigdl-nano-unset-env' after using bigdl-nano yourself"
     else
         echo "Setting environment variables in current conda env"
@@ -371,8 +372,9 @@ elif [ $OS = "macos" ]; then
 fi
 echo "MALLOC_CONF           = ${MALLOC_CONF}"
 echo "OMP_NUM_THREADS       = ${OMP_NUM_THREADS}"
-echo "OMP_PRC_BIND          = ${OMP_PRC_BIND}"
+echo "OMP_PROC_BIND         = ${OMP_PROC_BIND}"
 echo "OMP_SCHEDULE          = ${OMP_SCHEDULE}"
+echo "MKL_NUM_THREADS       = ${MKL_NUM_THREADS}"
 echo "KMP_AFFINITY          = ${KMP_AFFINITY}"
 echo "KMP_BLOCKTIME         = ${KMP_BLOCKTIME}"
 echo "TF_ENABLE_ONEDNN_OPTS = ${TF_ENABLE_ONEDNN_OPTS}"

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -42,7 +42,7 @@ lib_urls = [
     "https://github.com/analytics-zoo/jemalloc/releases/download/v5.3.0/libjemalloc.so",
     "https://github.com/analytics-zoo/jemalloc/releases/download/v5.3.0/libjemalloc.dylib",
     "https://github.com/analytics-zoo/libjpeg-turbo/releases/download/v2.1.4/libturbojpeg.so.0.2.0",
-    "https://github.com/analytics-zoo/tcmalloc/releases/download/v1/libtcmalloc.so"
+    "https://github.com/analytics-zoo/tcmalloc/releases/download/v2.10/libtcmalloc.so"
 ]
 
 


### PR DESCRIPTION
## Description

### 1. Why the change?
Three problems are raised by ppml team that nano could not bring out-of-box acceleration to sgx docker.
1. old tcmalloc brings performance downgrade
2. `OMP_PRC_BIND` and `OMP_SCHEDULE` could be set for non-intel-openmp environment
3. false cpu number detection in docker

### 2. User API changes
#### 2.1 `source bigdl-nano-init -r <core_num>`
Add a new `source bigdl-nano-init -r <core_num>` usage. This is because I found that there seems no reliable detect method for a docker container (e.g., the way to check `/sys/fs/cgroup/cpuset/cpuset.cpus` has been proved only useful for `--cpuset-cpus` on some "normal" setted machine) and users may want to use partial computing resource even on a bare metal machine.

#### 2.2 `source bigdl-nano-init -s/--sgx`
`OMP_PRC_BIND` and `OMP_SCHEDULE` are set for non-intel-openmp environment.

Here is an example usage.
```bash
(junweid-nano) cpx@cpx-3:/disk3/junweid/bug-reproduce/tcmalloc$ source bigdl-nano-init --sgx -r 5
Sourcing bigdl-nano-init in: /disk3/miniconda3/envs/junweid-nano/bin
Option: Enable sgx specific performance variables
Setting OMP_NUM_THREADS...
Setting KMP_AFFINITY...
Setting KMP_BLOCKTIME...
Setting jemalloc...
nano_vars.sh already exists
+++++ Env Variables +++++
LD_PRELOAD            = /disk3/miniconda3/envs/junweid-nano/lib/libiomp5.so /disk3/miniconda3/envs/junweid-nano/lib/python3.9/site-packages/bigdl/nano/libs/libjemalloc.so
MALLOC_CONF           = oversize_threshold:1,background_thread:false,metadata_thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1
OMP_NUM_THREADS       = 5
OMP_PROC_BIND         = close
OMP_SCHEDULE          = STATIC
MKL_NUM_THREADS       = 5
KMP_AFFINITY          = granularity=fine,none
KMP_BLOCKTIME         = 1
TF_ENABLE_ONEDNN_OPTS = 1
+++++++++++++++++++++++++
Complete.
```

### 3. Summary of the change 

1. old tcmalloc brings performance downgrade: **a new release based on gperftools 2.10 https://github.com/analytics-zoo/tcmalloc/releases/tag/v2.10 and repoint the download link to this release in setup.py.**
2. `OMP_PRC_BIND` and `OMP_SCHEDULE` could be set for non-intel-openmp environment: **this PR set these variables for `--sgx`**
3. false cpu number detection in docker: **add a `source bigdl-nano-init -r <core_num>` usage.**

### 4. How to test?
- [ ] Unit test

### 5. New dependencies
- [x] https://github.com/analytics-zoo/tcmalloc/releases/tag/v2.10
