### PR TITLE
[llm] Add convert_model api

### DIFF
--- a/python/llm/src/bigdl/llm/ggml/__init__.py
+++ b/python/llm/src/bigdl/llm/ggml/__init__.py
@@ -21,3 +21,4 @@
 
 from .quantize import quantize
 from .convert import _convert_to_ggml
+from .convert_model import convert_model

--- a/python/llm/src/bigdl/llm/ggml/convert_model.py
+++ b/python/llm/src/bigdl/llm/ggml/convert_model.py
@@ -1,0 +1,35 @@
+from bigdl.llm.ggml.convert import _convert_to_ggml
+from bigdl.llm.ggml.quantize import quantize
+from pathlib import Path
+import time
+
+
+def convert_model(model_path: str,
+                  output_path: str = None,
+                  model_family: str = 'llama',
+                  dtype: str = 'q4_0'):
+    """
+    Convert Hugging Face llama-like / gpt-neox-like / bloom-like model to lower precision
+
+    :param model_path: str, path of model, for example `./llama-7b-hf`.
+    :param output_path: Save path of output quantized model. Default to `None`.
+            If you don't specify this parameter, quantized model will be saved in
+            the same directory as the input and just replace precision with quantize_type
+            like `./ggml-model-q4_0.bin`.
+    :param model_family: Which model family your input model belongs to. Default to `llama`.
+            Now only `llama`/`bloomz`/`gptneox` are supported.
+    """
+
+    model_name = Path(model_path).stem
+    tmp_ggml_file_path = f'/tmp/{model_name}_{int(time.time())}'
+    _convert_to_ggml(model_path=model_path,
+                     outfile_dir=tmp_ggml_file_path,
+                     model_family=model_family,
+                     outtype="fp16")
+    
+    tmp_ggml_file_path = next(Path(tmp_ggml_file_path).iterdir())
+
+    quantize(input_path=tmp_ggml_file_path,
+             output_path=output_path,
+             model_family=model_family,
+             dtype=dtype)

