### PR TITLE
[ORCA] Support custom objects with tf2 pyspark estimator (none model_creator)

### DIFF
--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -639,12 +639,12 @@ class SparkTFEstimator():
 
         """
         sc = OrcaContext.get_spark_context()
-        self.load_params = dict( # type:ignore
+        self.load_params = dict(  # type:ignore
             filepath=filepath,
             custom_objects=custom_objects,
             compile=compile
         )
-        model = load_model(**self.load_params) # type:ignore
+        model = load_model(**self.load_params)  # type:ignore
         self.model_weights = model.get_weights()
         if model.optimizer is not None:
             self.optimizer_weights = model.optimizer.get_weights()
@@ -669,7 +669,7 @@ class SparkTFEstimator():
             model = self.model_creator(self.config)
         else:
             if self.load_params is not None:
-                model = load_model(**self.load_params) # type:ignore
+                model = load_model(**self.load_params)  # type:ignore
             else:
                 invalidInputError(False,
                                   "Please load a saved model when model_creator is None.")

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -88,6 +88,7 @@ class SparkTFEstimator():
         self.model_weights = None
         self.optimizer_weights = None
         self.load_path = None
+        self.load_params = None
 
         if "batch_size" in self.config:
             invalidInputError(False,

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -668,7 +668,11 @@ class SparkTFEstimator():
         if self.model_creator is not None:
             model = self.model_creator(self.config)
         else:
-            model = load_model(**self.load_params) # type:ignore
+            if self.load_params is not None:
+                model = load_model(**self.load_params) # type:ignore
+            else:
+                invalidInputError(False,
+                                  "Please load a saved model when model_creator is None.")
 
         if set_weights:
             if self.optimizer_weights is not None:

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -201,7 +201,9 @@ class SparkTFEstimator():
             driver_ip=self.ip,
             driver_port=self.port
         )
-        init_params.update(self.load_params)
+
+        if self.load_params is not None:
+            init_params.update(self.load_params)
 
         params = dict(
             epochs=epochs,
@@ -358,7 +360,9 @@ class SparkTFEstimator():
             driver_ip=self.ip,
             driver_port=self.port
         )
-        init_params.update(self.load_params)
+
+        if self.load_params is not None:
+            init_params.update(self.load_params)
 
         params = dict(
             batch_size=batch_size,
@@ -450,7 +454,9 @@ class SparkTFEstimator():
             driver_ip=self.ip,
             driver_port=self.port
         )
-        init_params.update(self.load_params)
+
+        if self.load_params is not None:
+            init_params.update(self.load_params)
 
         params = dict(
             verbose=verbose,

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -200,6 +200,7 @@ class SparkTFEstimator():
             driver_ip=self.ip,
             driver_port=self.port
         )
+        init_params.update(self.load_params)
 
         params = dict(
             epochs=epochs,
@@ -356,6 +357,7 @@ class SparkTFEstimator():
             driver_ip=self.ip,
             driver_port=self.port
         )
+        init_params.update(self.load_params)
 
         params = dict(
             batch_size=batch_size,
@@ -447,6 +449,7 @@ class SparkTFEstimator():
             driver_ip=self.ip,
             driver_port=self.port
         )
+        init_params.update(self.load_params)
 
         params = dict(
             verbose=verbose,

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -639,12 +639,12 @@ class SparkTFEstimator():
 
         """
         sc = OrcaContext.get_spark_context()
