### PR TITLE
Nano: fix bug of `@nano(use_ipex=True)`

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/torch_nano.py
+++ b/python/nano/src/bigdl/nano/pytorch/torch_nano.py
@@ -260,7 +260,7 @@ class TorchNano(LightningLite):
         # which is not supported by ddp currently,
         # so add IPEX 1.11's optimization after `_setup_model`
         if self.use_ipex:
-            ret = ipex_optimize(model, optimizers=optimizers, inplace=False, dtype=self.dtype)
+            ret = ipex_optimize(model, optimizers=optimizers, inplace=True, dtype=self.dtype)
             if isinstance(ret, tuple):
                 model, optimizers = ret[0], [ret[1]]
             else:

--- a/python/nano/test/pytorch/tests/train/torch_nano/test_torch_nano_ipex.py
+++ b/python/nano/test/pytorch/tests/train/torch_nano/test_torch_nano_ipex.py
@@ -182,7 +182,7 @@ class Lite:
         MyNano(use_ipex=True, precision='bf16', num_processes=2, distributed_backend="subprocess").train()
 
     def test_torch_nano_load_state_dict(self):
-        # _ipex_optimizer does not suppory load_state_dict until 1.13
+        # _ipex_optimizer does not support load_state_dict until 1.13
         # https://github.com/intel/intel-extension-for-pytorch/blob/release/1.12/
         # intel_extension_for_pytorch/optim/_optimizer_utils.py#L72
         from bigdl.nano.utils.common import compare_version

--- a/python/nano/test/pytorch/tests/train/torch_nano/test_torch_nano_ipex.py
+++ b/python/nano/test/pytorch/tests/train/torch_nano/test_torch_nano_ipex.py
@@ -182,7 +182,15 @@ class Lite:
         MyNano(use_ipex=True, precision='bf16', num_processes=2, distributed_backend="subprocess").train()
 
     def test_torch_nano_load_state_dict(self):
-        MyNanoLoadStateDict(use_ipex=True).train(0.25)
+        # _ipex_optimizer does not suppory load_state_dict until 1.13
+        # https://github.com/intel/intel-extension-for-pytorch/blob/release/1.12/
+        # intel_extension_for_pytorch/optim/_optimizer_utils.py#L72
+        from bigdl.nano.utils.common import compare_version
+        import operator
+        if compare_version("intel_extension_for_pytorch", operator.lt, "1.13"):
+            pass
+        else:
+            MyNanoLoadStateDict(use_ipex=True).train(0.25)
 
 
 TORCH_CLS = Lite


### PR DESCRIPTION
## Description

To fix bug reported by @gc-fu : when use `@nano(use_ipex=True)` to accelerate training loop, the output model seems not trained

### 2. User API changes

None

### 4. How to test?
- [x] Unit test
- [x] Local test

