### PR TITLE
LLM: first add `_tokenize`, `detokenize` and `_generate` for bloom pybinding

### DIFF
--- a/python/llm/src/bigdl/llm/ggml/model/bloom/bloom.py
+++ b/python/llm/src/bigdl/llm/ggml/model/bloom/bloom.py
@@ -302,7 +302,7 @@ class Bloom(GenerationMixin):
     def free(self):
         bloom_free(self.ctx)
 
-    def _tokenize(self, text: bytes, add_bos: bool = True) -> List[int]:
+    def _tokenize(self, text: bytes, add_bos: bool = False) -> List[int]:
         """Tokenize a string.
 
         Args:
@@ -315,7 +315,7 @@ class Bloom(GenerationMixin):
             A list of tokens.
         """
         invalidInputError(self.ctx is not None, "The attribute `ctx` of `Bloom` object is None.")
-        return bloom_tokenize(self.ctx, text, add_bos)
+        return bloom_tokenize(self.ctx, text, False)
 
     def detokenize(self, tokens: List[int]) -> bytes:
         """Detokenize a list of tokens.
@@ -327,10 +327,10 @@ class Bloom(GenerationMixin):
             The detokenized string.
         """
         invalidInputError(self.ctx is not None, "The attribute `ctx` of `Bloom` object is None.")
-        output = b""
+        output = ""
         for token in tokens:
             output += bloom_detokenize(self.ctx, token)
