### PR TITLE
Reduce SGX EPC of trusted-dl-serving and manually_build_for_testing tests

### DIFF
--- a/.github/workflows/manually_build_for_testing.yml
+++ b/.github/workflows/manually_build_for_testing.yml
@@ -131,7 +131,7 @@ jobs:
           --build-arg http_proxy=${HTTP_PROXY} \
           --build-arg https_proxy=${HTTPS_PROXY} \
           --build-arg no_proxy=${NO_PROXY} \
-          --build-arg SGX_MEM_SIZE=16G \
+          --build-arg SGX_MEM_SIZE=8G \
           --build-arg SGX_LOG_LEVEL=error \
           --build-arg BASE_IMAGE_NAME=${base_image} \
           --build-arg BASE_IMAGE_TAG=${TAG} \

--- a/ppml/trusted-dl-serving/ref/Dockerfile
+++ b/ppml/trusted-dl-serving/ref/Dockerfile
@@ -4,7 +4,7 @@ ARG BASE_IMAGE_TAG
 # stage 1. generate SGX secrets and prepare KMS env
 FROM $BASE_IMAGE_NAME:$BASE_IMAGE_TAG as temp
 
-ARG SGX_MEM_SIZE     16G 
+ARG SGX_MEM_SIZE     8G
 ARG SGX_LOG_LEVEL    error
 
 ADD ./enclave-key.pem /root/.config/gramine/enclave-key.pem


### PR DESCRIPTION
## Description

Reduce EPCM.

### 1. Why the change?

To exclude the influence of EPCM.
