### PR TITLE
Nano: make MKL thread setting an SGX-specific var for bigdl-nano-init

### DIFF
--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -300,7 +300,6 @@ if [ "${OPENMP}" -eq 1 ]; then
         let threads_per_core=$cpu_/$core_
         let cores_per_socket=$core_/$sockets_
         export OMP_NUM_THREADS=$core_
-        export MKL_NUM_THREADS=$core_
         unset OMP_PROC_BIND  # to avoid affinity issue
         unset OMP_SCHEDULE  # to avoid affinity issue
         if [[ ! -z "${SGX_ENABLED:-}" ]]; then
@@ -328,7 +327,6 @@ fi
 # Set forced core num
 if [[ ! -z "${FORCED_CORE_NUM:-}" ]]; then
     export OMP_NUM_THREADS=$FORCED_CORE_NUM
-    export MKL_NUM_THREADS=$FORCED_CORE_NUM
 fi
 
 # Set allocator
@@ -391,7 +389,6 @@ echo "MALLOC_CONF           = ${MALLOC_CONF}"
 echo "OMP_NUM_THREADS       = ${OMP_NUM_THREADS}"
 echo "OMP_PROC_BIND         = ${OMP_PROC_BIND}"
 echo "OMP_SCHEDULE          = ${OMP_SCHEDULE}"
-echo "MKL_NUM_THREADS       = ${MKL_NUM_THREADS}"
 echo "KMP_AFFINITY          = ${KMP_AFFINITY}"
 echo "KMP_BLOCKTIME         = ${KMP_BLOCKTIME}"
 echo "TF_ENABLE_ONEDNN_OPTS = ${TF_ENABLE_ONEDNN_OPTS}"

--- a/python/nano/scripts/bigdl-nano-init
+++ b/python/nano/scripts/bigdl-nano-init
@@ -300,9 +300,11 @@ if [ "${OPENMP}" -eq 1 ]; then
         let threads_per_core=$cpu_/$core_
         let cores_per_socket=$core_/$sockets_
         export OMP_NUM_THREADS=$core_
+        unset MKL_NUM_THREADS  # to avoid inc issue when this var is set diff with OMP_NUM_THREADS
         unset OMP_PROC_BIND  # to avoid affinity issue
         unset OMP_SCHEDULE  # to avoid affinity issue
         if [[ ! -z "${SGX_ENABLED:-}" ]]; then
+            export MKL_NUM_THREADS=$core_
             export OMP_PROC_BIND="close"
             export OMP_SCHEDULE="STATIC"
         fi
@@ -327,6 +329,9 @@ fi
 # Set forced core num
 if [[ ! -z "${FORCED_CORE_NUM:-}" ]]; then
     export OMP_NUM_THREADS=$FORCED_CORE_NUM
+    if [[ ! -z "${SGX_ENABLED:-}" ]]; then
+        export MKL_NUM_THREADS=$FORCED_CORE_NUM
+    fi
 fi
 
 # Set allocator
@@ -389,6 +394,7 @@ echo "MALLOC_CONF           = ${MALLOC_CONF}"
 echo "OMP_NUM_THREADS       = ${OMP_NUM_THREADS}"
 echo "OMP_PROC_BIND         = ${OMP_PROC_BIND}"
 echo "OMP_SCHEDULE          = ${OMP_SCHEDULE}"
+echo "MKL_NUM_THREADS       = ${MKL_NUM_THREADS}"
 echo "KMP_AFFINITY          = ${KMP_AFFINITY}"
 echo "KMP_BLOCKTIME         = ${KMP_BLOCKTIME}"
 echo "TF_ENABLE_ONEDNN_OPTS = ${TF_ENABLE_ONEDNN_OPTS}"


### PR DESCRIPTION
## Description
It seems that INC reads this variable and may cause some problem when it comes to a conflict setting between `OMP_NUM_THREADS` and `MKL_NUM_THREADS`.

Since its perfectly enough to set `OMP_NUM_THREADS` only for most of the cases, so I make`MKL_NUM_THREADS` an SGX-specific var for now. @gc-fu 

```bash
>>> source bigdl-nano-init
+++++ Env Variables +++++
LD_PRELOAD            = /disk3/miniconda3/envs/junweid-nano/lib/libiomp5.so /disk3/miniconda3/envs/junweid-nano/lib/python3.9/site-packages/bigdl/nano/libs/libjemalloc.so
MALLOC_CONF           = oversize_threshold:1,background_thread:false,metadata_thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1
OMP_NUM_THREADS       = 112
OMP_PROC_BIND         = 
OMP_SCHEDULE          = 
MKL_NUM_THREADS       = 
KMP_AFFINITY          = granularity=fine,none
KMP_BLOCKTIME         = 1
TF_ENABLE_ONEDNN_OPTS = 1
+++++++++++++++++++++++++

>>> source bigdl-nano-init --sgx
+++++ Env Variables +++++
LD_PRELOAD            = /disk3/miniconda3/envs/junweid-nano/lib/libiomp5.so /disk3/miniconda3/envs/junweid-nano/lib/python3.9/site-packages/bigdl/nano/libs/libjemalloc.so
MALLOC_CONF           = oversize_threshold:1,background_thread:false,metadata_thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1
OMP_NUM_THREADS       = 112
OMP_PROC_BIND         = close
OMP_SCHEDULE          = STATIC
MKL_NUM_THREADS       = 112
KMP_AFFINITY          = granularity=fine,none
KMP_BLOCKTIME         = 1
TF_ENABLE_ONEDNN_OPTS = 1
+++++++++++++++++++++++++

>>> source bigdl-nano-init --sgx -r 5
+++++ Env Variables +++++
LD_PRELOAD            = /disk3/miniconda3/envs/junweid-nano/lib/libiomp5.so /disk3/miniconda3/envs/junweid-nano/lib/python3.9/site-packages/bigdl/nano/libs/libjemalloc.so
MALLOC_CONF           = oversize_threshold:1,background_thread:false,metadata_thp:always,dirty_decay_ms:-1,muzzy_decay_ms:-1
OMP_NUM_THREADS       = 5
OMP_PROC_BIND         = close
OMP_SCHEDULE          = STATIC
MKL_NUM_THREADS       = 5
KMP_AFFINITY          = granularity=fine,none
KMP_BLOCKTIME         = 1
TF_ENABLE_ONEDNN_OPTS = 1
+++++++++++++++++++++++++
```