### PR TITLE
Dllib: add `import subprocess` in spark.py

### DIFF
--- a/python/dllib/src/bigdl/dllib/utils/spark.py
+++ b/python/dllib/src/bigdl/dllib/utils/spark.py
@@ -157,6 +157,8 @@ class SparkRunner:
                                    conf=None,
                                    jars=None,
                                    py_files=None):
+        import subprocess        
+
         print("Initializing job for yarn-cluster mode")
         executor_python_env = "python_env"
         os.environ["HADOOP_CONF_DIR"] = hadoop_conf
@@ -344,6 +346,8 @@ class SparkRunner:
                           conf=None,
                           jars=None,
                           python_location=None):
+        import subprocess
+
         print("Initializing SparkContext for k8s-client mode")
         executor_python_env = "python_env"
         os.environ["PYSPARK_PYTHON"] = "{}/bin/python".format(executor_python_env)

--- a/python/dllib/src/bigdl/dllib/utils/spark.py
+++ b/python/dllib/src/bigdl/dllib/utils/spark.py
@@ -157,7 +157,7 @@ class SparkRunner:
                                    conf=None,
                                    jars=None,
                                    py_files=None):
-        import subprocess        
+        import subprocess
 
         print("Initializing job for yarn-cluster mode")
         executor_python_env = "python_env"
@@ -346,8 +346,6 @@ class SparkRunner:
                           conf=None,
                           jars=None,
                           python_location=None):
-        import subprocess
-
         print("Initializing SparkContext for k8s-client mode")
         executor_python_env = "python_env"
         os.environ["PYSPARK_PYTHON"] = "{}/bin/python".format(executor_python_env)
@@ -412,6 +410,8 @@ class SparkRunner:
                                   conf=None,
                                   jars=None,
                                   python_location=None):
+        import subprocess
+
         print("Initializing SparkContext for k8s-cluster mode")
         executor_python_env = "python_env"
 


### PR DESCRIPTION
## Description


### 1. Why the change?

Test on k8s cluster mode failed:
```python
Traceback (most recent call last):
  File "/bigdl/nfsdata/yinchen/pytorch_train_spark_dataframe.py", line 31, in <module>
    init_orca(args.cluster_mode, extra_python_lib="process_spark_dataframe.py,"
  File "/bigdl/nfsdata/yinchen/utils.py", line 97, in init_orca
    sc = init_orca_context(cluster_mode="k8s-cluster",
  File "/usr/local/envs/py38/lib/python3.8/site-packages/bigdl/orca/common.py", line 311, in init_orca_context
    sc = init_spark_on_k8s_cluster(master=kwargs["master"],
  File "/usr/local/envs/py38/lib/python3.8/site-packages/bigdl/dllib/nncontext.py", line 406, in init_spark_on_k8s_cluster
    return_value = runner.init_spark_on_k8s_cluster(
  File "/usr/local/envs/py38/lib/python3.8/site-packages/bigdl/dllib/utils/spark.py", line 454, in init_spark_on_k8s_cluster
    return_value = subprocess.run(submit_command_list)
NameError: name 'subprocess' is not defined
```

add the import at the beginning of the two functions
previous pr: https://github.com/intel-analytics/BigDL/pull/8018

### 2. How to test?

- [x] test on k8s-cluster
- [x] test on yarn-cluster
