### PR TITLE
[Nano] Update ipex to 2.0.1 for nano and restore ipex related tests

### DIFF
--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -120,7 +120,7 @@ def setup_package():
     # ipex is only avaliable for linux now
     pytorch_20_requires = ["torch==2.0.0",
                            "torchvision==0.15.1",
-                           "intel_extension_for_pytorch==2.0.0;platform_system=='Linux'"]
+                           "intel_extension_for_pytorch==2.0.100;platform_system=='Linux'"]
 
     pytorch_113_requires = ["torch==1.13.1",
                             "torchvision==0.14.1",

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -591,7 +591,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                  logging: bool = True,
                  inplace: bool = False,
                  weights_prepack: Optional[bool] = None,
-                 enable_onednn: bool = True,
+                 enable_onednn: bool = False,
                  q_config=None,
                  output_tensors: bool = True,
                  example_kwarg_inputs=None,
@@ -722,7 +722,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                 parameter to ``False``.
         :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph API,
                               which provides a flexible API for aggressive fusion. Default to
-                              ``True``, only valid when accelerator='jit', otherwise will
+                              ``False``, only valid when accelerator='jit', otherwise will
                               be ignored. For more details, please refer https://github.com/
                               pytorch/pytorch/tree/master/torch/csrc/jit/codegen/
                               onednn#pytorch---onednn-graph-api-bridge.
@@ -1029,7 +1029,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
               logging: bool = True,
               inplace: bool = False,
               weights_prepack: Optional[bool] = None,
-              enable_onednn: bool = True,
+              enable_onednn: bool = False,
               output_tensors: bool = True,
               strict_check: bool = True,
               example_kwarg_inputs=None,
@@ -1099,7 +1099,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                                 parameter to ``False``.
         :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph API,
                               which provides a flexible API for aggressive fusion. Default to
-                              ``True``, only valid when accelerator='jit', otherwise will be
+                              ``False``, only valid when accelerator='jit', otherwise will be
                               ignored. For more details, please refer https://github.com/pytorch/
                               pytorch/tree/master/torch/csrc/jit/codegen/
                               onednn#pytorch---onednn-graph-api-bridge.

--- a/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
+++ b/python/nano/test/pytorch/tests/inference/test_bf16_ipex.py
@@ -498,19 +498,10 @@ class Pytorch1_11:
 TORCH_VERSION_CLS = Pytorch1_11
 
 
-class CaseWithoutAVX2:
-    def test_placeholder(self):
-        pass
-
-
 if not _avx512_checker():
     print("IPEX Inference Model Without AVX512")
     print("IPEX BF16 Inference Model Without AVX512")
     TORCH_VERSION_CLS = CaseWithoutAVX512
-if not TORCH_VERSION_LESS_2_0 and not _avx2_checker():
-    print("IPEX BF16 Inference Model Without AVX2")
-    # Intel® Extension for PyTorch* only works on machines with instruction sets equal or newer than AVX2
-    TORCH_VERSION_CLS = CaseWithoutAVX2
 
 
 class TestIPEXBF16(TORCH_VERSION_CLS, TestCase):

--- a/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
@@ -630,8 +630,9 @@ class InferencePipeline:
         model = CannotCopyNet()
         ipex_model = inference_opt.trace(model, input_sample=self.train_loader, use_ipex=True, inplace=True)
 
-        inference_opt.save(ipex_model, "ipex")
-        ipex_model = inference_opt.load("ipex", model, inplace=True)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            inference_opt.save(ipex_model, tmpdir)
+            ipex_model = inference_opt.load(tmpdir, model, inplace=True)
 
     def test_multi_context_manager(self):
         inference_opt = InferenceOptimizer()

--- a/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
@@ -20,6 +20,7 @@ from torch import nn
 import tempfile
 from unittest import TestCase
 import pytest
+import operator
 import torchvision.transforms as transforms
 from bigdl.nano.pytorch import Trainer
 from bigdl.nano.pytorch import InferenceOptimizer
@@ -620,6 +621,8 @@ class InferencePipeline:
         with InferenceOptimizer.get_context(model):
             pass
 
+    @pytest.mark.skipif(compare_version('intel_extension_for_pytorch', operator.ge, '2.0.100+cpu'),
+                        reason="inplace ipex optimization will lose weight of model")
     def test_inplace(self):
         class CannotCopyNet(Net):
             def __deepcopy__(self, memo):

--- a/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
+++ b/python/nano/test/pytorch/tests/inference/test_inference_optimizer.py
@@ -940,17 +940,6 @@ class InferencePipeline:
 TORCH_CLS = InferencePipeline
 
 
-class CaseWithoutAVX2:
-    def test_placeholder(self):
-        pass
-
-
-if not TORCH_VERSION_LESS_2_0 and not _avx2_checker():
-    print("Inference Optimizer Without AVX2")
-    # Intel® Extension for PyTorch* only works on machines with instruction sets equal or newer than AVX2
-    TORCH_CLS = CaseWithoutAVX2
-
-
 class TestInferencePipeline(TORCH_CLS, TestCase):
     pass
 

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -58,6 +58,7 @@ class MultipleInputNet(nn.Module):
     def forward(self, x1, x2):
         return self.dense1(x1) + self.dense2(x2)
 
+
 class DummyMultiInputModel(nn.Module):
     """
     A simple model for test various inputs of channels last format
@@ -452,7 +453,8 @@ class IPEXJITInference:
         model = InferenceOptimizer.trace(net,
                                          accelerator='jit',
                                          use_ipex=True,
-                                         calib_data=dataloader)
+                                         calib_data=dataloader,
+                                         enable_onednn=False)
         with InferenceOptimizer.get_context(model):
             model(x1, x2)
             # test keyword argument

--- a/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
+++ b/python/nano/test/pytorch/tests/inference/test_ipex_jit_inference.py
@@ -716,18 +716,9 @@ class IPEXJITInference:
         np.testing.assert_allclose(output2.detach().numpy(), output1.detach().numpy(), atol=1e-5)
 
 
-class CaseWithoutAVX2:
-    def test_placeholder(self):
-        pass
-
-
 TORCH_VERSION_CLS = IPEXJITInference
 if TORCH_VERSION_LESS_1_10:
     print("IPEX Inference Model Without AVX512")
-    TORCH_VERSION_CLS = CaseWithoutAVX2
-if not TORCH_VERSION_LESS_2_0 and not _avx2_checker():
-    print("IPEX Inference Model Without AVX2")
-    # Intel® Extension for PyTorch* only works on machines with instruction sets equal or newer than AVX2
     TORCH_VERSION_CLS = CaseWithoutAVX2
 
 

--- a/python/nano/test/pytorch/tests/train/torch_nano/test_torch_nano_ipex.py
+++ b/python/nano/test/pytorch/tests/train/torch_nano/test_torch_nano_ipex.py
@@ -188,17 +188,6 @@ class Lite:
 TORCH_CLS = Lite
 
 
-class CaseWithoutAVX2:
-    def test_placeholder(self):
-        pass
-
-
-if not TORCH_VERSION_LESS_2_0 and not _avx2_checker():
-    print("Torch_nano IPEX Without AVX2")
-    # Intel® Extension for PyTorch* only works on machines with instruction sets equal or newer than AVX2
-    TORCH_CLS = CaseWithoutAVX2
-
-
 class TestLite(TORCH_CLS, TestCase):
     pass
 

--- a/python/nano/test/pytorch/tests/train/trainer/test_plugin_ipex.py
+++ b/python/nano/test/pytorch/tests/train/trainer/test_plugin_ipex.py
@@ -88,6 +88,17 @@ class Plugin:
 TORCH_CLS = Plugin
 
 
+class CasePT2:
+    def test_placeholder(self):
+        pass
+
+
+if not TORCH_VERSION_LESS_2_0:
+    print("Trainer Plugin with torch 2.0")
+    # TODO: after we upgrade version of pytorch lightning, we can remove this part
+    TORCH_CLS = CasePT2
+
+
 class TestPlugin(TORCH_CLS, TestCase):
     pass
 

--- a/python/nano/test/pytorch/tests/train/trainer/test_plugin_ipex.py
+++ b/python/nano/test/pytorch/tests/train/trainer/test_plugin_ipex.py
@@ -88,17 +88,6 @@ class Plugin:
 TORCH_CLS = Plugin
 
 
-class CaseWithoutAVX2:
-    def test_placeholder(self):
-        pass
-
-
-if not TORCH_VERSION_LESS_2_0 and not _avx2_checker():
-    print("Plugin IPEX Without AVX2")
-    # Intel® Extension for PyTorch* only works on machines with instruction sets equal or newer than AVX2
-    TORCH_CLS = CaseWithoutAVX2
-
-
 class TestPlugin(TORCH_CLS, TestCase):
     pass
 

--- a/python/nano/test/pytorch/tests/train/trainer/test_trainer_ipex.py
+++ b/python/nano/test/pytorch/tests/train/trainer/test_trainer_ipex.py
@@ -130,17 +130,6 @@ class PLTrainer:
 TORCH_CLS = PLTrainer
 
 
-class CaseWithoutAVX2:
-    def test_placeholder(self):
-        pass
-
-
-if not TORCH_VERSION_LESS_2_0 and not _avx2_checker():
-    print("Trainer IPEX Without AVX2")
-    # Intel® Extension for PyTorch* only works on machines with instruction sets equal or newer than AVX2
-    TORCH_CLS = CaseWithoutAVX2
-
-
 class TestTrainer(TORCH_CLS, TestCase):
     pass
 

--- a/python/nano/test/pytorch/tests/train/trainer/test_trainer_ipex.py
+++ b/python/nano/test/pytorch/tests/train/trainer/test_trainer_ipex.py
@@ -130,6 +130,17 @@ class PLTrainer:
 TORCH_CLS = PLTrainer
 
 
+class CasePT2:
+    def test_placeholder(self):
+        pass
+
+
+if not TORCH_VERSION_LESS_2_0:
+    print("Trainer IPEX with Torch 2.0")
+    # TODO: after we upgrade version of pytorch lightning, we can remove this part
+    TORCH_CLS = CasePT2
+
+
 class TestTrainer(TORCH_CLS, TestCase):
     pass
 


### PR DESCRIPTION
## Description

Update ipex to 2.0.100 for Nano and restore ipex related tests

### 1. Why the change?

Follow up of https://github.com/intel-analytics/BigDL/pull/8017.
As ipex 2.0.1 has fixed  strange AVX2 behaviour in runner, we can upgrade to ipex 2.0.1 and restore ipex related tests.
![image](https://github.com/intel-analytics/BigDL/assets/105281011/b76d7157-34e4-4479-acb1-5215064eca70)


### 2. User API changes

- Change default value of  `enable_onednn` to False

### 3. Summary of the change 

- Update ipex to 2.0.100 for Nano and restore ipex related tests
- Set default value of `enable_onednn` to False as some known issue and it will cause `RuntimeError: bad optional access` when torch=2.0 & use jit & input contain kwargs
- Jump the inplace UT as a new found issue of ipex 2.0.100 that it will lose weight of model during inplace optimization, has reported related issue to ipex team
### 4. How to test?
- [x] Unit test

