### PR TITLE
Orca: fix save_weights() hdfs command not found issue.

### DIFF
--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -21,11 +21,11 @@ import tempfile
 import shutil
 
 from bigdl.dllib.utils.common import get_node_and_core_number
-from bigdl.dllib.utils.file_utils import is_local_path
+from bigdl.dllib.utils.file_utils import is_local_path, put_local_file_to_remote, \
+    put_local_files_with_prefix_to_remote
 from bigdl.dllib.utils.utils import get_node_ip
 from bigdl.orca.data.file import is_file, exists, get_remote_file_to_local, \
-    get_remote_files_with_prefix_to_local, put_local_file_to_remote, \
-    put_local_files_with_prefix_to_remote
+    get_remote_files_with_prefix_to_local
 from bigdl.orca.learn.tf2.spark_runner import SparkRunner
 from bigdl.orca.learn.utils import find_free_port, find_ip_and_free_port
 from bigdl.orca.learn.utils import maybe_dataframe_to_xshards, dataframe_to_xshards, \

--- a/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/pyspark_estimator.py
@@ -22,10 +22,10 @@ import shutil
 
 from bigdl.dllib.utils.common import get_node_and_core_number
 from bigdl.dllib.utils.file_utils import is_local_path, put_local_file_to_remote, \
-    put_local_files_with_prefix_to_remote
-from bigdl.dllib.utils.utils import get_node_ip
-from bigdl.orca.data.file import is_file, exists, get_remote_file_to_local, \
+    put_local_files_with_prefix_to_remote, get_remote_file_to_local, \
     get_remote_files_with_prefix_to_local
+from bigdl.dllib.utils.utils import get_node_ip
+from bigdl.orca.data.file import is_file, exists
 from bigdl.orca.learn.tf2.spark_runner import SparkRunner
 from bigdl.orca.learn.utils import find_free_port, find_ip_and_free_port
 from bigdl.orca.learn.utils import maybe_dataframe_to_xshards, dataframe_to_xshards, \


### PR DESCRIPTION
## Description
This PR is to fix `hdfs: command not found` issue #8275 , using [dllib api](https://github.com/intel-analytics/BigDL/blob/main/python/dllib/src/bigdl/dllib/utils/file_utils.py#L218) instead of [orca api](https://github.com/intel-analytics/BigDL/blob/main/python/orca/src/bigdl/orca/data/file.py#L429).
