### PR TITLE
[WIP] Chronos: upgrade tensorflow to 2.12

### DIFF
--- a/.github/workflows/chronos-nb-python-spark31.yml
+++ b/.github/workflows/chronos-nb-python-spark31.yml
@@ -183,7 +183,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos-spark3[inference,automl,distributed]
-          pip install -i tensorflow==2.11.0 intel-tensorflow==2.11.0 
+          pip install tensorflow==2.11.0 intel-tensorflow==2.11.0 
           export SPARK_LOCAL_HOSTNAME=localhost
           export KERAS_BACKEND=tensorflow
           source bigdl-nano-init

--- a/.github/workflows/chronos-nb-python-spark31.yml
+++ b/.github/workflows/chronos-nb-python-spark31.yml
@@ -270,6 +270,7 @@ jobs:
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos-spark3[inference,automl,distributed]
           pip install tensorflow==2.12.0 intel-tensorflow==2.12.0 tf2onnx==1.14.0
+          pip install protobuf==3.20.3
           export SPARK_LOCAL_HOSTNAME=localhost
           export KERAS_BACKEND=tensorflow
           source bigdl-nano-init

--- a/.github/workflows/chronos-nb-python-spark31.yml
+++ b/.github/workflows/chronos-nb-python-spark31.yml
@@ -16,7 +16,7 @@ env:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  chronos-NB-pytorch-test:
+  chronos-NB-tensorflow2.8-inference-automl-distributed-test:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
     strategy:
       fail-fast: false
