### PR TITLE
[Nano] Revert reshape if compile failed

### DIFF
--- a/python/nano/src/bigdl/nano/deps/openvino/core/model.py
+++ b/python/nano/src/bigdl/nano/deps/openvino/core/model.py
@@ -174,6 +174,7 @@ class OpenVINOModel:
                 success = False
                 error_msg = f"Failed to reshape this model. Error message: \n {str(e)}"
                 if self._infer_request:
+                    print(error_msg)
                     return success, error_msg
                 else:
                     error_msg += "\nCompile the original model instead."
@@ -186,6 +187,8 @@ class OpenVINOModel:
             error_msg = f"Failed to compile the reshaped model. Error message: \n {str(e)}"
             invalidOperationError(self._infer_request is not None, error_msg)
             # Reshape to the original shapes
+            print(error_msg)
+            print("Revert the reshaping process.")
             self.ie_network.reshape(origin_shapes)
 
         return success, error_msg

--- a/python/nano/test/openvino/pytorch/test_openvino.py
+++ b/python/nano/test/openvino/pytorch/test_openvino.py
@@ -640,9 +640,11 @@ class TestOpenVINO(TestCase):
             assert (second_load_end - second_load_start) < (first_load_end - first_load_start)
 
             # Reshape failed, should not recompile
-            new_model.reshape("sample[1,4,64,64],encoder_hidden_states[1,12,10]")
+            success, error_msg = new_model.reshape("sample[1,4,64,64],encoder_hidden_states[1,12,10]")
             reshape_end = datetime.utcnow()
             new_model_inputs = {i.any_name: i.shape for i in new_model.ov_model.ie_network.inputs}
+            assert not success
+            assert "Failed to reshape this model." in error_msg
             assert list(new_model_inputs["sample"]) == [2, 4, 8, 8]
             assert list(new_model_inputs["encoder_hidden_states"]) == [2, 12, 10]
             assert (reshape_end - second_load_end).total_seconds() * 1000 < 50


### PR DESCRIPTION
## Description

If reshape success but fails to compile, the user cannot reshape to the same size again since the network has already reshaped to the specific size.

### 1. Why the change?

Fix this bug.

### 2. User API changes

Now the reshape function will return reshape status: success, and the error_msg if reshape failed.

### 3. Summary of the change 

1. Revert the reshaping process if compile failed.
2. Return success status and error message.

### 4. How to test?
- [ ] Unit test
