### PR TITLE
Only mount necessary etc files to Occlum

### DIFF
--- a/ppml/trusted-big-data-ml/scala/docker-occlum/production/run_spark_on_occlum_glibc.sh
+++ b/ppml/trusted-big-data-ml/scala/docker-occlum/production/run_spark_on_occlum_glibc.sh
@@ -66,7 +66,7 @@ init_instance() {
         echo "${edit_json}" > Occlum.json
     fi
 
-    edit_json="$(cat Occlum.json | jq '.mount+=[{"target": "/etc","type": "hostfs","source": "/etc"}]')" && \
+    edit_json="$(cat Occlum.json | jq '.mount+=[{"target": "/etc/ssl/certs","type": "hostfs","source": "/etc/ssl/certs"}]')" && \
     echo "${edit_json}" > Occlum.json
 
     if [[ -z "$SGX_MEM_SIZE" ]]; then


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

There is no need mount the whole `/etc` directory to Occlum with hostfs mount which is not safe.