@@ -34,231 +34,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      - name: Run Chronos NB (pytorch)
-        shell: bash
-        run: |
-          conda remove -n chronos-nb-env -y --all
-          conda create -n chronos-nb-env -y python=${{matrix.python-version}} setuptools==58.0.4 -c ${GONDOLIN_CONDA_CHANNEL} --override-channels
-          source activate chronos-nb-env
-          pip install pytest
-          apt-get update
-          apt-get install patchelf
-          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
-          pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos-spark3[pytorch]
-          source bigdl-nano-init
-          bash python/chronos/dev/test/run-installation-options.sh "torch and not inference and not automl and not distributed and not diff_set_all"
-          source deactivate
-          conda remove -n chronos-nb-env -y --all
-
-        env:
-          BIGDL_ROOT: ${{ github.workspace }}
-          ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
-
-      - name: Remove Chronos Env
-        if: ${{ always() }}
-        shell: bash
-        run: |
-          conda remove -n chronos-nb-env -y --all
-
-      - name: Create Job Badge
-        uses: ./.github/actions/create-job-status-badge
-        if: ${{ always() }}
-        with:
-          secret: ${{ secrets.GIST_SECRET}}
-          gist-id: ${{env.GIST_ID}}
-          is-self-hosted-runner: true
-          file-name: chronos-NB-pytorch-test.json
-          type: job
-          job-name: chronos-NB-pytorch-test
-          runner-hosted-on: 'Shanghai'
-
-  chronos-NB-pytorch-inference-test:
-    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.8", "3.9"]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: ./.github/actions/jdk-setup-action
-      - name: Set up Maven
-        uses: ./.github/actions/maven-setup-action
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Run Chronos NB (pytorch,inference)
-        shell: bash
-        run: |
-          conda remove -n chronos-nb-env -y --all
-          conda create -n chronos-nb-env -y python=${{matrix.python-version}} setuptools==58.0.4 -c ${GONDOLIN_CONDA_CHANNEL} --override-channels
-          source activate chronos-nb-env
-          pip install pytest
-          apt-get update
-          apt-get install patchelf
-          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
-          pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos-spark3[pytorch,inference]
-          source bigdl-nano-init
-          bash python/chronos/dev/test/run-installation-options.sh "torch and not automl and not distributed and not diff_set_all"
-          source deactivate
-          conda remove -n chronos-nb-env -y --all
-        env:
-          BIGDL_ROOT: ${{ github.workspace }}
-          ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
-      
-      - name: Remove Chronos Env
-        if: ${{ always() }}
-        shell: bash
-        run: |
-          conda remove -n chronos-nb-env -y --all
-
-      - name: Create Job Badge
-        uses: ./.github/actions/create-job-status-badge
-        if: ${{ always() }}
-        with:
-          secret: ${{ secrets.GIST_SECRET}}
-          gist-id: ${{env.GIST_ID}}
-          is-self-hosted-runner: true
-          file-name: chronos-NB-pytorch-inference-test.json
-          type: job
-          job-name: chronos-NB-pytorch-inference-test
-          runner-hosted-on: 'Shanghai'
-
-  chronos-NB-pytorch-inference-automl-test:
-    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.8", "3.9"]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: ./.github/actions/jdk-setup-action
-      - name: Set up Maven
-        uses: ./.github/actions/maven-setup-action
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Run Chronos NB (pytorch,inference,automl)
-        shell: bash
-        run: |
-          conda remove -n chronos-nb-env -y --all
-          conda create -n chronos-nb-env -y python=${{matrix.python-version}} setuptools==58.0.4 -c ${GONDOLIN_CONDA_CHANNEL} --override-channels
-          source activate chronos-nb-env
-          pip install pytest
-          apt-get update
-          apt-get install patchelf
-          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
-          pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos-spark3[pytorch,inference,automl]
-          source bigdl-nano-init
-          bash python/chronos/dev/test/run-installation-options.sh "torch and not distributed and not diff_set_all"
-          source deactivate
-          conda remove -n chronos-nb-env -y --all
-        env:
-          BIGDL_ROOT: ${{ github.workspace }}
-          ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
-      
-      - name: Remove Chronos Env
-        if: ${{ always() }}
-        shell: bash
-        run: |
-          conda remove -n chronos-nb-env -y --all
-
-      - name: Create Job Badge
-        uses: ./.github/actions/create-job-status-badge
-        if: ${{ always() }}
-        with:
-          secret: ${{ secrets.GIST_SECRET}}
-          gist-id: ${{env.GIST_ID}}
-          is-self-hosted-runner: true
-          file-name: chronos-NB-pytorch-inference-automl-test.json
-          type: job
-          job-name: chronos-NB-pytorch-inference-automl-test
-          runner-hosted-on: 'Shanghai'
-
-  chronos-NB-pytorch-inference-automl-distributed-test:
-    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.8", "3.9"]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: ./.github/actions/jdk-setup-action
-      - name: Set up Maven
-        uses: ./.github/actions/maven-setup-action
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Run Chronos NB (pytorch,inference,automl,distributed)
-        shell: bash
-        run: |
-          conda remove -n chronos-nb-env -y --all
-          conda create -n chronos-nb-env -y python=${{matrix.python-version}} setuptools==58.0.4 -c ${GONDOLIN_CONDA_CHANNEL} --override-channels
-          source activate chronos-nb-env
-          pip install pytest
-          apt-get update
-          apt-get install patchelf
-          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
-          pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos-spark3[pytorch,inference,automl,distributed]
-          pip uninstall -y colorful
-          export SPARK_LOCAL_HOSTNAME=localhost
-          export KERAS_BACKEND=tensorflow
-          source bigdl-nano-init
-          bash python/chronos/dev/test/run-installation-options.sh "torch and not diff_set_all"
-          source deactivate
-          conda remove -n chronos-nb-env -y --all
-        env:
-          BIGDL_ROOT: ${{ github.workspace }}
-          ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
-      
-      - name: Remove Chronos Env
-        if: ${{ always() }}
-        shell: bash
-        run: |
-          conda remove -n chronos-nb-env -y --all
-
-      - name: Create Job Badge
-        uses: ./.github/actions/create-job-status-badge
-        if: ${{ always() }}
-        with:
-          secret: ${{ secrets.GIST_SECRET}}
-          gist-id: ${{env.GIST_ID}}
-          is-self-hosted-runner: true
-          file-name: chronos-NB-pytorch-inference-automl-distributed-test.json
-          type: job
-          job-name: chronos-NB-pytorch-inference-automl-distributed-test
-          runner-hosted-on: 'Shanghai'
-
-  chronos-NB-tensorflow-inference-automl-distributed-test:
-    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.8", "3.9"]
-    steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 8
-        uses: ./.github/actions/jdk-setup-action
-      - name: Set up Maven
-        uses: ./.github/actions/maven-setup-action
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Run Chronos NB (tensorflow,inference,automl,distributed)
+      - name: Run Chronos NB (tensorflow2.8,inference,automl,distributed)
         shell: bash
         run: |
           conda remove -n chronos-nb-env -y --all
@@ -269,8 +45,7 @@ jobs:
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
           pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos-spark3[inference,automl,distributed]
-          pip install tensorflow==2.12.0 intel-tensorflow==2.12.0 tf2onnx==1.14.0
-          pip install protobuf==3.20.3
+          pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-nano[tensorflow_28]
           export SPARK_LOCAL_HOSTNAME=localhost
           export KERAS_BACKEND=tensorflow
           source bigdl-nano-init
@@ -287,27 +62,187 @@ jobs:
         run: |
           conda remove -n chronos-nb-env -y --all
 
