### PR TITLE
Fix the problem caused by scipy 1.11.0rc01 lead the `input_shape ` doesn't keep dims

### DIFF
--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -171,6 +171,7 @@ def setup_package():
                           "onnxruntime-extensions==0.3.1; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
                           platform_system=='Darwin'",
                           "openvino-dev==2022.3.0",
+                          "scipy<=1.10.1",
                           "neural-compressor==2.0; platform_system!='Windows'",
                           "onnxsim==0.4.8; platform_system!='Darwin'",
                           "onnxsim==0.4.1; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \


### PR DESCRIPTION
FIX https://github.com/intel-analytics/BigDL/actions/runs/5144688461/jobs/9274180276
The scipy 1.11.0rc01's `mode` function has default `keep_dims=False` which will lead the `input_shape`[1,3,224,224] error using `mode(xx)[0][0]`
And before this version the `keep_dims` is default None, which will keep the `input_shape` [[1,3, 224,224]]