--- a/python/llm/src/bigdl/llm/ggml/convert_model.py
+++ b/python/llm/src/bigdl/llm/ggml/convert_model.py
@@ -25,7 +25,6 @@ def convert_model(input_path: str,
     if dtype == 'int4':
         dtype = 'q4_0'
 
-
     model_name = Path(input_path).stem
     tmp_ggml_file_path = f'/tmp/{model_name}_{int(time.time())}'
     _convert_to_ggml(model_path=input_path,

--- a/python/llm/src/bigdl/llm/ggml/convert_model.py
+++ b/python/llm/src/bigdl/llm/ggml/convert_model.py
@@ -22,6 +22,7 @@ def convert_model(input_path: str,
             Now only int4 supported.
     """
 
+    dtype = dtype.lower()
     if dtype == 'int4':
         dtype = 'q4_0'
 

--- a/python/llm/src/bigdl/llm/ggml/convert_model.py
+++ b/python/llm/src/bigdl/llm/ggml/convert_model.py
@@ -4,14 +4,14 @@ from pathlib import Path
 import time
 
 
-def convert_model(model_path: str,
+def convert_model(input_path: str,
                   output_path: str = None,
                   model_family: str = 'llama',
                   dtype: str = 'q4_0'):
     """
     Convert Hugging Face llama-like / gpt-neox-like / bloom-like model to lower precision
 
-    :param model_path: str, path of model, for example `./llama-7b-hf`.
+    :param input_path: str, path of model, for example `./llama-7b-hf`.
     :param output_path: Save path of output quantized model. Default to `None`.
             If you don't specify this parameter, quantized model will be saved in
             the same directory as the input and just replace precision with quantize_type
@@ -20,9 +20,9 @@ def convert_model(model_path: str,
             Now only `llama`/`bloomz`/`gptneox` are supported.
     """
 
-    model_name = Path(model_path).stem
+    model_name = Path(input_path).stem
     tmp_ggml_file_path = f'/tmp/{model_name}_{int(time.time())}'
-    _convert_to_ggml(model_path=model_path,
+    _convert_to_ggml(model_path=input_path,
                      outfile_dir=tmp_ggml_file_path,
                      model_family=model_family,
                      outtype="fp16")

--- a/python/llm/src/bigdl/llm/ggml/convert_model.py
+++ b/python/llm/src/bigdl/llm/ggml/convert_model.py
@@ -5,8 +5,8 @@ import time
 
 
 def convert_model(input_path: str,
-                  output_path: str = None,
-                  model_family: str = 'llama',
+                  output_path: str,
+                  model_family: str,
                   dtype: str = 'int4'):
     """
     Convert Hugging Face llama-like / gpt-neox-like / bloom-like model to lower precision
@@ -16,9 +16,9 @@ def convert_model(input_path: str,
             If you don't specify this parameter, quantized model will be saved in
             the same directory as the input and just replace precision with quantize_type
             like `./ggml-model-q4_0.bin`.
-    :param model_family: Which model family your input model belongs to. Default to `llama`.
-            Now only `llama`/`bloomz`/`gptneox` are supported.
-    :param dtype: Which quantized precision will be converted
+    :param model_family: Which model family your input model belongs to.
+            Now only `llama`/`bloom`/`gptneox` are supported.
+    :param dtype: Which quantized precision will be converted.
             Now only int4 supported.
     """
 

--- a/python/llm/src/bigdl/llm/ggml/convert_model.py
+++ b/python/llm/src/bigdl/llm/ggml/convert_model.py
@@ -7,7 +7,7 @@ import time
 def convert_model(input_path: str,
                   output_path: str = None,
                   model_family: str = 'llama',
-                  dtype: str = 'q4_0'):
+                  dtype: str = 'int4'):
     """
     Convert Hugging Face llama-like / gpt-neox-like / bloom-like model to lower precision
 
@@ -18,7 +18,13 @@ def convert_model(input_path: str,
             like `./ggml-model-q4_0.bin`.
     :param model_family: Which model family your input model belongs to. Default to `llama`.
             Now only `llama`/`bloomz`/`gptneox` are supported.
+    :param dtype: Which quantized precision will be converted
+            Now only int4 supported.
     """
+
+    if dtype == 'int4':
+        dtype = 'q4_0'
+
 
     model_name = Path(input_path).stem
     tmp_ggml_file_path = f'/tmp/{model_name}_{int(time.time())}'

--- a/python/llm/src/bigdl/llm/ggml/quantize.py
+++ b/python/llm/src/bigdl/llm/ggml/quantize.py
@@ -29,7 +29,7 @@ _llama_quantize_type = {"q4_0": 2,
                         "q5_0": 8,
                         "q5_1": 9,
                         "q8_0": 7}
-_bloomz_quantize_type = {"q4_0": 2,
+_bloom_quantize_type = {"q4_0": 2,
                          "q4_1": 3}
 _gptneox_quantize_type = {"q4_0": 2,
                           "q4_1": 3,
@@ -39,7 +39,7 @@ _gptneox_quantize_type = {"q4_0": 2,
                           "q8_0": 7}
 
 _quantize_type = {"llama": _llama_quantize_type,
-                  "bloomz": _bloomz_quantize_type,
+                  "bloom": _bloom_quantize_type,
                   "gptneox": _gptneox_quantize_type}
 
 _valid_types = set(list(_llama_quantize_type.keys()) + list(_bloomz_quantize_type.keys()) +
@@ -57,17 +57,17 @@ def quantize(input_path: str, output_path: str=None,
             the same directory as the input and just replace precision with quantize_type
             like `./ggml-model-q4_0.bin`.
     :param model_family: Which model family your input model belongs to. Default to `llama`.
-            Now only `llama`/`bloomz`/`gptneox` are supported.
+            Now only `llama`/`bloom`/`gptneox` are supported.
     :param dtype: Quantization method which differs in the resulting model disk size and
             inference speed. Defalut to `q4_0`. Difference model family may support different types,
             now the supported list is:
             llama : "q4_0", "q4_1", "q4_2"
-            bloomz : "q4_0", "q4_1"
+            bloom : "q4_0", "q4_1"
             gptneox : "q4_0", "q4_1", "q4_2", "q5_0", "q5_1", "q8_0"
     """
-    invalidInputError(model_family in ['llama', 'bloomz', 'gptneox'],
+    invalidInputError(model_family in ['llama', 'bloom', 'gptneox'],
                       "Now we only support quantization of model \
-                       family('llama', 'bloomz', 'gptneox')",
+                       family('llama', 'bloom', 'gptneox')",
                       "{} is not in the list.".format(model_family))
     invalidInputError(os.path.isfile(input_path),
                       "The file {} was not found".format(input_path))

--- a/python/llm/src/bigdl/llm/ggml/quantize.py
+++ b/python/llm/src/bigdl/llm/ggml/quantize.py
@@ -18,6 +18,7 @@ import os
 import subprocess
 from bigdl.llm.utils.common import invalidInputError
 import platform
+from pathlib import Path
 
 
 dirname, _ = os.path.split(os.path.abspath(__file__))
@@ -72,7 +73,7 @@ def quantize(input_path: str, output_path: str=None,
                       "The file {} was not found".format(input_path))
     # TODO : multi input model path
     if output_path is None:
-        output_path = input_path.replace("f16", dtype)
+        output_path = Path(str(input_path).replace('f16', dtype))
     # convert quantize type str into corresponding int value
     quantize_type_map = _quantize_type[model_family]
     invalidInputError(dtype in quantize_type_map, "{0} model just accept {1} now, \


### PR DESCRIPTION
## Description
combine #8235 and #8228  to one api `convert_model`


### 1. User API changes

Basic usage of convert a model to  int4-quantized model

```python
from bigdl.llm.ggml import convert_model
model_path = .'/models/vicuna-13b-1.1'
convert_model(model_path=model_path, output_path=None, model_family='llama')
```

### 2. Summary of the change 

* add `convert_model` api for bigdl.llm.ggml
* fix a path name replace problem of pathlib.Path in `quantize.py`

### 3. How to test?
successfully test on vicuna-13b-1.1