-      - name: Create Job Badge
-        uses: ./.github/actions/create-job-status-badge
-        if: ${{ always() }}
-        with:
-          secret: ${{ secrets.GIST_SECRET}}
-          gist-id: ${{env.GIST_ID}}
-          is-self-hosted-runner: true
-          file-name: chronos-NB-tensorflow-inference-automl-distributed-test.json
-          type: job
-          job-name: chronos-NB-tensorflow-inference-automl-distributed-test
-          runner-hosted-on: 'Shanghai'
-
-  create-workflow-badge:
-    runs-on: ubuntu-latest
+  chronos-NB-tensorflow2.9-inference-automl-distributed-test:
+    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9"]
     steps:
-    - uses: actions/checkout@v3
-    - name: create workflow badge
-      if: ${{ always() }}
-      uses: ./.github/actions/create-job-status-badge
-      with:
-        secret: ${{ secrets.GIST_SECRET }}
-        gist-id: ${{env.GIST_ID}}
-        file-name: chronos-nb-python-spark31.json
-        type: workflow
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: ./.github/actions/jdk-setup-action
+      - name: Set up Maven
+        uses: ./.github/actions/maven-setup-action
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run Chronos NB (tensorflow2.9,inference,automl,distributed)
+        shell: bash
+        run: |
+          conda remove -n chronos-nb-env -y --all
+          conda create -n chronos-nb-env -y python=${{matrix.python-version}} setuptools==58.0.4 -c ${GONDOLIN_CONDA_CHANNEL} --override-channels
+          source activate chronos-nb-env
+          pip install pytest==5.4.1
+          apt-get update
+          apt-get install patchelf
+          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
+          pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos-spark3[inference,automl,distributed]
+          pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-nano[tensorflow_29]
+          export SPARK_LOCAL_HOSTNAME=localhost
+          export KERAS_BACKEND=tensorflow
+          source bigdl-nano-init
+          bash python/chronos/dev/test/run-installation-options.sh "tf2 and not diff_set_all"
+          source deactivate
+          conda remove -n chronos-nb-env -y --all
+        env:
+          BIGDL_ROOT: ${{ github.workspace }}
+          ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
+
+      - name: Remove Chronos Env
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          conda remove -n chronos-nb-env -y --all
+
+  chronos-NB-tensorflow2.10-inference-automl-distributed-test:
+    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: ./.github/actions/jdk-setup-action
+      - name: Set up Maven
+        uses: ./.github/actions/maven-setup-action
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run Chronos NB (tensorflow2.10,inference,automl,distributed)
+        shell: bash
+        run: |
+          conda remove -n chronos-nb-env -y --all
+          conda create -n chronos-nb-env -y python=${{matrix.python-version}} setuptools==58.0.4 -c ${GONDOLIN_CONDA_CHANNEL} --override-channels
+          source activate chronos-nb-env
+          pip install pytest==5.4.1
+          apt-get update
+          apt-get install patchelf
+          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
+          pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos-spark3[inference,automl,distributed]
+          pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-nano[tensorflow_210]
+          export SPARK_LOCAL_HOSTNAME=localhost
+          export KERAS_BACKEND=tensorflow
+          source bigdl-nano-init
+          bash python/chronos/dev/test/run-installation-options.sh "tf2 and not diff_set_all"
+          source deactivate
+          conda remove -n chronos-nb-env -y --all
+        env:
+          BIGDL_ROOT: ${{ github.workspace }}
+          ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
+
+      - name: Remove Chronos Env
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          conda remove -n chronos-nb-env -y --all
+
+  chronos-NB-tensorflow2.11-inference-automl-distributed-test:
+    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: ./.github/actions/jdk-setup-action
+      - name: Set up Maven
+        uses: ./.github/actions/maven-setup-action
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run Chronos NB (tensorflow2.11,inference,automl,distributed)
+        shell: bash
+        run: |
+          conda remove -n chronos-nb-env -y --all
+          conda create -n chronos-nb-env -y python=${{matrix.python-version}} setuptools==58.0.4 -c ${GONDOLIN_CONDA_CHANNEL} --override-channels
+          source activate chronos-nb-env
+          pip install pytest==5.4.1
+          apt-get update
+          apt-get install patchelf
+          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
+          pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos-spark3[inference,automl,distributed]
+          pip install -i tensorflow==2.11.0 intel-tensorflow==2.11.0 
+          export SPARK_LOCAL_HOSTNAME=localhost
+          export KERAS_BACKEND=tensorflow
+          source bigdl-nano-init
+          bash python/chronos/dev/test/run-installation-options.sh "tf2 and not diff_set_all"
+          source deactivate
+          conda remove -n chronos-nb-env -y --all
+        env:
+          BIGDL_ROOT: ${{ github.workspace }}
+          ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
+
+      - name: Remove Chronos Env
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          conda remove -n chronos-nb-env -y --all
+
+  chronos-NB-tensorflow2.12-inference-automl-distributed-test:
+    runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.8", "3.9"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK 8
+        uses: ./.github/actions/jdk-setup-action
+      - name: Set up Maven
+        uses: ./.github/actions/maven-setup-action
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Run Chronos NB (tensorflow2.12,inference,automl,distributed)
+        shell: bash
+        run: |
+          conda remove -n chronos-nb-env -y --all
+          conda create -n chronos-nb-env -y python=${{matrix.python-version}} setuptools==58.0.4 -c ${GONDOLIN_CONDA_CHANNEL} --override-channels
+          source activate chronos-nb-env
+          pip install pytest==5.4.1
+          apt-get update
+          apt-get install patchelf
+          pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
+          pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos-spark3[inference,automl,distributed]
+          pip install tensorflow==2.12.0 intel-tensorflow==2.12.0
+          pip install protobuf==3.20.3
+          export SPARK_LOCAL_HOSTNAME=localhost
+          export KERAS_BACKEND=tensorflow
+          source bigdl-nano-init
+          bash python/chronos/dev/test/run-installation-options.sh "tf2 and not diff_set_all"
+          source deactivate
+          conda remove -n chronos-nb-env -y --all
+        env:
+          BIGDL_ROOT: ${{ github.workspace }}
+          ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
+
+      - name: Remove Chronos Env
+        if: ${{ always() }}
+        shell: bash
+        run: |
+          conda remove -n chronos-nb-env -y --all

