### PR TITLE
Orca: enhance shard cache logic

### DIFF
--- a/python/orca/src/bigdl/orca/data/shard.py
+++ b/python/orca/src/bigdl/orca/data/shard.py
@@ -166,7 +166,7 @@ class SparkXShards(XShards):
                  transient: bool = False,
                  class_name: Optional[str] = None) -> None:
         self.rdd = rdd
-        self.user_caching = self.rdd.is_cached()
+        self.user_caching = self.rdd.is_cached
         if transient:
             self.eager = False
         else:

--- a/python/orca/src/bigdl/orca/data/shard.py
+++ b/python/orca/src/bigdl/orca/data/shard.py
@@ -277,7 +277,7 @@ class SparkXShards(XShards):
         try:
             if self.is_cached():
                 self.rdd.unpersist()
-        except Exception:
+        except (Py4JError, TypeError):
             pass
         return self
 

--- a/python/orca/src/bigdl/orca/data/shard.py
+++ b/python/orca/src/bigdl/orca/data/shard.py
@@ -166,7 +166,7 @@ class SparkXShards(XShards):
                  transient: bool = False,
                  class_name: Optional[str] = None) -> None:
         self.rdd = rdd
-        self.user_caching = False
+        self.user_caching = self.rdd.is_cached()
         if transient:
             self.eager = False
         else:
@@ -274,11 +274,11 @@ class SparkXShards(XShards):
         :return:
         """
         self.user_caching = False
-        if self.is_cached():
-            try:
+        try:
+            if self.is_cached():
                 self.rdd.unpersist()
-            except Py4JError:
-                print("Try to unpersist an uncached rdd")
+        except Exception:
+            pass
         return self
 
     def _uncache(self) -> None:
@@ -835,7 +835,7 @@ class SparkXShards(XShards):
         return self
 
     def __del__(self):
-        self.uncache()
+        self._uncache()
 
     def __getitem__(self, key: str) -> "SparkXShards":
         def get_data(data):


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

1. To fix the [`TypeError: 'NoneType' object is not callable when run TF2 Estimator`](https://github.com/intel-analytics/BigDL/issues/6838). 
2. Enhance the shard cache logic.

### 2. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

1. Init `SparkXshards.user_caching` with `rdd.is_cached`, as it's possible that the rdd is already cached by user
2. User api `uncache()` will first try to access `self.rdd` by querying `self.rdd.is_cached`
    + If it's not reachable, namely the rdd does not exist or has been destroyed by spark, then catch the exception **(All kind of exceptions? or just Py4jError+TypeError?)**
    + If reachable, call `rdd.unpersist()` to uncache
3. `__del__` will call `_uncache()`, meaning that SparkXshards only uncaches automatically if the rdd is not cached by user

### 3. How to test?
- [x] Unit test
- [x] Test on yarn
- [x] Test on k8s
- [x] Test on Local
No other kind of exceptions found up to now.
