### PR TITLE
LLM: Support package/quantize for llama.cpp/redpajama.cpp on Windows

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,7 +1,3 @@
-[submodule "python/llm/vendor/llama.cpp"]
-	path = python/llm/vendor/llama.cpp
-	url = https://github.com/analytics-zoo/llama.cpp.git
-	branch = server
 [submodule "python/llm/vendor/redpajama.cpp"]
 	path = python/llm/vendor/redpajama.cpp
 	url = https://github.com/analytics-zoo/redpajama.cpp.git
@@ -10,3 +6,7 @@
 	path = python/llm/vendor/bloomz.cpp
 	url = https://github.com/analytics-zoo/bloomz.cpp.git
 	branch = server
+[submodule "python/llm/vendor/llama.cpp"]
+	path = python/llm/vendor/llama.cpp
+	url = https://github.com/analytics-zoo/llama.cpp.git
+	branch = cache

--- a/python/llm/CMakeLists.txt
+++ b/python/llm/CMakeLists.txt
@@ -32,27 +32,27 @@ add_custom_target(
 )
 install(
     FILES ${CMAKE_CURRENT_SOURCE_DIR}/vendor/llama.cpp/libllama.so
-    DESTINATION src/bigdl/llm/lib
+    DESTINATION src/bigdl/llm/libs
 )
 install(
     PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/vendor/llama.cpp/quantize
     RENAME quantize-llama
-    DESTINATION src/bigdl/llm/bin
+    DESTINATION src/bigdl/llm/libs
 )
 install(
     FILES ${CMAKE_CURRENT_SOURCE_DIR}/vendor/redpajama.cpp/libgptneox.so
-    DESTINATION src/bigdl/llm/lib
+    DESTINATION src/bigdl/llm/libs
 )
 install(
     PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/vendor/redpajama.cpp/quantize-gptneox
-    DESTINATION src/bigdl/llm/bin
+    DESTINATION src/bigdl/llm/libs
 )
 install(
     FILES ${CMAKE_CURRENT_SOURCE_DIR}/vendor/bloomz.cpp/libbloom.so
-    DESTINATION src/bigdl/llm/lib
+    DESTINATION src/bigdl/llm/libs
 )
 install(
     PROGRAMS ${CMAKE_CURRENT_SOURCE_DIR}/vendor/bloomz.cpp/quantize
     RENAME quantize-bloomz
-    DESTINATION src/bigdl/llm/bin
+    DESTINATION src/bigdl/llm/libs
 )

--- a/python/llm/setup-linux.py
+++ b/python/llm/setup-linux.py
@@ -18,8 +18,7 @@
 
 import os
 import fnmatch