-        return output
+        return output.encode('utf-8')
 
     def forward(self, input_ids: List[int]) -> int:
         return bloom_forward(ctx=self.ctx,

--- a/python/llm/src/bigdl/llm/ggml/model/bloom/bloom.py
+++ b/python/llm/src/bigdl/llm/ggml/model/bloom/bloom.py
@@ -63,7 +63,7 @@ class Bloom(GenerationMixin):
         n_ctx: int = 512,
         n_parts: int = -1,
         n_gpu_layers: int = 0,
-        seed: int = 1337,
+        seed: int = -1,
         f16_kv: bool = True,
         logits_all: bool = False,
         vocab_only: bool = False,
@@ -84,7 +84,7 @@ class Bloom(GenerationMixin):
             n_ctx: Maximum context size.
             n_parts: Number of parts to split the model into. If -1, the number of parts
             is automatically determined.
-            seed: Random seed. 0 for random.
+            seed: Random seed. For default value -1, current timestamp is used as seed.
             f16_kv: Use half-precision for key/value cache.
             logits_all: Return logits for all tokens, not just the last token.
             vocab_only: Only load the vocabulary no weights.

--- a/python/llm/src/bigdl/llm/ggml/model/bloom/bloom.py
+++ b/python/llm/src/bigdl/llm/ggml/model/bloom/bloom.py
@@ -57,33 +57,46 @@ import uuid
 class Bloom(GenerationMixin):
     """High-level Python wrapper for a bloom.cpp model."""
 
-    def __init__(self,
-                 model_path: str,
-                 n_ctx: int = 512,
-                 n_parts: int = -1,
-                 n_gpu_layers: int = 0,
-                 seed: int = 1337,
-                 f16_kv: bool = True,
-                 logits_all: bool = False,
-                 vocab_only: bool = False,
-                 use_mmap: bool = True,
-                 use_mlock: bool = False,
-                 embedding: bool = False,
-                 n_threads: int = 2,
-                 n_batch: int = 512,
-                 last_n_tokens_size: int = 64,
-                 verbose: bool = True,
-                 ):
+    def __init__(
+        self,
+        model_path: str,
+        n_ctx: int = 512,
+        n_parts: int = -1,
+        n_gpu_layers: int = 0,
+        seed: int = 1337,
+        f16_kv: bool = True,
+        logits_all: bool = False,
+        vocab_only: bool = False,
+        use_mmap: bool = True,
+        use_mlock: bool = False,
+        embedding: bool = False,
+        n_threads: Optional[int] = 2,
+        n_batch: int = 512,
+        last_n_tokens_size: int = 64,
+        lora_base: Optional[str] = None,
+        lora_path: Optional[str] = None,
+        verbose: bool = True,
+    ):
         """Load a bloom.cpp model from `model_path`.
 
         Args:
             model_path: Path to the model.
             n_ctx: Maximum context size.
+            n_parts: Number of parts to split the model into. If -1, the number of parts
+            is automatically determined.
             seed: Random seed. 0 for random.
+            f16_kv: Use half-precision for key/value cache.
             logits_all: Return logits for all tokens, not just the last token.
+            vocab_only: Only load the vocabulary no weights.
+            use_mmap: Use mmap if possible.
+            use_mlock: Force the system to keep the model in RAM.
+            embedding: Embedding mode only.
             n_threads: Number of threads to use. Default to be 2.
-            n_batch: Maximum number of prompt tokens to batch together when calling llama_eval.
+            n_batch: Maximum number of prompt tokens to batch together when calling bloom_eval.
             last_n_tokens_size: Maximum number of tokens to keep in the last_n_tokens deque.
+            lora_base: Optional path to base model, useful if using a quantized base model and
+            you want to apply LoRA to an f16 model.
+            lora_path: Path to a LoRA file to apply to the model.
             verbose: Print verbose output to stderr.
 
         Raises:
@@ -96,15 +109,73 @@ class Bloom(GenerationMixin):
         self.ctx = bloom_load(bytes(model_path, encoding='utf-8'), n_ctx, n_threads)
         invalidInputError(self.ctx is not None, f"Failed to load model from {model_path}")
         self.n_ctx = n_ctx
+        self.n_parts = n_parts
+        self.n_gpu_layers = n_gpu_layers
+        self.f16_kv = f16_kv
         self.seed = seed
         self.logits_all = logits_all
+        self.vocab_only = vocab_only
+        self.use_mmap = use_mmap
+        self.use_mlock = use_mlock
+        self.embedding = embedding
         self.n_threads = n_threads
         self.n_batch = n_batch
         self.last_n_tokens_size = last_n_tokens_size
+        self.lora_base = lora_base
+        self.lora_path = lora_path
         self.verbose = verbose
+        # TODO: Some parameters are temporarily not supported
+        unsupported_arg = {'n_parts': -1, 'n_gpu_layers': 0, 'f16_kv': True, 'logits_all': False,
+                           'vocab_only': False, 'use_mmap': True, 'use_mlock': False,
+                           'embedding': False, 'last_n_tokens_size': 64, 'lora_base': None,
+                           'lora_path': None, 'verbose': True}
+        for arg in unsupported_arg.keys():
+            invalidInputError(getattr(self, arg) == unsupported_arg[arg], f"The parameter {arg}"
+                              " is temporarily unsupported, please use the default value.")
 
-    def __call__(self, prompt: str, max_tokens: int = 128, stream: bool = False,
-                 stop: Optional[List[str]] = []):
+    def __call__(
+        self,
+        prompt: str,
+        suffix: Optional[str] = None,
+        max_tokens: int = 128,
+        temperature: float = 0.8,
+        top_p: float = 0.95,
+        logprobs: Optional[int] = None,
+        echo: bool = False,
+        stop: Optional[Union[str, List[str]]]=[],
+        frequency_penalty: float = 0.0,
+        presence_penalty: float = 0.0,
+        repeat_penalty: float = 1.1,
+        top_k: int = 40,
+        stream: bool = False,
+        tfs_z: float = 1.0,
+        mirostat_mode: int = 0,
+        mirostat_tau: float = 5.0,
+        mirostat_eta: float = 0.1,
+        model: Optional[str] = None,
+    ):
+        # TODO: Some parameters are temporarily not supported
+        # Unsupported parameters are checked in `_supported_call`
+        return self._supported_call(prompt, max_tokens, stream, stop,
+                                    suffix, temperature, top_p, logprobs, echo, frequency_penalty,
+                                    presence_penalty, repeat_penalty, top_k, tfs_z, mirostat_mode,
+                                    mirostat_tau, mirostat_eta, model)
+
+    def _supported_call(self, prompt: str, max_tokens: int, stream: bool = False,
+                        stop: Optional[List[str]] = [], *args):
+        # Check unsupporeted parameters
+        unsupported_arg = ['suffix', 'temperature', 'top_p', 'logprobs', 'echo',
+                           'frequency_penalty', 'presence_penalty', 'repeat_penalty', 'top_k',
+                           'tfs_z', 'mirostat_mode', 'mirostat_tau', 'mirostat_eta', 'model']
+        defult_value = {'suffix': None, 'temperature': 0.8, 'top_p': 0.95, 'logprobs': None,
+                        'echo': False, 'frequency_penalty': 0.0, 'presence_penalty': 0.0,
+                        'repeat_penalty': 1.1, 'top_k': 40, 'tfs_z': 1.0, 'mirostat_mode': 0,
+                        'mirostat_tau': 5.0, 'mirostat_eta': 0.1, 'model': None}
+        for index in range(len(args)):
+            invalidInputError(args[index] == defult_value[unsupported_arg[index]],
+                              f"The parameter {unsupported_arg[index]} is temporarily "
+                              "unsupported, please use the default value.")
+
         if stream:
             return self.stream(prompt, max_tokens, stop)
         else:
@@ -276,7 +347,21 @@ class Bloom(GenerationMixin):
                           n_threads=self.n_threads,
                           n_batch=len(input_ids))
 
-    def _generate(self, tokens: Sequence[int]) -> Generator[int, Optional[Sequence[int]], None]:
+    def _generate(
+        self,
+        tokens: Sequence[int],
+        top_k: int = 40,
+        top_p: float = 0.95,
+        temp: float = 0.80,
+        repeat_penalty: float = 1.1,
+        reset: bool = True,
+        frequency_penalty: float = 0.0,
+        presence_penalty: float = 0.0,
+        tfs_z: float = 1.0,
+        mirostat_mode: int = 0,
+        mirostat_tau: float = 5.0,
+        mirostat_eta: float = 0.1,
+    ) -> Generator[int, Optional[Sequence[int]], None]:
         """Create a generator of tokens from a prompt.
 
         Examples:
@@ -291,9 +376,26 @@ class Bloom(GenerationMixin):
         Yields:
             The generated tokens.
         """
-        # TODO: Sample related parameters need to add to align with GenerationMixin.generate
-        invalidInputError(self.ctx is not None, "The attribute `ctx` of `Bloom` object is None.")
+        # TODO: Some parameters are temporarily not supported
+        # Unsupported parameters are checked in `_supported_generate`
+        return self._supported_generate(tokens, top_k, top_p, temp, repeat_penalty, reset,
+                                        frequency_penalty, presence_penalty, tfs_z, mirostat_mode,
+                                        mirostat_tau, mirostat_eta)
 
+    def _supported_generate(self, tokens: Sequence[int], *args):
+        # Check unsupporeted parameters
+        unsupported_arg = ['top_k', 'top_p', 'temp', 'repeat_penalty', 'reset',
+                           'frequency_penalty', 'presence_penalty', 'tfs_z', 'mirostat_mode',
+                           'mirostat_tau', 'mirostat_eta']
+        defult_value = {'top_k': 40, 'top_p': 0.95, 'temp': 0.80, 'repeat_penalty': 1.1,
+                        'reset': True, 'frequency_penalty': 0.0, 'presence_penalty': 0.0,
+                        'tfs_z': 1.0, 'mirostat_mode': 0, 'mirostat_tau': 5.0, 'mirostat_eta': 0.1}
+        for index in range(len(args)):
+            invalidInputError(args[index] == defult_value[unsupported_arg[index]],
+                              f"The parameter {unsupported_arg[index]} is temporarily "
+                              "unsupported, please use the default value.")
+
+        invalidInputError(self.ctx is not None, "The attribute `ctx` of `Bloom` object is None.")
         while True:
             token = self.forward(tokens)
             tokens_or_none = yield token

--- a/python/llm/src/bigdl/llm/ggml/model/bloom/bloom_cpp.py
+++ b/python/llm/src/bigdl/llm/ggml/model/bloom/bloom_cpp.py
@@ -48,13 +48,16 @@
 import sys
 import os
 import ctypes
+from typing import List
 from ctypes import (
     c_int,
+    c_long,
     c_float,
     c_char_p,
     c_void_p,
     c_bool,
     POINTER,
+    pointer,
     Structure,
     Array,
     c_uint8,
@@ -101,6 +104,7 @@ def _load_shared_library(lib_base_name: str):
     for _lib_path in _lib_paths:
         if _lib_path.exists():
             try:
+                print("_lib_path:", _lib_path)
                 return ctypes.CDLL(str(_lib_path))
             except Exception as e:
                 invalidInputError(False,
@@ -114,6 +118,14 @@ _lib_base_name = "bloom"
 
 # Load the library
 _lib = _load_shared_library(_lib_base_name)
+
+
+def c_free(p: c_void_p):
+    _lib.c_free(p)
+
+
+_lib.c_free.argtypes = [c_void_p]
+_lib.c_free.restype = None
 
 
 def bloom_load(fname: bytes, n_ctx: c_int, n_threads: c_int) -> c_void_p:
@@ -145,5 +157,82 @@ def bloom_run(ctx: c_void_p,
 
 _lib.bloom_run.argtypes = [c_void_p, c_int, c_int, c_int, c_int, c_bool, c_char_p, c_char_p]
 _lib.bloom_run.restype = c_int
+
+
+def bloom_tokenize(ctx: c_void_p,
+                   prompt: bytes,
+                   bos: bool = False) -> List[int]:
+    n_tokens = c_int(0)
+    c_tokens = _lib.tokenize_api(ctx, prompt, bos, pointer(n_tokens))
+    tokens = [c_tokens[i] for i in range(0, n_tokens.value)]
+    c_free(c_tokens)
+    return tokens
+
+
+_lib.tokenize_api.argtypes = [c_void_p, c_char_p, c_bool, c_void_p]
+_lib.tokenize_api.restype = POINTER(c_int)
+
+
+def bloom_detokenize(ctx: c_void_p,
+                     token_id: c_int) -> bytes:
+    return _lib.detokenize_api(ctx, token_id)
+
+
+_lib.detokenize_api.argtypes = [c_void_p, c_int]
+_lib.detokenize_api.restype = c_char_p
+
+
+def bloom_eval(ctx: c_void_p,
+               input_ids: List[int],
+               seed: c_int,
+               n_threads: c_int,
+               n_batch: c_int) -> List[List[float]]:
+    length = len(input_ids)
+    c_input_ids = (c_int * length)(*input_ids)
+    n_logits = c_long(0)
+    c_logits = _lib.eval_api(ctx, c_input_ids, length, seed, n_threads, n_batch, pointer(n_logits))
+    n_vocab = n_logits.value // length
+    assert(n_vocab * length == n_logits.value)
+    logits = [[c_logits[i * n_vocab + j] for j in range(n_vocab)] for i in range(length)]
+    # do not free c_logits
+    return logits
+
+
+_lib.eval_api.argtypes = [c_void_p, c_void_p, c_int, c_int, c_int, c_int, c_void_p]
+_lib.eval_api.restype = POINTER(c_float)
+
+
+def bloom_embed(ctx: c_void_p,
+                input_ids: List[int],
+                seed: c_int,
+                n_threads: c_int,
+                n_batch: c_int) -> List[float]:
+    length = len(input_ids)
+    c_input_ids = (c_int * length)(*input_ids)
+    n_embd = c_long(0)
+    c_embeddings = _lib.embed_api(ctx, c_input_ids, length, seed, n_threads,
+                                  n_batch, pointer(n_embd))
+    embeddings = [c_embeddings[i] for i in range(n_embd.value)]
+    # do not free c_embeddings
+    return embeddings
+
+
+_lib.embed_api.argtypes = [c_void_p, c_void_p, c_int, c_int, c_int, c_int, c_void_p]
+_lib.embed_api.restype = POINTER(c_float)
+
+
+def bloom_forward(ctx: c_void_p,
+                  input_ids: List[int],
+                  seed: c_int,
+                  n_threads: c_int,
+                  n_batch: c_int) -> int:
+    length = len(input_ids)
+    c_input_ids = (c_int * length)(*input_ids)
+    token_id = _lib.forward_api(ctx, c_input_ids, length, seed, n_threads, n_batch)
+    return token_id
+
+
+_lib.forward_api.argtypes = [c_void_p, c_void_p, c_int, c_int, c_int, c_int]
+_lib.forward_api.restype = c_int
 
 # ------------------------------------------------------------------- #

--- a/python/llm/src/bigdl/llm/ggml/model/bloom/bloom_cpp.py
+++ b/python/llm/src/bigdl/llm/ggml/model/bloom/bloom_cpp.py
@@ -104,7 +104,6 @@ def _load_shared_library(lib_base_name: str):
     for _lib_path in _lib_paths:
         if _lib_path.exists():
             try:
-                print("_lib_path:", _lib_path)
                 return ctypes.CDLL(str(_lib_path))
             except Exception as e:
                 invalidInputError(False,

--- a/python/llm/src/bigdl/llm/ggml/model/bloom/bloom_cpp.py
+++ b/python/llm/src/bigdl/llm/ggml/model/bloom/bloom_cpp.py
@@ -174,8 +174,10 @@ _lib.tokenize_api.restype = POINTER(c_int)
 
 
 def bloom_detokenize(ctx: c_void_p,
-                     token_id: c_int) -> bytes:
-    return _lib.detokenize_api(ctx, token_id)
+                     token_id: c_int) -> str:
+    c_chars = _lib.detokenize_api(ctx, token_id)
+    s = c_chars.decode('utf-8')
+    return s
 
 
 _lib.detokenize_api.argtypes = [c_void_p, c_int]

--- a/python/llm/src/bigdl/llm/ggml/model/gptneox/gptneox.py
+++ b/python/llm/src/bigdl/llm/ggml/model/gptneox/gptneox.py
@@ -132,7 +132,7 @@ class Gptneox(GenerationMixin):
         n_ctx: int = 512,
         n_parts: int = -1,
         n_gpu_layers: int = 0,
-        seed: int = 1337,
+        seed: int = -1,
         f16_kv: bool = True,
         logits_all: bool = False,
         vocab_only: bool = False,
@@ -153,7 +153,7 @@ class Gptneox(GenerationMixin):
             n_ctx: Maximum context size.
             n_parts: Number of parts to split the model into. If -1,
             the number of parts is automatically determined.
-            seed: Random seed. 0 for random.
+            seed: Random seed. For default value -1, current timestamp is used as seed.
             f16_kv: Use half-precision for key/value cache.
             logits_all: Return logits for all tokens, not just the last token.
             vocab_only: Only load the vocabulary no weights.

--- a/python/llm/src/bigdl/llm/ggml/model/llama/llama.py
+++ b/python/llm/src/bigdl/llm/ggml/model/llama/llama.py
@@ -130,7 +130,7 @@ class Llama(GenerationMixin):
         n_ctx: int = 512,
         n_parts: int = -1,
         n_gpu_layers: int = 0,
-        seed: int = 1337,
+        seed: int = -1,
         f16_kv: bool = True,
         logits_all: bool = False,
         vocab_only: bool = False,
@@ -151,7 +151,7 @@ class Llama(GenerationMixin):
             n_ctx: Maximum context size.
             n_parts: Number of parts to split the model into. If -1, the number of parts
             is automatically determined.
-            seed: Random seed. 0 for random.
+            seed: Random seed. For default value -1, current timestamp is used as seed.
             f16_kv: Use half-precision for key/value cache.
             logits_all: Return logits for all tokens, not just the last token.
             vocab_only: Only load the vocabulary no weights.


### PR DESCRIPTION
## Description

Add `tokenize`, `detokenize` and `generate` methods for Bloom pybinding. And make API compatible with Llama and Gptneox. 
**For those unsupported parameters of Bloom, errors will be raised if users input them. The default behavior is to ignore these settings temporarily.**
(More enhancements are on the way.)

### 2. User API changes

- transformers-like API
```python
from bigdl.llm.ggml.transformers import AutoModelForCausalLM

llm = AutoModelForCausalLM.from_pretrained(pretrained_model_name_or_path=your_model_path,
                                           model_family='bloom')
tokens = llm.tokenize(b"Learning English is")
tokens_id = llm.generate(tokens, max_new_tokens=10)
output = llm.batch_decode(tokens_id)
print(output)
```
- directly call model
```python
from bigdl.llm.models import Bloom

llm = Bloom(your_model_path)
tokens = llm._tokenize(b"Learning English is")
for token in llm._generate(tokens):
    print(llm.detokenize([token]).decode("utf-8", errors="ignore"))
```

### 3. Summary of the change 

- internal implementation of `Bloom._tokenize`, `Bloom.detokenize` and `Bloom._generate`
- internal implementation of `Bloom._supported_call` and `Bloom._supported_generate`, in which unsupported parameters will be checked
- `__init__`, `__call__`, `_tokenize` and `_generate` are compatible with Llama and Gptneox.

### 4. How to test?
- [ ] Unit test
- [x] Local test
