### PR TITLE
[Friesian] Serving dockerfile fix some SDL issues

### DIFF
--- a/docker/friesian-serving/Dockerfile
+++ b/docker/friesian-serving/Dockerfile
@@ -35,11 +35,11 @@ RUN apt-get update --fix-missing && \
     rm -f ${SPARK_HOME}/jars/log4j-1.2.17.jar && \
     rm -f ${SPARK_HOME}/jars/slf4j-log4j12-1.7.16.jar && \
     rm -f ${SPARK_HOME}/jars/apache-log4j-extras-1.2.17.jar && \
-    wget -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-1.2-api/2.17.1/log4j-1.2-api-2.17.1.jar && \
-    wget -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/slf4j/slf4j-reload4j/1.7.35/slf4j-reload4j-1.7.35.jar && \
-    wget -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.17.1/log4j-api-2.17.1.jar && \
-    wget -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.17.1/log4j-core-2.17.1.jar && \
-    wget -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/2.17.1/log4j-slf4j-impl-2.17.1.jar && \
+    wget --progress=dot:giga -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-1.2-api/2.17.1/log4j-1.2-api-2.17.1.jar && \
+    wget --progress=dot:giga -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/slf4j/slf4j-reload4j/1.7.35/slf4j-reload4j-1.7.35.jar && \
+    wget --progress=dot:giga -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-api/2.17.1/log4j-api-2.17.1.jar && \
+    wget --progress=dot:giga -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-core/2.17.1/log4j-core-2.17.1.jar && \
+    wget --progress=dot:giga -P ${SPARK_HOME}/jars/ https://repo1.maven.org/maven2/org/apache/logging/log4j/log4j-slf4j-impl/2.17.1/log4j-slf4j-impl-2.17.1.jar && \
     # remove conflict jars
     rm -f ${SPARK_HOME}/jars/guava* && \
     rm -f ${SPARK_HOME}/jars/metrics-core* && \

--- a/docker/friesian-serving/Dockerfile
+++ b/docker/friesian-serving/Dockerfile
@@ -24,8 +24,10 @@ ARG SPARK_VERSION=2.4.6
 ARG SPARK_HOME=/opt/spark
 
 RUN apt-get update --fix-missing && \
-    apt-get install -y apt-utils wget && \
-    wget https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop2.7.tgz && \
+    apt-get install -y --no-install-recommends apt-utils wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* && \
+    wget --progress=dot:giga https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop2.7.tgz && \
     tar -zxvf spark-${SPARK_VERSION}-bin-hadoop2.7.tgz && \
     mv spark-${SPARK_VERSION}-bin-hadoop2.7 /opt/spark && \
     rm spark-${SPARK_VERSION}-bin-hadoop2.7.tgz && \
@@ -59,18 +61,20 @@ WORKDIR /opt/work
 COPY --from=spark /opt/spark ${SPARK_HOME}
 
 RUN apt-get update --fix-missing && \
-    apt-get install -y openjdk-8-jdk libgomp1 vim net-tools openssh-server wget
+    apt-get install -y --no-install-recommends openjdk-8-jdk libgomp1 vim net-tools openssh-server wget && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 RUN mkdir logs
 
-ADD download-friesian-serving.sh /opt/work
+COPY download-friesian-serving.sh /opt/work
 
-RUN chmod a+x download-friesian-serving.sh
-RUN /opt/work/download-friesian-serving.sh
+RUN chmod a+x download-friesian-serving.sh \
+    /opt/work/download-friesian-serving.sh
 
-ADD lib/* /opt/work/lib/
-ADD start_service.sh /opt/work/
-ADD jersey/* /opt/work/jersey/
+COPY lib/* /opt/work/lib/
+COPY start_service.sh /opt/work/
+COPY jersey/* /opt/work/jersey/
 RUN chmod a+x /opt/work/start_service.sh
 
 ENTRYPOINT ["/opt/work/start_service.sh"]

--- a/docker/friesian-serving/Dockerfile
+++ b/docker/friesian-serving/Dockerfile
@@ -24,7 +24,7 @@ ARG SPARK_VERSION=2.4.6
 ARG SPARK_HOME=/opt/spark
 
 RUN apt-get update --fix-missing && \
-    apt-get install -y --no-install-recommends apt-utils wget && \
+    apt-get install -y --no-install-recommends apt-utils=2.0.9 wget=1.20.3-1ubuntu2 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     wget --progress=dot:giga https://archive.apache.org/dist/spark/spark-${SPARK_VERSION}/spark-${SPARK_VERSION}-bin-hadoop2.7.tgz && \
@@ -61,7 +61,7 @@ WORKDIR /opt/work
 COPY --from=spark /opt/spark ${SPARK_HOME}
 
 RUN apt-get update --fix-missing && \
-    apt-get install -y --no-install-recommends openjdk-8-jdk libgomp1 vim net-tools openssh-server wget && \
+    apt-get install -y --no-install-recommends openjdk-8-jdk=8u342-b07-0ubuntu1~20.04 libgomp1=10.3.0-1ubuntu1~20.04 vim=2:8.1.2269-1ubuntu5.9 net-tools=1.60+git20180626.aebd88e-1ubuntu1 openssh-server=1:8.2p1-4ubuntu0.5 wget=1.20.3-1ubuntu2 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
 
@@ -69,7 +69,7 @@ RUN mkdir logs
 
 COPY download-friesian-serving.sh /opt/work
 
-RUN chmod a+x download-friesian-serving.sh \
+RUN chmod a+x download-friesian-serving.sh && \
     /opt/work/download-friesian-serving.sh
 
 COPY lib/* /opt/work/lib/


### PR DESCRIPTION
## Description

Fix SDL Issues in frieisan serving dockerfile.

- [x] -:26 DL3008 [1m[93mwarning[0m: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
- [x] -:26 DL3015 [92minfo[0m: Avoid additional packages by specifying `--no-install-recommends`
- [x] -:26 DL3047 [92minfo[0m: Avoid use of wget without progress bar. Use `wget --progress=dot:giga <url>`. Or consider using `-q` or `-nv` (shorthands for `--quiet` or `--no-verbose`).
- [x] -:61 DL3008 [1m[93mwarning[0m: Pin versions in apt get install. Instead of `apt-get install <package>` use `apt-get install <package>=<version>`
- [x] -:61 DL3015 [92minfo[0m: Avoid additional packages by specifying `--no-install-recommends`
- [x] -:61 DL3009 [92minfo[0m: Delete the apt-get lists after installing something
- [x] -:66 DL3020 [1m[91merror[0m: Use COPY instead of ADD for files and folders
- [x] -:69 DL3059 [92minfo[0m: Multiple consecutive `RUN` instructions. Consider consolidation.
- [x] -:71 DL3020 [1m[91merror[0m: Use COPY instead of ADD for files and folders
- [x] -:72 DL3020 [1m[91merror[0m: Use COPY instead of ADD for files and folders
- [x] -:73 DL3020 [1m[91merror[0m: Use COPY instead of ADD for files and folders