### PR TITLE
Refine orchestrate-tdxvm.sh

### DIFF
--- a/ppml/tdx/tdx-vm/README.md
+++ b/ppml/tdx/tdx-vm/README.md
@@ -24,10 +24,10 @@ To deploy an actual workload with TDX-VM, you need to prepare the environment fi
     The Verify TDX Host Status section provides guidance on how to verify whether TDX is initializing on the host. Refer to [Getting_Started_External.pdf (2023ww01)](https://ubit-artifactory-or.intel.com/artifactory/linuxcloudstacks-or-local/tdx-stack/tdx-2023ww01/Getting_Started_External.pdf)
 
 5. Launch TD Guests
-    It is time to launch TD guests. Execute `./scripts/orchestrate-tdxvm.sh` to launch multiple tdvms based on images ppml provided.
+    It is time to launch TD guests. Execute `./scripts/orchestrate-tdxvm.sh <Number of VMs> <Absolute path to store kernel & image>` to launch multiple tdxvms. You can edit orchestrate-tdxvm.sh to specify memory, vcpus, sockets, threads, and cores.
     
 6. Deploy Kubernetes cluster on tdvms
-    Execute `./scripts/install-k8s-components.sh <Number of VMs> <Absolute path to store kernel & image>` on each tdvm and `./scripts/deploy-k8s-cluster.sh` on master node to get a Kubernetes cluster. 
+    Execute `./scripts/install-k8s-components.sh` on each tdvm and `./scripts/deploy-k8s-cluster.sh` on master node to get a Kubernetes cluster. 
 
 
 ## Run Sparkpi as Spark Local Mode

--- a/ppml/tdx/tdx-vm/README.md
+++ b/ppml/tdx/tdx-vm/README.md
@@ -27,7 +27,7 @@ To deploy an actual workload with TDX-VM, you need to prepare the environment fi
     It is time to launch TD guests. Execute `./scripts/orchestrate-tdxvm.sh` to launch multiple tdvms based on images ppml provided.
     
 6. Deploy Kubernetes cluster on tdvms
-    Execute `./scripts/install-k8s-components.sh` on each tdvm and `./scripts/deploy-k8s-cluster.sh` on master node to get a Kubernetes cluster. 
+    Execute `./scripts/install-k8s-components.sh <Number of VMs> <Absolute path to store kernel & image>` on each tdvm and `./scripts/deploy-k8s-cluster.sh` on master node to get a Kubernetes cluster. 
 
 
 ## Run Sparkpi as Spark Local Mode

--- a/ppml/tdx/tdx-vm/scripts/orchestrate-tdxvm.sh
+++ b/ppml/tdx/tdx-vm/scripts/orchestrate-tdxvm.sh
@@ -1,72 +1,92 @@
 #!/bin/bash
 
+num_of_vms=$1
+dir=$2
+memory=500
+vcpus=180
+sockets=2
+threads=2
+cores=45
+
+### destroy tdx vms if exists
+
+echo destroy existing vms
+for ((i=1; i<=$num_of_vms; i++)); do 
+  virsh destroy tdvm$i
+  virsh undefine tdvm$i --nvram
+done
+
+virsh list --all
+
+
 ### download guest_image, kernel and tdx.xml
-cd ~
-mkdir ~/tdx-vm
+rm -rf $dir
+mkdir -p $dir
 
 echo downloading ubuntu guest image: td-guest-ubuntu-22.04.qcow2.tar.xz
-wget http://td_guest_url/td-guest-ubuntu-22.04.qcow2.tar.xz -O ~/tdx-vm/td-guest-ubuntu-22.04.qcow2.tar.xz
+wget https://ubit-artifactory-or.intel.com/artifactory/linuxcloudstacks-or-local/tdx-stack/tdx-2022ww44/guest-images/td-guest-ubuntu-22.04.qcow2.tar.xz -O $dir/td-guest-ubuntu-22.04.qcow2.tar.xz
 
 echo extract td-guest-ubuntu-22.04.qcow2.tar.xz
-tar -xvf ~/tdx-vm/td-guest-ubuntu-22.04.qcow2.tar.xz -C ~/tdx-vm
+tar -xvf $dir/td-guest-ubuntu-22.04.qcow2.tar.xz -C $dir
 
 echo downloading guest kernel: vmlinuz-jammy
-wget http://td_guest_url/vmlinuz-jammy -O ~/tdx-vm/vmlinuz-jammy
+wget https://ubit-artifactory-or.intel.com/artifactory/linuxcloudstacks-or-local/tdx-stack/tdx-2022ww44/guest-images/vmlinuz-jammy -O $dir/vmlinuz-jammy
 
 echo downloading tdx.xml
-wget http://td_guest_url/tdx.xml -O ~/tdx-vm/tdx.xml
+wget https://raw.githubusercontent.com/intel/tdx-tools/2022ww44/doc/tdx_libvirt_direct.ubuntu.xml.template -O $dir/tdx.xml
 
-echo destroy vms
-virsh destroy tdvm1
-virsh destroy tdvm2
-virsh destroy tdvm3
-virsh undefine tdvm1
-virsh undefine tdvm2
-virsh undefine tdvm3
+cp /usr/share/qemu/OVMF_VARS.fd $dir/OVMF_VARS.fd
 
-rm -rf ~/tdx-vm/vm1
-rm -rf ~/tdx-vm/vm2
-rm -rf ~/tdx-vm/vm3
-mkdir -p ~/tdx-vm/vm1
-mkdir -p ~/tdx-vm/vm2
-mkdir -p ~/tdx-vm/vm3
+### update tdx.xml
 
-cp ~/tdx-vm/td-guest-ubuntu-22.04.qcow2 ~/tdx-vm/vm1/
-cp ~/tdx-vm/td-guest-ubuntu-22.04.qcow2 ~/tdx-vm/vm2/
-cp ~/tdx-vm/td-guest-ubuntu-22.04.qcow2 ~/tdx-vm/vm3/
+# Set distro related parameters according to distro
+DISTRO=$(grep -w 'NAME' /etc/os-release)
+if [[ "$DISTRO" =~ .*"Ubuntu".* ]]; then
+    QEMU_EXEC="/usr/bin/qemu-system-x86_64"
+else
+    QEMU_EXEC="/usr/libexec/qemu-kvm"
+fi
 
-cp ~/tdx-vm/vmlinuz-jammy ~/tdx-vm/vm1/
-cp ~/tdx-vm/vmlinuz-jammy ~/tdx-vm/vm2/
-cp ~/tdx-vm/vmlinuz-jammy ~/tdx-vm/vm3/
+sed -i "s#<emulator>/usr/bin/qemu-system-x86_64</emulator>#<emulator>$QEMU_EXEC</emulator>#g" $dir/tdx.xml
 
-cp /usr/share/qemu/OVMF.fd ~/tdx-vm/vm1/
-cp /usr/share/qemu/OVMF.fd ~/tdx-vm/vm2/
-cp /usr/share/qemu/OVMF.fd ~/tdx-vm/vm3/
 
-cp ~/tdx-vm/tdx.xml ~/tdx-vm/vm1/
-cp ~/tdx-vm/tdx.xml ~/tdx-vm/vm2/
-cp ~/tdx-vm/tdx.xml ~/tdx-vm/vm3/
+# Set network
+sed -i ':a;N;$!ba;s#<interface type="user">\n.*<model type="virtio"/>\n.*</interface>#placeholder#g' tdx.xml
 
-echo updating tdx.xml
-sed -i "s#<name>td-guest-ubuntu-22.04</name>#<name>tdvm1</name>#g" /root/tdx-vm/vm1/tdx.xml
-sed -i "s#<loader>/path/to/OVMF.fd</loader>#<loader>/root/tdx-vm/vm1/OVMF.fd</loader>#g" /root/tdx-vm/vm1/tdx.xml
-sed -i "s#<kernel>/path/to/vmlinuz</kernel>#<kernel>/root/tdx-vm/vm1/vmlinuz-jammy</kernel>#g" /root/tdx-vm/vm1/tdx.xml
-sed -i "s#<source file='/path/to/td-guest-ubuntu-22.04.qcow2'/>#<source file='/root/tdx-vm/vm1/td-guest-ubuntu-22.04.qcow2'/>#g" /root/tdx-vm/vm1/tdx.xml
-sed -i "s#<name>td-guest-ubuntu-22.04</name>#<name>tdvm2</name>#g" /root/tdx-vm/vm2/tdx.xml
-sed -i "s#<loader>/path/to/OVMF.fd</loader>#<loader>/root/tdx-vm/vm2/OVMF.fd</loader>#g" /root/tdx-vm/vm2/tdx.xml
-sed -i "s#<kernel>/path/to/vmlinuz</kernel>#<kernel>/root/tdx-vm/vm2/vmlinuz-jammy</kernel>#g" /root/tdx-vm/vm2/tdx.xml
-sed -i "s#<source file='/path/to/td-guest-ubuntu-22.04.qcow2'/>#<source file='/root/tdx-vm/vm2/td-guest-ubuntu-22.04.qcow2'/>#g" /root/tdx-vm/vm2/tdx.xml
-sed -i "s#<name>td-guest-ubuntu-22.04</name>#<name>tdvm3</name>#g" /root/tdx-vm/vm3/tdx.xml
-sed -i "s#<loader>/path/to/OVMF.fd</loader>#<loader>/root/tdx-vm/vm3/OVMF.fd</loader>#g" /root/tdx-vm/vm3/tdx.xml
-sed -i "s#<kernel>/path/to/vmlinuz</kernel>#<kernel>/root/tdx-vm/vm3/vmlinuz-jammy</kernel>#g" /root/tdx-vm/vm3/tdx.xml
-sed -i "s#<source file='/path/to/td-guest-ubuntu-22.04.qcow2'/>#<source file='/root/tdx-vm/vm3/td-guest-ubuntu-22.04.qcow2'/>#g" /root/tdx-vm/vm3/tdx.xml
+sed -i 's/placeholder/<interface type="bridge"> \
+      <source bridge="virbr0"\/>\
+      <model type="virtio"\/>\
+      <driver name="vhost"\/>\
+    <\/interface>/' tdx.xml
 
+
+### prepare guest image, kernel, bios and tdx.xml for each VM
+echo prepare guest image, kernel, bios and tdx.xml
+for ((i=1; i<=$num_of_vms; i++)); do
+  rm -rf $dir/vm$i
+  mkdir -p $dir/vm$i
+  cp $dir/td-guest-ubuntu-22.04.qcow2 $dir/vm$i/
+  cp $dir/vmlinuz-jammy $dir/vm$i/
+  cp /usr/share/qemu/OVMF_VARS.fd $dir/vm$i/
+  cp $dir/tdx.xml $dir/vm$i/
+
+  sed -i "s#<memory unit='KiB'>2097152</memory>#<memory unit='GB'>$memory</memory>#g" $dir/vm$i/tdx.xml
+  sed -i "s#<vcpu placement='static'>1</vcpu>#<vcpu placement='static'>$vcpus</vcpu>#g" $dir/vm$i/tdx.xml
+  sed -i "s#<topology sockets='1' cores='1' threads='1'/>#<topology sockets='$sockets' cores='$cores' threads='$threads'/>#g" $dir/vm$i/tdx.xml
+  sed -i "s#<name>td-guest-ubuntu-22.04</name>#<name>tdvm$i</name>#g" $dir/vm$i/tdx.xml
+  sed -i "s#/path/to/OVMF_VARS.fd#$dir/vm$i/OVMF_VARS.fd#g" $dir/vm$i/tdx.xml
+  sed -i "s#<kernel>/path/to/vmlinuz</kernel>#<kernel>$dir/vm$i/vmlinuz-jammy</kernel>#g" $dir/vm$i/tdx.xml
+  sed -i "s#<source file='/path/to/td-guest-ubuntu-22.04.qcow2'/>#<source file='$dir/vm$i/td-guest-ubuntu-22.04.qcow2'/>#g" $dir/vm$i/tdx.xml
+
+done
+
+
+### launch tdx vms
 
 echo launch vms
-virsh define ~/tdx-vm/vm1/tdx.xml
-virsh define ~/tdx-vm/vm2/tdx.xml
-virsh define ~/tdx-vm/vm3/tdx.xml
+for ((i=1; i<=$num_of_vms; i++)); do
+  virsh define $dir/vm$i/tdx.xml
+  virsh start tdvm$i
+done
 
-virsh start tdvm1
-virsh start tdvm2
-virsh start tdvm3
+virsh list --all


### PR DESCRIPTION
This submission refines orchestrate-tdxvm.sh to let the user specify how many VMs they need.