### PR TITLE
LLM: enhancements for `convert_model`

### DIFF
--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -42,7 +42,7 @@ BIGDL_PYTHON_HOME = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 VERSION = open(os.path.join(BIGDL_PYTHON_HOME, 'version.txt'), 'r').read().strip()
 llm_home = os.path.join(os.path.dirname(os.path.abspath(__file__)), "src")
 libs_dir = os.path.join(llm_home, "bigdl", "llm", "libs")
-CONVERT_DEP = ['numpy', 'torch', 'transformers', 'sentencepiece']
+CONVERT_DEP = ['numpy', 'torch', 'transformers', 'sentencepiece', 'accelerate']
 
 
 def get_llm_packages():

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -151,6 +151,11 @@ def setup_package():
         package_dir={"": "src"},
         package_data={"bigdl.llm": package_data[platform_name]},
         include_package_data=True,
+        entry_points={
+            "console_scripts": [
+                'convert_model=bigdl.llm.ggml.convert_model:main'
+            ]
+        },
         extras_require={"all": all_requires},
         classifiers=[
             'License :: OSI Approved :: Apache Software License',

--- a/python/llm/src/bigdl/llm/ggml/convert.py
+++ b/python/llm/src/bigdl/llm/ggml/convert.py
@@ -77,8 +77,11 @@ def _convert_to_ggml(model_path: str, outfile_dir: str,
     """
     Convert Hugging Face llama-like / gpt-neox-like / bloom-like model to ggml format.
 
-    :param input_path: A path to a *directory* containing model weights saved using
-           `PreTrainedModel.save_pretrained` in transformers, for example `./llama-7b-hf`.
+    :param input_path: Path to a *directory*  for huggingface checkpoint that are directly
+            pulled from huggingface hub, for example `./llama-7b-hf`. This should be a dir
+            path that contains: weight bin, tokenizer config, tokenizer.model (required for
+            llama) and added_tokens.json (if applied).
+            For lora finetuned model, the path should be pointed to a merged weight.
     :param outfile_dir: str, the directory to save ggml compatible file, for example `./models`.
     :param model_family: Which model family your input model belongs to. Default to `llama`.
             Now only `llama`/`bloom`/`gptneox` are supported.

--- a/python/llm/src/bigdl/llm/ggml/convert.py
+++ b/python/llm/src/bigdl/llm/ggml/convert.py
@@ -77,7 +77,8 @@ def _convert_to_ggml(model_path: str, outfile_dir: str,
     """
     Convert Hugging Face llama-like / gpt-neox-like / bloom-like model to ggml format.
 
-    :param model_path: str, path of model, for example `./llama-7b-hf`.
+    :param input_path: A path to a *directory* containing model weights saved using
+           `PreTrainedModel.save_pretrained` in transformers, for example `./llama-7b-hf`.
     :param outfile_dir: str, the directory to save ggml compatible file, for example `./models`.
     :param model_family: Which model family your input model belongs to. Default to `llama`.
             Now only `llama`/`bloom`/`gptneox` are supported.

--- a/python/llm/src/bigdl/llm/ggml/convert_model.py
+++ b/python/llm/src/bigdl/llm/ggml/convert_model.py
@@ -31,8 +31,11 @@ def convert_model(input_path: str,
     """
     Convert Hugging Face llama-like / gpt-neox-like / bloom-like model to lower precision
 
-    :param input_path: A path to a *directory* containing model weights saved using
-            `PreTrainedModel.save_pretrained` in transformers, for example `./llama-7b-hf`.
+    :param input_path: Path to a *directory*  for huggingface checkpoint that are directly
+            pulled from huggingface hub, for example `./llama-7b-hf`. This should be a dir
+            path that contains: weight bin, tokenizer config, tokenizer.model (required for
+            llama) and added_tokens.json (if applied).
+            For lora finetuned model, the path should be pointed to a merged weight.
     :param output_dir: Save path of output quantized model. You must pass a *directory* to
             save all related output.
     :param model_family: Which model family your input model belongs to.
@@ -98,7 +101,7 @@ def main():
                         help=("input_path, a path to a *directory* containing model weights"))
     parser.add_argument('-o', '--output_dir', type=str, required=True,
                         help=("output_dir,save path of output quantized model."))
-    parser.add_argument('-f', '--model_family', type=str, required=True,
+    parser.add_argument('-x', '--model_family', type=str, required=True,
                         help=("model_family: Which model family your input model belongs to."
                               "Now only `llama`/`bloom`/`gptneox` are supported."))
     parser.add_argument('-t', '--dtype', type=str, default="int4",

--- a/python/llm/src/bigdl/llm/ggml/convert_model.py
+++ b/python/llm/src/bigdl/llm/ggml/convert_model.py
@@ -24,7 +24,7 @@ import tempfile
 
 
 def convert_model(input_path: str,
-                  output_dir: str,
+                  output_path: str,
                   model_family: str,
                   dtype: str = 'int4',
                   tmp_path: str = None):
@@ -36,7 +36,7 @@ def convert_model(input_path: str,
             path that contains: weight bin, tokenizer config, tokenizer.model (required for
             llama) and added_tokens.json (if applied).
             For lora finetuned model, the path should be pointed to a merged weight.
-    :param output_dir: Save path of output quantized model. You must pass a *directory* to
+    :param output_path: Save path of output quantized model. You must pass a *directory* to
             save all related output.
     :param model_family: Which model family your input model belongs to.
             Now only `llama`/`bloom`/`gptneox` are supported.
@@ -50,14 +50,14 @@ def convert_model(input_path: str,
 
     dtype = dtype.lower()
     # make sure directory exists
-    os.makedirs(output_dir, exist_ok=True)
+    os.makedirs(output_path, exist_ok=True)
     # check input value
     invalidInputError(model_family in ['llama', 'bloom', 'gptneox'],
                       "Now we only support quantization of model \
                        family('llama', 'bloom', 'gptneox')",
                       "{} is not in the list.".format(model_family))
-    invalidInputError(os.path.isdir(output_dir),
-                      "The output_dir {} was not a directory".format(output_dir))
+    invalidInputError(os.path.isdir(output_path),
+                      "The output_path {} was not a directory".format(output_path))
     invalidInputError(dtype == 'int4',
                       "Now only int4 is supported.")
     # check for input_path
@@ -79,7 +79,7 @@ def convert_model(input_path: str,
                          outtype="fp16")
         tmp_ggml_file_path = next(Path(tmp_ggml_file_path).iterdir())
         return quantize(input_path=tmp_ggml_file_path,
-                        output_dir=output_dir,
+                        output_path=output_path,
                         model_family=model_family,
                         dtype=dtype)
     else:
@@ -90,7 +90,7 @@ def convert_model(input_path: str,
                              outtype="fp16")
             tmp_ggml_file_path = next(Path(tmp_ggml_file_path).iterdir())
             return quantize(input_path=tmp_ggml_file_path,
-                            output_dir=output_dir,
+                            output_path=output_path,
                             model_family=model_family,
                             dtype=dtype)
 
@@ -99,8 +99,8 @@ def main():
     parser = argparse.ArgumentParser(description='Model Convert Parameters')
     parser.add_argument('-i', '--input_path', type=str, required=True,
                         help=("input_path, a path to a *directory* containing model weights"))
-    parser.add_argument('-o', '--output_dir', type=str, required=True,
-                        help=("output_dir,save path of output quantized model."))
+    parser.add_argument('-o', '--output_path', type=str, required=True,
+                        help=("output_path,save path of output quantized model."))
     parser.add_argument('-x', '--model_family', type=str, required=True,
                         help=("model_family: Which model family your input model belongs to."
                               "Now only `llama`/`bloom`/`gptneox` are supported."))

--- a/python/llm/src/bigdl/llm/ggml/convert_model.py
+++ b/python/llm/src/bigdl/llm/ggml/convert_model.py
@@ -37,6 +37,7 @@ def convert_model(input_path: str,
     :param dtype: Which quantized precision will be converted.
             Now only int4 supported.
     :param tmp_path: Which path to store the intermediate model during the conversion process.
+            Default to `None` so that intermediate model will not be saved.
 
     :return: the path str to the converted lower precision checkpoint
     """

--- a/python/llm/src/bigdl/llm/ggml/convert_model.py
+++ b/python/llm/src/bigdl/llm/ggml/convert_model.py
@@ -18,6 +18,7 @@ import time
 from pathlib import Path
 from bigdl.llm.ggml.convert import _convert_to_ggml
 from bigdl.llm.ggml.quantize import quantize
+from bigdl.llm.utils.common import invalidInputError
 import tempfile
 
 
@@ -29,8 +30,9 @@ def convert_model(input_path: str,
     """
     Convert Hugging Face llama-like / gpt-neox-like / bloom-like model to lower precision
 
-    :param input_path: str, path of model, for example `./llama-7b-hf`.
-    :param output_dir: Save path of output quantized model. You must pass a directory to
+    :param input_path: A path to a *directory* containing model weights saved using
+            `PreTrainedModel.save_pretrained` in transformers, for example `./llama-7b-hf`.
+    :param output_dir: Save path of output quantized model. You must pass a *directory* to
             save all related output.
     :param model_family: Which model family your input model belongs to.
             Now only `llama`/`bloom`/`gptneox` are supported.
@@ -39,10 +41,24 @@ def convert_model(input_path: str,
     :param tmp_path: Which path to store the intermediate model during the conversion process.
             Default to `None` so that intermediate model will not be saved.
 
-    :return: the path str to the converted lower precision checkpoint
+    :return: the path string to the converted lower precision checkpoint.
     """
 
     dtype = dtype.lower()
+    # check input value
+    invalidInputError(model_family in ['llama', 'bloom', 'gptneox'],
+                      "Now we only support quantization of model \
+                       family('llama', 'bloom', 'gptneox')",
+                      "{} is not in the list.".format(model_family))
+    invalidInputError(os.path.isdir(output_dir),
+                      "The output_dir {} was not a directory".format(output_dir))
+    # check for input_path
+    invalidInputError(os.path.exists(input_path),
+                      "The input path {} was not found".format(model_path))
+    invalidInputError(os.path.isdir(input_path),
+                      "The input path {} was not a directory".format(model_path))
+    # shall we support model_id or just model directory?
+
     if dtype == 'int4':
         dtype = 'q4_0'
 

--- a/python/llm/src/bigdl/llm/ggml/convert_model.py
+++ b/python/llm/src/bigdl/llm/ggml/convert_model.py
@@ -104,7 +104,8 @@ def main():
     parser.add_argument('-t', '--dtype', type=str, default="int4",
                         help="Which quantized precision will be converted.")
     parser.add_argument('-p', '--tmp_path', type=str, default=None,
-                        help="Which path to store the intermediate model during the conversion process.")
+                        help="Which path to store the intermediate model during the"
+                        "conversion process.")
     args = parser.parse_args()
     params = vars(args)
     convert_model(**params)

--- a/python/llm/src/bigdl/llm/ggml/quantize.py
+++ b/python/llm/src/bigdl/llm/ggml/quantize.py
@@ -42,13 +42,13 @@ _quantize_type = {"llama": _llama_quantize_type,
                   "gptneox": _gptneox_quantize_type}
 
 
-def quantize(input_path: str, output_dir: str,
+def quantize(input_path: str, output_path: str,
              model_family: str, dtype: str='q4_0'):
     """
     Quantize ggml file to lower precision.
 
     :param input_path: Path of input ggml file, for example `./ggml-model-f16.bin`.
-    :param output_dir: Save path of output quantized model. You must pass a directory to
+    :param output_path: Save path of output quantized model. You must pass a directory to
             save all related output. Filename of quantized model will be like
             `bigdl_llm_llama_q4_0.bin`.
     :param model_family: Which model family your input model belongs to.
@@ -68,13 +68,13 @@ def quantize(input_path: str, output_dir: str,
                       "{} is not in the list.".format(model_family))
     invalidInputError(os.path.isfile(input_path),
                       "The file {} was not found".format(input_path))
-    invalidInputError(os.path.isdir(output_dir),
-                      "The output_dir {} was not a directory".format(output_dir))
+    invalidInputError(os.path.isdir(output_path),
+                      "The output_path {} was not a directory".format(output_path))
     # convert quantize type str into corresponding int value
     quantize_type_map = _quantize_type[model_family]
     output_filename = "bigdl_llm_{}_{}.bin".format(model_family,
                                                    dtype.lower())
-    output_path = os.path.join(output_dir, output_filename)
+    output_path = os.path.join(output_path, output_filename)
     invalidInputError(dtype.lower() in quantize_type_map, "{0} model just accept {1} now, \
                       but you pass in {2}.".format(
                       model_family,

--- a/python/llm/src/bigdl/llm/ggml/quantize.py
+++ b/python/llm/src/bigdl/llm/ggml/quantize.py
@@ -43,21 +43,22 @@ _quantize_type = {"llama": _llama_quantize_type,
 
 
 def quantize(input_path: str, output_dir: str,
-             model_family: str = 'llama', dtype: str='q4_0'):
+             model_family: str, dtype: str='q4_0'):
     """
     Quantize ggml file to lower precision.
 
     :param input_path: Path of input ggml file, for example `./ggml-model-f16.bin`.
     :param output_dir: Save path of output quantized model. You must pass a directory to
-            save all related output. A default output will be `output_dir/bigdl_llm_q4_0.bin`.
-    :param model_family: Which model family your input model belongs to. Default to `llama`.
+            save all related output. Filename of quantized model will be like
+            `bigdl_llm_llama_q4_0.bin`.
+    :param model_family: Which model family your input model belongs to.
             Now only `llama`/`bloom`/`gptneox` are supported.
     :param dtype: Quantization method which differs in the resulting model disk size and
-            inference speed. Defalut to `q4_0`. Difference model family may support different types,
-            now the supported list is:
+            inference speed. Defalut to `q4_0`. Difference model family may support
+            different types, now the supported list is:
             llama : "q4_0", "q4_1", "q4_2"
             bloom : "q4_0", "q4_1"
-            gptneox : "q4_0", "q4_1", "q4_2", "q5_0", "q5_1", "q8_0"
+            gptneox : "q4_0", "q4_1", "q5_0", "q5_1", "q8_0"
 
     :return: the path str to the converted ggml binary checkpoint
     """
@@ -71,7 +72,8 @@ def quantize(input_path: str, output_dir: str,
                       "The output_dir {} was not a directory".format(output_dir))
     # convert quantize type str into corresponding int value
     quantize_type_map = _quantize_type[model_family]
-    output_filename = "bigdl_llm_{}.bin".format(dtype.lower())
+    output_filename = "bigdl_llm_{}_{}.bin".format(model_family,
+                                                   dtype.lower())
     output_path = os.path.join(output_dir, output_filename)
     invalidInputError(dtype.lower() in quantize_type_map, "{0} model just accept {1} now, \
                       but you pass in {2}.".format(
@@ -93,4 +95,4 @@ def quantize(input_path: str, output_dir: str,
     p.communicate()
     invalidInputError(not p.returncode,
                       "Fail to quantize {}.".format(str(input_path)))
-    return output_path
+    return str(output_path)

--- a/python/llm/src/bigdl/llm/ggml/transformers/model.py
+++ b/python/llm/src/bigdl/llm/ggml/transformers/model.py
@@ -42,7 +42,7 @@ class AutoModelForCausalLM:
         """
         :param pretrained_model_name_or_path: We support 3 kinds of pretrained model checkpoint
 
-               1. path for huggingface checkpoint that are directly pulled from hugginface hub.
+               1. path for huggingface checkpoint that are directly pulled from huggingface hub.
                   This should be a dir path that contains: weight bin, tokenizer config,
                   tokenizer.model (required for llama) and added_tokens.json (if applied).
                   For lora fine tuned model, the path should be pointed to a merged weight.


### PR DESCRIPTION
## Description

Some enhancements for `convert_model` and provide command line for it.

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/8254

### 2. User API changes
small change for `convert_model`:
```python
from bigdl.llm.ggml import convert_model

output_path = convert_model(input_path=model_dir,
                            output_path="./quantized_gpt4all",
                            model_family="llama")
print(output_path)
```
```
./quantized_gpt4all/bigdl_llm_llama_q4_0.bin
```
command line script for convert:
`convert_model -i "/data/llm_models/gpt4all-7b-hf/" -o "./output_gpt4all/" -x "llama" -t "int4" -p "./llama_temp"
`
### 3. Summary of the change 

- change model filename pattern and extension to `bigdl_llm_llama_q4_0.bin`
- change `output_path` to `output_dir`, and make this path a mandatory entry
- Use tempfile to save intermediate results so that can avoid occupying too much space
- Update description of `input_path`
- Add input value check for `convert_model`
- command line script for convert
- fix some known bug

### 4. How to test?
- [x] Unit test

