### PR TITLE
[Nano] Support python 3.10 in nightly test

### DIFF
--- a/.github/actions/nano/setup-pytorch-env/action.yml
+++ b/.github/actions/nano/setup-pytorch-env/action.yml
@@ -81,7 +81,7 @@ runs:
 
         # required by Ray test
         pip install google-api-core==2.8.2
-        pip install ray[default]==1.11.0 prometheus_client==0.13.0
+        pip install ray[default]==1.13.0 prometheus_client==0.13.0
 
         # required by Automl test
         pip install ConfigSpace optuna

--- a/.github/actions/nano/setup-tensorflow-env/action.yml
+++ b/.github/actions/nano/setup-tensorflow-env/action.yml
@@ -79,7 +79,7 @@ runs:
 
         # required by Ray test
         pip install google-api-core==2.8.2
-        pip install ray[default]==1.11.0 prometheus_client==0.13.0
+        pip install ray[default]==1.13.0 prometheus_client==0.13.0
 
         # required by Automl test
         pip install ConfigSpace optuna

--- a/.github/workflows/nano-nightly-test.yml
+++ b/.github/workflows/nano-nightly-test.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v3
@@ -61,7 +61,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - uses: actions/checkout@v3

--- a/docs/readthedocs/source/doc/Nano/Overview/install.md
+++ b/docs/readthedocs/source/doc/Nano/Overview/install.md
@@ -77,7 +77,7 @@ In a pure pip environment, you need to run `source bigdl-nano-init` every time y
 We support a wide range of PyTorch and Tensorflow. We only care the MAJOR.MINOR in [Semantic Versioning](https://semver.org/). If you have a specific PyTorch/Tensorflow version want to use, e.g. PyTorch 1.11.0+cpu, you may select corresponding MAJOR.MINOR (i.e., PyTorch 1.11 in this case) and install PyTorch again after installing nano.
 
 ## Python Version
-`bigdl-nano` is validated on Python 3.8-3.9.
+`bigdl-nano` is validated on Python 3.8-3.10.
 
 
 ## Operating System

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -167,10 +167,7 @@ def setup_package():
 
     inference_requires = ["onnx==1.12.0",
                           "onnxruntime==1.12.1",
-                          "onnxruntime-extensions==0.4.2; platform_system!='Darwin' and \
-                          python_full_version<'3.10.0'",
-                          "onnxruntime-extensions==0.7.0; platform_system!='Darwin' and \
-                          python_full_version>='3.10.0'",
+                          "onnxruntime-extensions==0.7.0; platform_system!='Darwin'",
                           "onnxruntime-extensions==0.3.1; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
                           platform_system=='Darwin'",
                           "openvino-dev==2022.3.0",

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -167,7 +167,10 @@ def setup_package():
 
     inference_requires = ["onnx==1.12.0",
                           "onnxruntime==1.12.1",
-                          "onnxruntime-extensions==0.4.2; platform_system!='Darwin'",
+                          "onnxruntime-extensions==0.4.2; platform_system!='Darwin' and \
+                          python_full_version<'3.10.0'",
+                          "onnxruntime-extensions==0.7.0; platform_system!='Darwin' and \
+                          python_full_version>='3.10.0'",
                           "onnxruntime-extensions==0.3.1; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
                           platform_system=='Darwin'",
                           "openvino-dev==2022.3.0",

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantization.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantization.py
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 from typing import Callable
-from collections import Iterable
+from collections.abc import Iterable
 from bigdl.nano.utils.common import invalidInputError
 from ..core import BaseQuantization
 from .utils import _check_loader


### PR DESCRIPTION
## Description

Support python 3.10 in nightly test and installation doc

### 1. Why the change?

To support python 3.10 for Nano

### 2. User API changes

None

### 3. Summary of the change 

- Support python 3.10 in nightly test and installation doc
- upgrade onnxruntime-extensions to 0.7.0 in setup 
- upgrade ray to 1.13.0 in workflow
- change to `from collections.abc import Iterable`

### 4. How to test?
- [x] Unit test