-from setuptools import setup
-import urllib.request
+from skbuild import setup
 
 long_description = '''
     BigDL LLM
@@ -45,33 +44,7 @@ def get_llm_packages():
     return llm_packages
 
 
-lib_urls = [
-    "https://sourceforge.net/projects/analytics-zoo/files/bigdl-llm/llama.dll",
-    "https://sourceforge.net/projects/analytics-zoo/files/bigdl-llm/quantize-llama.exe",
-    # TODO: add bloomz and redpajama
-]
-
-
-def download_libs(url: str):
-    libs_dir = os.path.join(llm_home, "bigdl", "llm", "libs")
-    if not os.path.exists(libs_dir):
-        os.makedirs(libs_dir, exist_ok=True)
-    libso_file_name = url.split('/')[-1]
-    libso_file = os.path.join(libs_dir, libso_file_name)
-    if not os.path.exists(libso_file):
-        urllib.request.urlretrieve(url, libso_file)
-
-
 def setup_package():
-    
-    package_data = [
-        "libs/llama.dll",
-        "libs/quantize-llama.exe"
-    ]
-
-    for url in lib_urls:
-        download_libs(url)
-
     metadata = dict(
         name='bigdl-llm',
         version=VERSION,
@@ -84,14 +57,14 @@ def setup_package():
         url='https://github.com/intel-analytics/BigDL',
         packages=get_llm_packages(),
         package_dir={"": "src"},
-        package_data={"bigdl.llm": package_data},
+        install_requires=[""],
         include_package_data=True,
         classifiers=[
             'License :: OSI Approved :: Apache Software License',
             'Programming Language :: Python :: 3',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: Implementation :: CPython'],
-        platforms=['windows']
+        platforms=['linux']
     )
 
     setup(**metadata)

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -48,6 +48,7 @@ def get_llm_packages():
 lib_urls = [
     "https://sourceforge.net/projects/analytics-zoo/files/bigdl-llm/llama.dll",
     "https://sourceforge.net/projects/analytics-zoo/files/bigdl-llm/quantize-llama.exe",
+    "https://sourceforge.net/projects/analytics-zoo/files/bigdl-llm/gptneox.dll",
     # TODO: add bloomz and redpajama
 ]
 
@@ -66,7 +67,8 @@ def setup_package():
     
     package_data = [
         "libs/llama.dll",
-        "libs/quantize-llama.exe"
+        "libs/quantize-llama.exe",
+        "libs/gptneox.dll",
     ]
 
     for url in lib_urls:

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -49,7 +49,8 @@ lib_urls = [
     "https://sourceforge.net/projects/analytics-zoo/files/bigdl-llm/llama.dll",
     "https://sourceforge.net/projects/analytics-zoo/files/bigdl-llm/quantize-llama.exe",
     "https://sourceforge.net/projects/analytics-zoo/files/bigdl-llm/gptneox.dll",
-    # TODO: add bloomz and redpajama
+    "https://sourceforge.net/projects/analytics-zoo/files/bigdl-llm/quantize-gptneox.exe",
+    # TODO: add bloomz
 ]
 
 

--- a/python/llm/src/bigdl/llm/ggml/quantize.py
+++ b/python/llm/src/bigdl/llm/ggml/quantize.py
@@ -17,14 +17,17 @@
 import os
 import subprocess
 from bigdl.llm.utils.common import invalidInputError
+import platform
 
 
 dirname, _ = os.path.split(os.path.abspath(__file__))
-bin_dirname = os.path.dirname(dirname)
+libs_dirname = os.path.dirname(dirname)
 
 _llama_quantize_type = {"q4_0": 2,
                         "q4_1": 3,
-                        "q4_2": 5}
+                        "q5_0": 8,
+                        "q5_1": 9,
+                        "q8_0": 7}
 _bloomz_quantize_type = {"q4_0": 2,
                          "q4_1": 3}
 _gptneox_quantize_type = {"q4_0": 2,
@@ -78,11 +81,16 @@ def quantize(input_path: str, output_path: str=None,
                       list(quantize_type_map.keys()),
                       dtype))
     quantize_type = quantize_type_map[dtype]
-    quantize_args = "{0}/bin/quantize-{1} {2} {3} {4}".format(bin_dirname,
-                                                              model_family,
-                                                              input_path,
-                                                              output_path,
-                                                              str(quantize_type))
+    if platform.platform().startswith('Windows'):
+        suffix = '.exe'
+    else:
+        suffix = ''
+    quantize_args = "{0}/libs/quantize-{1}{2} {3} {4} {5}".format(libs_dirname,
+                                                                  model_family,
+                                                                  suffix,
+                                                                  input_path,
+                                                                  output_path,
+                                                                  str(quantize_type))
     p = subprocess.Popen(quantize_args.split())
     p.communicate()
     invalidInputError(not p.returncode,


### PR DESCRIPTION
## Description

Initial support of llama.cpp on Windows by uploading manually llama.dll and quantize-llama.exe and downloading them in `setup.py`, as well as support `quantize` on Windows.

Files need to be uploaded for Windows :
- [x] llama.dll
- [x] quantize-llama.exe
- [x] gptneox.dll
- [x] quantize-gptneox.exe
- [ ] bloomz.dll
- [ ] quantize-bloomz.exe
![image](https://github.com/intel-analytics/BigDL/assets/105281011/8925cc2b-5abe-4e9c-b697-f1913a831db1)

bloomz will be added in the future as bloomz.cpp don't have Windows support now.
Linux support will be refactored in the future.

### 1. Why the change?
To support these cpp repo on Windows without exposing these repo public.

### 2. User API changes
package for Windows:
`python setup.py bdist_wheel`
package for Linux:
`python setup-linux.py bdist_wheel`
quantization for Windows is the same as Linux
```python
from bigdl.llm.ggml import quantize

quantize(input_path=r".\merged_gpt4all_llama_7b\ggml-model-f16.bin",
         output_path=r".\merged_gpt4all_llama_7b\ggml-model-q4_0.bin",
         model_family="llama",
         dtype="q4_0")
```

### 3. Summary of the change 

- new setup.py for Windows
- Initial support of llama.cpp on Windows by uploading manually llama.dll and quantize-llama.exe and download them in setup.py
- support quantize on Windows
- move all .exe/.dll/.lib files to libs directory
- update llama-cpp-python's CMakeFiles.txt to obtain `quantize-llama.exe`
- update redpajama.cpp's CMakeFiles.txt and related pybinding's CMakeFiles.txt to obtain `quantize-gptneox.exe`

### 4. How to test?
- [x] Unit test
- [x] Local test

