### PR TITLE
[Chronos]: multi-process training batch_size check 

### DIFF
--- a/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
@@ -147,6 +147,7 @@ class LSTMForecaster(BasePytorchForecaster):
         self.metrics = metrics
         self.seed = seed
         self.has_bn = False
+
         # nano setting
         current_num_threads = torch.get_num_threads()
         self.thread_num = current_num_threads

--- a/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/lstm_forecaster.py
@@ -146,7 +146,7 @@ class LSTMForecaster(BasePytorchForecaster):
         self.lr = lr
         self.metrics = metrics
         self.seed = seed
-
+        self.has_bn = False
         # nano setting
         current_num_threads = torch.get_num_threads()
         self.thread_num = current_num_threads

--- a/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/nbeats_forecaster.py
@@ -154,6 +154,7 @@ class NBeatsForecaster(BasePytorchForecaster):
         self.lr = lr
         self.seed = seed
         self.metrics = metrics
+        self.has_bn = False
 
         # nano settings
         current_num_threads = torch.get_num_threads()

--- a/python/chronos/src/bigdl/chronos/forecaster/seq2seq_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/seq2seq_forecaster.py
@@ -150,6 +150,7 @@ class Seq2SeqForecaster(BasePytorchForecaster):
         self.lr = lr
         self.metrics = metrics
         self.seed = seed
+        self.has_bn = False
 
         # nano setting
         current_num_threads = torch.get_num_threads()

--- a/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
+++ b/python/chronos/src/bigdl/chronos/forecaster/tcn_forecaster.py
@@ -170,6 +170,7 @@ class TCNForecaster(BasePytorchForecaster):
         self.lr = lr
         self.metrics = metrics
         self.seed = seed
+        self.has_bn = not dummy_encoder
 
         # nano setting
         current_num_threads = torch.get_num_threads()


### PR DESCRIPTION
## Description
Add batch sample number detect before multi-process training to avoid too small sample num make the training result has big inaccuracy.

### Summary of the change
* add `has_bn` attribution for pytorch forecast to indicate if the class have batch_normalize function
* add batch_size check before multi-process training