-        self.load_params = dict(
+        self.load_params = dict( # type:ignore
             filepath=filepath,
             custom_objects=custom_objects,
             compile=compile
         )
-        model = load_model(**self.load_params)
+        model = load_model(**self.load_params) # type:ignore
         self.model_weights = model.get_weights()
         if model.optimizer is not None:
             self.optimizer_weights = model.optimizer.get_weights()
@@ -668,7 +668,7 @@ class SparkTFEstimator():
         if self.model_creator is not None:
             model = self.model_creator(self.config)
         else:
-            model = load_model(**self.load_params)
+            model = load_model(**self.load_params) # type:ignore
 
         if set_weights:
             if self.optimizer_weights is not None:

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -297,7 +297,7 @@ class SparkRunner:
                 self.setup_local(self.custom_objects, self.compile)
         else:
             # create local model for predict
-            self.setup_local(self.custom_object, self.compile)
+            self.setup_local(self.custom_objects, self.compile)
 
     def setup(self):
         import tensorflow as tf

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -312,7 +312,8 @@ class SparkRunner:
         if self.model_creator is not None:
             self.model = self.model_creator(self.config)
         else:
-            self.model = tf.keras.models.load_model(self.model_load, self.custom_objects,
+            self.model = tf.keras.models.load_model(self.model_load,
+                                                    self.custom_objects,
                                                     self.compile)
         if self.model_weights:
             self.model.set_weights(self.model_weights.value)

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -294,10 +294,10 @@ class SparkRunner:
                         if self.model_weights:
                             self.model.set_weights(self.model_weights.value)
             else:
-                self.setup_local(self.custom_objects, self.compile)
+                self.setup_local()
         else:
             # create local model for predict
-            self.setup_local(self.custom_objects, self.compile)
+            self.setup_local()
 
     def setup(self):
         import tensorflow as tf
@@ -306,13 +306,14 @@ class SparkRunner:
         os.environ["KMP_BLOCKING_TIME"] = self.config.get("KMP_BLOCKING_TIME",
                                                           os.environ.get("KMP_BLOCKING_TIME", "0"))
 
-    def setup_local(self, custom_objects, compile):
+    def setup_local(self):
         self.size = 1
         self.rank = 0
         if self.model_creator is not None:
             self.model = self.model_creator(self.config)
         else:
-            self.model = tf.keras.models.load_model(self.model_load, custom_objects, compile)
+            self.model = tf.keras.models.load_model(self.model_load, self.custom_objects,
+                                                    self.compile)
         if self.model_weights:
             self.model.set_weights(self.model_weights.value)
         from tensorflow.python.distribute import distribution_strategy_context as ds_context

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -202,6 +202,7 @@ class SparkRunner:
                  need_to_log_to_driver=False,
                  driver_ip=None,
                  driver_port=None,
+                 filepath=None,
                  custom_objects=None,
                  compile=True
                  ):
@@ -477,7 +478,9 @@ class SparkRunner:
             if self.model_creator is not None:
                 local_model = self.model_creator(self.config)
             else:
-                local_model = tf.keras.models.load_model(self.model_load)
+                local_model = tf.keras.models.load_model(self.model_load,
+                                                         self.custom_objects,
+                                                         self.compile)
             if self.model_weights:
                 local_model = local_model.set_weights(self.model_weights.value)
             results = local_model.evaluate(dataset, **params)

--- a/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/spark_runner.py
@@ -306,13 +306,13 @@ class SparkRunner:
         os.environ["KMP_BLOCKING_TIME"] = self.config.get("KMP_BLOCKING_TIME",
                                                           os.environ.get("KMP_BLOCKING_TIME", "0"))
 
-    def setup_local(self, custom_object, compile):
+    def setup_local(self, custom_objects, compile):
         self.size = 1
         self.rank = 0
         if self.model_creator is not None:
             self.model = self.model_creator(self.config)
         else:
-            self.model = tf.keras.models.load_model(self.model_load, custom_object, compile)
+            self.model = tf.keras.models.load_model(self.model_load, custom_objects, compile)
         if self.model_weights:
             self.model.set_weights(self.model_weights.value)
         from tensorflow.python.distribute import distribution_strategy_context as ds_context


### PR DESCRIPTION
## Description
Fix and update for https://github.com/intel-analytics/BigDL/issues/8138.

### 1. Why the change?
In some cases, we may need to support users in specifying tf load model parameters, including `custom objects` and `compile`, which were not available in the previous version.

### 2. User API changes
For the new usage:
```python
estimator = Estimator.from_keras(backend="spark")
estimator.load(trained_model_path, custom_object=None, compile=False)
```

### 3. Summary of the change 
Support users to specify more load model params when calling `estimator.load( )` with none model_creator.

### 4. How to test?
- [x] Unit test
- [x] Test on Yarn

