### PR TITLE
[Nano] add dictionary input support for nano

### DIFF
--- a/python/nano/src/bigdl/nano/utils/pytorch/dataset.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/dataset.py
@@ -17,6 +17,7 @@
 import torch
 from torch.utils.data import Dataset
 from torch.utils.data.dataloader import default_collate
+from logging import warning
 
 
 class RepeatDataset(Dataset):
@@ -38,13 +39,17 @@ def remove_batch_dim_fn(loader):
         def recusive_remove(data):
             if isinstance(data, torch.Tensor):
                 return data.squeeze(0)
-            # TODO: if the data type of dict value is not tensor, will crash
             elif isinstance(data, dict):
                 for key in data:
                     data[key] = data[key].squeeze(0)
                 return data
-            else:
+            elif isinstance(data, (list, tuple)):
                 return tuple([recusive_remove(x) for x in data])
+            else:
+                warning(f"The input type should be tensor, or dict, list, tuple composed of tensor,\
+                        but get {type(data)}")
+                return data
+
         return recusive_remove(data)
     loader.collate_fn = warpper_fn
     return loader

--- a/python/nano/src/bigdl/nano/utils/pytorch/dataset.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/dataset.py
@@ -38,6 +38,11 @@ def remove_batch_dim_fn(loader):
         def recusive_remove(data):
             if isinstance(data, torch.Tensor):
                 return data.squeeze(0)
+            # TODO: if the data type of dict value is not tensor, will crash
+            elif isinstance(data, dict):
+                for key in data:
+                    data[key] = data[key].squeeze(0)
+                return data
             else:
                 return tuple([recusive_remove(x) for x in data])
         return recusive_remove(data)


### PR DESCRIPTION
## Description

change the `dataset.py`'s `wrap_fn` to fix the error when the input data contained dictionary 


### 1. How to test?
have successfully test on bert model 

### 2. Attention
The input of data maybe a dictionary which is not composed of tensor, this situation will lead error.

