### PR TITLE
[Nano] Upgrade python to 3.8

### DIFF
--- a/.github/workflows/nano-nightly-test.yml
+++ b/.github/workflows/nano-nightly-test.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v3
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9"]
+        python-version: ["3.8", "3.9"]
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/nano_howto_guides_tests.yml
+++ b/.github/workflows/nano_howto_guides_tests.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.7"]
+        python-version: ["3.8"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -47,7 +47,7 @@ jobs:
       - name: Run unit tests for Inference PyTorch how-to guides
         shell: bash
         run: |
-          $CONDA/bin/conda create -n howto-guides-inference-pytorch -y python==3.7.10 setuptools=58.0.4
+          $CONDA/bin/conda create -n howto-guides-inference-pytorch -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate howto-guides-inference-pytorch
           $CONDA/bin/conda info
           bash python/nano/dev/build_and_install.sh linux default false pytorch,inference
@@ -63,7 +63,7 @@ jobs:
       - name: Run unit tests for Training PyTorch how-to guides
         shell: bash
         run: |
-          $CONDA/bin/conda create -n howto-guides-training-pytorch -y python==3.7.10 setuptools=58.0.4
+          $CONDA/bin/conda create -n howto-guides-training-pytorch -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate howto-guides-training-pytorch
           $CONDA/bin/conda info
           bash python/nano/dev/build_and_install.sh linux default false pytorch
@@ -79,7 +79,7 @@ jobs:
       - name: Run unit tests for Training PyTorch Lightning how-to guides
         shell: bash
         run: |
-          $CONDA/bin/conda create -n howto-guides-training-pytorch-lightning -y python==3.7.10 setuptools=58.0.4
+          $CONDA/bin/conda create -n howto-guides-training-pytorch-lightning -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate howto-guides-training-pytorch-lightning
           $CONDA/bin/conda info
           bash python/nano/dev/build_and_install.sh linux default false pytorch
@@ -98,7 +98,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.7"]
+        python-version: ["3.8"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -117,7 +117,7 @@ jobs:
       - name: Run unit tests for Inference TensorFlow how-to guides
         shell: bash
         run: |
-          $CONDA/bin/conda create -n howto-guides-inference-tensorflow -y python==3.7.10 setuptools=58.0.4
+          $CONDA/bin/conda create -n howto-guides-inference-tensorflow -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate howto-guides-inference-tensorflow
           $CONDA/bin/conda info
           bash python/nano/dev/build_and_install.sh linux default false tensorflow,inference
@@ -133,7 +133,7 @@ jobs:
       - name: Run unit tests for Training TensorFlow how-to guides
         shell: bash
         run: |
-          $CONDA/bin/conda create -n howto-guides-training-tensorflow -y python==3.7.10 setuptools=58.0.4
+          $CONDA/bin/conda create -n howto-guides-training-tensorflow -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate howto-guides-training-tensorflow
           $CONDA/bin/conda info
           bash python/nano/dev/build_and_install.sh linux default false tensorflow
@@ -154,7 +154,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.7"]
+        python-version: ["3.8"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -173,7 +173,7 @@ jobs:
       - name: Run unit tests for Inference OpenVINO how-to guides
         shell: bash
         run: |
-            $CONDA/bin/conda create -n howto-guides-inference-openvino -y python==3.7.10 setuptools=58.0.4
+            $CONDA/bin/conda create -n howto-guides-inference-openvino -y python==3.8.16 setuptools=58.0.4
             source $CONDA/bin/activate howto-guides-inference-openvino
             $CONDA/bin/conda info
             bash python/nano/dev/build_and_install.sh linux default false basic

--- a/.github/workflows/nano_howto_guides_tests.yml
+++ b/.github/workflows/nano_howto_guides_tests.yml
@@ -140,7 +140,9 @@ jobs:
           source bigdl-nano-init
           pip install pytest nbmake
           pip install ipykernel==5.5.6
-          pip install tensorflow-datasets
+          pip install tensorflow-datasets==4.4.0
+          pip install protobuf==3.19.5
+          pip install tensorflow-metadata==1.13.0
           bash python/nano/tutorial/notebook/training/tensorflow/run-nano-howto-guides-training-tensorflow-tests.sh
           source $CONDA/bin/deactivate
           $CONDA/bin/conda remove -n howto-guides-training-tensorflow --all

--- a/.github/workflows/nano_notebooks_tests.yml
+++ b/.github/workflows/nano_notebooks_tests.yml
@@ -29,7 +29,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.7"]
+        python-version: ["3.8"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -48,7 +48,7 @@ jobs:
       - name: Run cifar10 notebooks PyTorch unit tests
         shell: bash
         run: |
-            $CONDA/bin/conda create -n notebooks-trainer-pytorch -y python==3.7.10 setuptools=58.0.4
+            $CONDA/bin/conda create -n notebooks-trainer-pytorch -y python==3.8.16 setuptools=58.0.4
             source $CONDA/bin/activate notebooks-trainer-pytorch
             $CONDA/bin/conda info
             bash python/nano/dev/build_and_install.sh linux default false pytorch,inference
@@ -64,7 +64,7 @@ jobs:
       - name: Run tutorial notebooks Pytorch unit tests
         shell: bash
         run: |
-            $CONDA/bin/conda create -n notebooks-tutorial-pytorch -y python==3.7.10 setuptools=58.0.4
+            $CONDA/bin/conda create -n notebooks-tutorial-pytorch -y python==3.8.16 setuptools=58.0.4
             source $CONDA/bin/activate notebooks-tutorial-pytorch
             $CONDA/bin/conda info
             bash python/nano/dev/build_and_install.sh linux default false pytorch,inference
@@ -83,14 +83,14 @@ jobs:
       - name: Run tutorial notebooks Pytorch unit tests(OpenVINO)
         shell: bash
         run: |
-            $CONDA/bin/conda create -n notebooks-tutorial-pytorch -y python==3.7.10 setuptools=58.0.4
+            $CONDA/bin/conda create -n notebooks-tutorial-pytorch -y python==3.8.16 setuptools=58.0.4
             source $CONDA/bin/activate notebooks-tutorial-pytorch
             $CONDA/bin/conda info
             bash python/nano/dev/build_and_install.sh linux default false pytorch
             source bigdl-nano-init
             pip install pytest nbmake
             pip install ipykernel==5.5.6
-            pip install openvino-dev==2022.2.0
+            pip install openvino-dev==2022.3.0
             bash python/nano/notebooks/pytorch/tutorial/run-nano-notebooks-pytorch-tutorial-tests.sh true
             bash python/nano/tutorial/inference/pytorch/run_nano_pytorch_inference_tests_openvino.sh
             source $CONDA/bin/deactivate
@@ -101,7 +101,7 @@ jobs:
       - name: Run tutorial notebooks Pytorch unit tests(JIT+IPEX)
         shell: bash
         run: |
-            $CONDA/bin/conda create -n notebooks-tutorial-pytorch -y python==3.7.10 setuptools=58.0.4
+            $CONDA/bin/conda create -n notebooks-tutorial-pytorch -y python==3.8.16 setuptools=58.0.4
             source $CONDA/bin/activate notebooks-tutorial-pytorch
             $CONDA/bin/conda info
             bash python/nano/dev/build_and_install.sh linux default false pytorch
@@ -115,14 +115,14 @@ jobs:
       - name: Run realworld notebooks Pytorch unit tests(OpenVINO)
         shell: bash
         run: |
-            $CONDA/bin/conda create -n notebooks-tutorial-pytorch -y python==3.7.10 setuptools=58.0.4
+            $CONDA/bin/conda create -n notebooks-tutorial-pytorch -y python==3.8.16 setuptools=58.0.4
             source $CONDA/bin/activate notebooks-tutorial-pytorch
             $CONDA/bin/conda info
             bash python/nano/dev/build_and_install.sh linux default false pytorch
             source bigdl-nano-init
             pip install pytest nbmake
             pip install ipykernel==5.5.6
-            pip install openvino-dev==2022.2.0
+            pip install openvino-dev==2022.3.0
             pip install matplotlib
             bash python/nano/notebooks/pytorch/openvino/run-nano-notebooks-pytorch-openvino-tests.sh
             source $CONDA/bin/deactivate
@@ -137,7 +137,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.7"]
+        python-version: ["3.8"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -155,7 +155,7 @@ jobs:
 
       - name: Run TensorFlow Example
         run: |
-          $CONDA/bin/conda create -n example-tensorflow -y python==3.7.10 setuptools=58.0.4
+          $CONDA/bin/conda create -n example-tensorflow -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate example-tensorflow
           bash python/nano/dev/build_and_install.sh linux default false tensorflow,inference
           pip install tensorflow-datasets
@@ -172,7 +172,7 @@ jobs:
       - name: Run tutorial notebooks TensorFlow unit tests
         shell: bash
         run: |
-            $CONDA/bin/conda create -n notebooks-tutorial-tensorflow -y python==3.7.10 setuptools=58.0.4
+            $CONDA/bin/conda create -n notebooks-tutorial-tensorflow -y python==3.8.16 setuptools=58.0.4
             source $CONDA/bin/activate notebooks-tutorial-tensorflow
             $CONDA/bin/conda info
             bash python/nano/dev/build_and_install.sh linux default false tensorflow,inference
@@ -193,7 +193,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.7"]
+        python-version: ["3.8"]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -212,12 +212,12 @@ jobs:
       - name: Run tutorial notebooks OpenVINO unit tests
         shell: bash
         run: |
-            $CONDA/bin/conda create -n notebooks-tutorial-openvino -y python==3.7.10 setuptools=58.0.4
+            $CONDA/bin/conda create -n notebooks-tutorial-openvino -y python==3.8.16 setuptools=58.0.4
             source $CONDA/bin/activate notebooks-tutorial-openvino
             $CONDA/bin/conda info
             bash python/nano/dev/build_and_install.sh linux default false basic
             source bigdl-nano-init
-            pip install openvino-dev==2022.2.0
+            pip install openvino-dev==2022.3.0
             bash python/nano/tutorial/inference/openvino/run_nano_openvino_inference_tests.sh
             source $CONDA/bin/deactivate
             $CONDA/bin/conda remove -n notebooks-tutorial-openvino --all

--- a/.github/workflows/nano_notebooks_tests.yml
+++ b/.github/workflows/nano_notebooks_tests.yml
@@ -158,7 +158,9 @@ jobs:
           $CONDA/bin/conda create -n example-tensorflow -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate example-tensorflow
           bash python/nano/dev/build_and_install.sh linux default false tensorflow,inference
-          pip install tensorflow-datasets
+          pip install tensorflow-datasets==4.4.0
+          pip install protobuf==3.19.5
+          pip install tensorflow-metadata==1.13.0
           source bigdl-nano-init
           bash python/nano/tutorial/training/tensorflow/run-nano-tensorflow-test.sh
           bash python/nano/tutorial/inference/tensorflow/run_nano_tf_quantization_inference_tests.sh
@@ -179,7 +181,9 @@ jobs:
             source bigdl-nano-init
             pip install pytest nbmake
             pip install jupyter nbconvert
-            pip install tensorflow-datasets
+            pip install tensorflow-datasets==4.4.0
+            pip install protobuf==3.19.5
+            pip install tensorflow-metadata==1.13.0
             bash python/nano/notebooks/tensorflow/tutorial/run-nano-notebooks-tensorflow-tutorial-tests.sh
             source $CONDA/bin/deactivate
             $CONDA/bin/conda remove -n notebooks-tutorial-tensorflow --all

--- a/.github/workflows/nano_unit_tests_basic.yml
+++ b/.github/workflows/nano_unit_tests_basic.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.7"]
+        python-version: ["3.8"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -43,7 +43,7 @@ jobs:
       - name: Run Nano-init test
         shell: bash
         run: |
-          $CONDA/bin/conda create -n bigdl-init -y python==3.7.10 setuptools==58.0.4
+          $CONDA/bin/conda create -n bigdl-init -y python==3.8.16 setuptools==58.0.4
           source $CONDA/bin/activate bigdl-init
           $CONDA/bin/conda info
           bash python/nano/dev/build_and_install.sh linux default false basic
@@ -74,7 +74,7 @@ jobs:
       - name: Run Basic unit tests (OpenVINO)
         shell: bash
         run: |
-          $CONDA/bin/conda create -n openvino-basic -y python==3.7.10 setuptools=58.0.4
+          $CONDA/bin/conda create -n openvino-basic -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate openvino-basic
           $CONDA/bin/conda info
           bash python/nano/dev/build_and_install.sh linux default false basic

--- a/.github/workflows/nano_unit_tests_tensorflow.yml
+++ b/.github/workflows/nano_unit_tests_tensorflow.yml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: ["ubuntu-20.04"]
-        python-version: ["3.7"]
+        python-version: ["3.8"]
         tf-version: [
           "tensorflow_27",
           "tensorflow_28",
@@ -58,7 +58,7 @@ jobs:
       - name: Run TensorFlow unit tests (train)
         shell: bash
         run: |
-          $CONDA/bin/conda create -n nano-tensorflow -y python==3.7.10
+          $CONDA/bin/conda create -n nano-tensorflow -y python==3.8.16
           source $CONDA/bin/activate nano-tensorflow
           $CONDA/bin/conda info
           if [ ! -z "${{matrix.tf-version}}" ]; then
@@ -75,7 +75,7 @@ jobs:
       - name: Run TensorFlow unit tests (inference)
         shell: bash
         run: |
-          $CONDA/bin/conda create -n nano-tensorflow -y python==3.7.10
+          $CONDA/bin/conda create -n nano-tensorflow -y python==3.8.16
           source $CONDA/bin/activate nano-tensorflow
           $CONDA/bin/conda info
           if [ ! -z "${{matrix.tf-version}}" ]; then
@@ -119,7 +119,7 @@ jobs:
       - name: Run TensorFlow unit tests (Horovod)
         shell: bash
         run: |
-          $CONDA/bin/conda create -n horovod-tf -y python==3.7.10 setuptools=58.0.4
+          $CONDA/bin/conda create -n horovod-tf -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate horovod-tf
           $CONDA/bin/conda info
           if [ ! -z "${{matrix.tf-version}}" ]; then
@@ -137,7 +137,7 @@ jobs:
       - name: Run TensorFlow unit tests (Ray)
         shell: bash
         run: |
-          $CONDA/bin/conda create -n ray-tf -y python==3.7.10 setuptools=58.0.4
+          $CONDA/bin/conda create -n ray-tf -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate ray-tf
           $CONDA/bin/conda info
           if [ ! -z "${{matrix.tf-version}}" ]; then
@@ -157,7 +157,7 @@ jobs:
       - name: Run TensorFlow unit tests (Automl)
         shell: bash
         run: |
-          $CONDA/bin/conda create -n nano-automl-tf -y python==3.7.10 setuptools=58.0.4
+          $CONDA/bin/conda create -n nano-automl-tf -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate nano-automl-tf
           $CONDA/bin/conda info
           if [ ! -z "${{matrix.tf-version}}" ]; then
@@ -177,7 +177,7 @@ jobs:
       - name: Run TensorFlow unit tests (INC)
         shell: bash
         run: |
-          $CONDA/bin/conda create -n inc-tf -y python==3.7.10 setuptools=58.0.4
+          $CONDA/bin/conda create -n inc-tf -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate inc-tf
           $CONDA/bin/conda info
           if [ ! -z "${{matrix.tf-version}}" ]; then
@@ -194,7 +194,7 @@ jobs:
       - name: Run tensorflow unit tests (OpenVINO)
         shell: bash
         run: |
-          $CONDA/bin/conda create -n openvino-tensorflow -y python==3.7.10 setuptools=58.0.4
+          $CONDA/bin/conda create -n openvino-tensorflow -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate openvino-tensorflow
           $CONDA/bin/conda info
           if [ ! -z "${{matrix.tf-version}}" ]; then
@@ -211,7 +211,7 @@ jobs:
       - name: Run tensorflow unit tests (ONNX)
         shell: bash
         run: |
-          $CONDA/bin/conda create -n onnx-tensorflow -y python==3.7.10 setuptools=58.0.4
+          $CONDA/bin/conda create -n onnx-tensorflow -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate onnx-tensorflow
           $CONDA/bin/conda info
           if [ ! -z "${{matrix.tf-version}}" ]; then

--- a/.github/workflows/performance-regression-test.yml
+++ b/.github/workflows/performance-regression-test.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: '3.7'
+          python-version: '3.8'
 
       - name: Install dependencies
         run: |

--- a/docs/readthedocs/source/doc/Nano/Overview/install.md
+++ b/docs/readthedocs/source/doc/Nano/Overview/install.md
@@ -77,7 +77,7 @@ In a pure pip environment, you need to run `source bigdl-nano-init` every time y
 We support a wide range of PyTorch and Tensorflow. We only care the MAJOR.MINOR in [Semantic Versioning](https://semver.org/). If you have a specific PyTorch/Tensorflow version want to use, e.g. PyTorch 1.11.0+cpu, you may select corresponding MAJOR.MINOR (i.e., PyTorch 1.11 in this case) and install PyTorch again after installing nano.
 
 ## Python Version
-`bigdl-nano` is validated on Python 3.7-3.9.
+`bigdl-nano` is validated on Python 3.8-3.9.
 
 
 ## Operating System


### PR DESCRIPTION
## Description

Upgrade python version from 3.7.10 to 3.8.16 in all Nano action tests and update related installation doc.

### 1. Why the change?

Start from torch2.0, python 3.7 is not supported anymore. So we should upgrade to python 3.8 as 3.7 is too old and will be deprecated soon.

### 2. User API changes

No change.

### 3. Summary of the change 

- Upgrade python version from 3.7.10 to 3.8.16 in all Nano action tests
- Update related installation doc
- upgrade python version in [performance test](https://github.com/intel-analytics/BigDL/blob/86231d9b96212550ee0773ffcf8f4af50be25289/.github/workflows/performance-regression-test.yml#L30) and [nano nightly test](https://github.com/intel-analytics/BigDL/blob/86231d9b96212550ee0773ffcf8f4af50be25289/.github/workflows/nano-nightly-test.yml#L31)

### 4. How to test?
- [x] Unit test

Note:
now pytorch-lightning 1.6.4 requires `protobuf<3.20`, however, tensorflow-datasets requires `protobuf>=3.20`.
We may upgrade protobuf after we upgrade pytorch-lightning.
