### PR TITLE
Fix np.stack for numpy 1.25.0rc1

### DIFF
--- a/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
+++ b/python/orca/test/bigdl/orca/learn/ray/pytorch/test_estimator_ray_backend.py
@@ -369,7 +369,8 @@ class TestPyTorchEstimator(TestCase):
 
         sc = init_nncontext()
         rdd = sc.range(0, 110).map(lambda x: np.array([x] * 50))
-        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(lambda x: {"x": np.stack(x)})
+        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(
+            lambda x: {"x": np.stack([list(i) for i in x])})  # convert chain to list
         shards = SparkXShards(shards)
 
         estimator = get_estimator(workers_per_node=2,
@@ -793,7 +794,8 @@ class TestPyTorchEstimator(TestCase):
     def test_optional_optimizer(self):
         sc = OrcaContext.get_spark_context()
         rdd = sc.range(0, 110).map(lambda x: np.array([x] * 50))
-        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(lambda x: {"x": np.stack(x)})
+        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(
+            lambda x: {"x": np.stack([list(i) for i in x])})  # convert chain to list
         shards = SparkXShards(shards)
 
         try:

--- a/python/orca/test/bigdl/orca/learn/test_pytorch_basic.py
+++ b/python/orca/test/bigdl/orca/learn/test_pytorch_basic.py
@@ -394,7 +394,8 @@ class TestPyTorchEstimatorBasic(TestCase):
 
         sc = init_nncontext()
         rdd = sc.range(0, 110).map(lambda x: np.array([x] * 50))
-        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(lambda x: {"x": np.stack(x)})
+        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(
+            lambda x: {"x": np.stack([list(i) for i in x])})  # convert chain to list
         shards = SparkXShards(shards)
 
         estimator = get_estimator(workers_per_node=2,
@@ -684,7 +685,8 @@ class TestPyTorchEstimatorBasic(TestCase):
     def test_optional_optimizer(self):
         sc = init_nncontext()
         rdd = sc.range(0, 110).map(lambda x: np.array([x] * 50))
-        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(lambda x: {"x": np.stack(x)})
+        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(
+            lambda x: {"x": np.stack([list(i) for i in x])})  # convert chain to list
         shards = SparkXShards(shards)
 
         try:
@@ -708,7 +710,8 @@ class TestPyTorchEstimatorBasic(TestCase):
     def test_optional_model_creator(self):
         sc = OrcaContext.get_spark_context()
         rdd = sc.range(0, 110).map(lambda x: np.array([x] * 50))
-        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(lambda x: {"x": np.stack(x)})
+        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(
+            lambda x: {"x": np.stack([list(i) for i in x])})  # convert chain to list
         shards = SparkXShards(shards)
 
         try:

--- a/python/orca/test/bigdl/orca/learn/test_utils.py
+++ b/python/orca/test/bigdl/orca/learn/test_utils.py
@@ -81,7 +81,8 @@ class TestUtil(TestCase):
 
     def test_convert_predict_rdd_to_xshard(self):
         rdd = self.sc.range(0, 110).map(lambda x: np.array([x]*50))
-        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(lambda x: {"x": np.stack(x)})
+        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(
+            lambda x: {"x": np.stack([list(i) for i in x])})  # convert chain to list
         shards = SparkXShards(shards)
         pred_rdd = self.sc.range(0, 110).map(lambda x: np.array([x]*50))
         result_shards = convert_predict_rdd_to_xshard(shards, pred_rdd)
@@ -92,7 +93,8 @@ class TestUtil(TestCase):
 
     def test_convert_predict_rdd_to_xshard_multi_output(self):
         rdd = self.sc.range(0, 110).map(lambda x: np.array([x]*50))
-        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(lambda x: {"x": np.stack(x)})
+        shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(
+            lambda x: {"x": np.stack([list(i) for i in x])})  # convert chain to list
         shards = SparkXShards(shards)
         pred_rdd = self.sc.range(0, 110).map(lambda x: [np.array([x]*24), np.array([x]*26)])
         result_shards = convert_predict_rdd_to_xshard(shards, pred_rdd)
@@ -107,7 +109,7 @@ class TestUtil(TestCase):
         def get_xshards(key):
             rdd = self.sc.range(0, 110).map(lambda x: np.array([x] * 50))
             shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(
-                lambda x: {key: np.stack(x)})
+                lambda x: {key: np.stack([list(i) for i in x])})  # convert chain to list
             shards = SparkXShards(shards)
             return shards
 
@@ -124,14 +126,15 @@ class TestUtil(TestCase):
         def get_data_xshards(key):
             rdd = self.sc.range(0, 110).map(lambda x: np.array([x] * 50))
             shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(
-                lambda x: {key: np.stack(x)})
+                lambda x: {key: np.stack([list(i) for i in x])})  # convert chain to list
             shards = SparkXShards(shards)
             return shards
 
         def get_pred_xshards(key):
             rdd = self.sc.range(0, 110).map(lambda x: np.array([x] * 50))
             shards = rdd.mapPartitions(lambda iter: chunks(iter, 5)).map(
-                lambda x: {key: np.stack(x)}).map(lambda x: {key: [x[key][:, :24], x[key][:, 24:]]})
+                lambda x: {key: np.stack([list(i) for i in x])}).map(  # convert chain to list
+                lambda x: {key: [x[key][:, :24], x[key][:, 24:]]})
             shards = SparkXShards(shards)
             return shards
 


### PR DESCRIPTION
Fix https://github.com/intel-analytics/BigDL/actions/runs/5123426737/jobs/9224123912

In numpy 1.25.0rc1, np.stack doesn't support chain objects, thus convert to list to fix this issue.