### PR TITLE
[LLM] add long time loading disclaimer for LLM model converting

### DIFF
--- a/python/llm/src/bigdl/llm/ggml/convert.py
+++ b/python/llm/src/bigdl/llm/ggml/convert.py
@@ -97,6 +97,7 @@ def _convert_to_ggml(model_path: str, outfile_dir: str,
     os.makedirs(outfile_dir, exist_ok=True)
 
     outtype = outtype.replace('p', '')
+    print("It may takes several minutes to load the original model, please wait...")
     if model_family == 'llama':
         _convert_llama(model_path, outfile_dir, outtype)
     if model_family == 'gptneox':


### PR DESCRIPTION
## Description

It may take several minutes for some LLM models to be loaded from checkpoints [using `AutoModelForCausalLM.from_pretrained`], add a print message as disclaimer to let users not be panicked if there's no output for a long time.