### PR TITLE
Chronos: fix SDL error of Dockerfile

### DIFF
--- a/docker/chronos-nightly/Dockerfile
+++ b/docker/chronos-nightly/Dockerfile
@@ -37,9 +37,9 @@ ARG inference=n
 #            y (for yes) or n (default, for no)
 ARG extra_dep=n
 
-ADD ./docker/chronos-nightly/install-python-env.sh /opt
-ADD ./python/chronos/colab-notebook /opt/work/colab-notebook
-ADD ./python/chronos/use-case/AIOps /opt/work/use-case/AIOps
+COPY ./docker/chronos-nightly/install-python-env.sh /opt
+COPY ./python/chronos/colab-notebook /opt/work/colab-notebook
+COPY ./python/chronos/use-case/AIOps /opt/work/use-case/AIOps
 RUN chmod a+x /opt/install-python-env.sh
 
 RUN apt-get update && \


### PR DESCRIPTION
## Description

Modify Chronos Dockerfile, replace `ADD` with `COPY`, because error in hadolint:
```bash
Use COPY instead of ADD for files and folders
```