### PR TITLE
Fix missing import of ipex int8 model

### DIFF
--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
@@ -57,6 +57,7 @@ class PytorchQuantizedModel(AcceleratedLightningModule):
         # only ipex quantization saves this file
         if os.path.exists(os.path.join(path, "best_configure.json")):
             ipex_quantization = True
+            import intel_extension_for_pytorch as ipex
         if ipex_quantization:
             invalidInputError(example_inputs is not None,
                               "For INC ipex quantizated model, you need to set input_sample "


### PR DESCRIPTION
## Description

Fix missing `import intel_extension_for_pytorch` of ipex int8 model which caused very severe performance degradation of loaded model.

### How to test?
- [x] Unit test
- [x] Local test