--- a/.github/workflows/chronos-nb-python-spark31.yml
+++ b/.github/workflows/chronos-nb-python-spark31.yml
@@ -16,7 +16,7 @@ env:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  chronos-NB-tensorflow2.8-inference-automl-distributed-test:
+  chronos-NB-tensorflow28-inference-automl-distributed-test:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
     strategy:
       fail-fast: false
@@ -62,7 +62,7 @@ jobs:
         run: |
           conda remove -n chronos-nb-env -y --all
 
-  chronos-NB-tensorflow2.9-inference-automl-distributed-test:
+  chronos-NB-tensorflow29-inference-automl-distributed-test:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
     strategy:
       fail-fast: false
@@ -108,7 +108,7 @@ jobs:
         run: |
           conda remove -n chronos-nb-env -y --all
 
-  chronos-NB-tensorflow2.10-inference-automl-distributed-test:
+  chronos-NB-tensorflow210-inference-automl-distributed-test:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
     strategy:
       fail-fast: false
@@ -154,7 +154,7 @@ jobs:
         run: |
           conda remove -n chronos-nb-env -y --all
 
-  chronos-NB-tensorflow2.11-inference-automl-distributed-test:
+  chronos-NB-tensorflow211-inference-automl-distributed-test:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
     strategy:
       fail-fast: false
@@ -200,7 +200,7 @@ jobs:
         run: |
           conda remove -n chronos-nb-env -y --all
 
-  chronos-NB-tensorflow2.12-inference-automl-distributed-test:
+  chronos-NB-tensorflow212-inference-automl-distributed-test:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
     strategy:
       fail-fast: false

--- a/.github/workflows/chronos-nb-python-spark31.yml
+++ b/.github/workflows/chronos-nb-python-spark31.yml
@@ -268,7 +268,8 @@ jobs:
           apt-get update
           apt-get install patchelf
           pip uninstall -y bigdl-friesian bigdl-friesian-spark3 bigdl-dllib bigdl-dllib-spark3 bigdl-orca pyspark bigdl-orca-spark3 bigdl-chronos bigdl-chronos-spark3 bigdl-nano bigdl-friesian bigdl-friesian-spark3
-          pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos-spark3[tensorflow,inference,automl,distributed]
+          pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-chronos-spark3[inference,automl,distributed]
+          pip install tensorflow==2.12.0 intel-tensorflow==2.12.0 tf2onnx==1.14.0
           export SPARK_LOCAL_HOSTNAME=localhost
           export KERAS_BACKEND=tensorflow
           source bigdl-nano-init


### PR DESCRIPTION
## Description

Currently, we only support tf2.7 which is quite old.
Try to upgrade tensorflow to 2.12.

**This PR is only used to test different versions of tf by triggering Github Action.**

### 1. Why the change?


### 2. User API changes



### 3. Summary of the change 


### 4. How to test?
- [ ] Unit test

