### PR TITLE
Increase client TCPStore timeout to support big model in Pytorch Pyspark Estimator training

### DIFF
--- a/python/orca/src/bigdl/orca/learn/pytorch/core/lifecycle.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/core/lifecycle.py
@@ -68,7 +68,8 @@ class LifeCycle(metaclass=ABCMeta):
                         world_size):
         """A runner will contain `rank`, `backend` and `size` after setup_torch_distribute."""
         import torch.distributed as dist
-        client_store = dist.TCPStore(tcp_store_host, tcp_store_port, -1, False)
+        client_store = dist.TCPStore(tcp_store_host, tcp_store_port, -1, False,
+                                     timeout=dist.constants.default_pg_timeout)
         dist.init_process_group(
             backend="gloo",
             store=client_store,


### PR DESCRIPTION
Increase client TCPStore timeout to support big model in Pytorch Pyspark Estimator training.

Related issue: https://github.com/intel-analytics/BigDL/issues/8151
