### PR TITLE
Remove python3-pip in apt.

### DIFF
--- a/ppml/trusted-dl-serving/base/Dockerfile
+++ b/ppml/trusted-dl-serving/base/Dockerfile
@@ -143,7 +143,7 @@ COPY --from=tf-serving /usr/local/bin/tensorflow_model_server /usr/bin/tensorflo
 
 # Dependencies
 RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
-    apt-get install -y --no-install-recommends software-properties-common libb64-0d             libcurl4-openssl-dev libre2-5 git gperf dirmngr libgoogle-perftools-dev libnuma-dev curl libgomp1 openmpi-bin patchelf python3 libarchive-dev python3-pip libpython3-dev && \
+    apt-get install -y --no-install-recommends software-properties-common libb64-0d             libcurl4-openssl-dev libre2-5 git gperf dirmngr libgoogle-perftools-dev libnuma-dev curl libgomp1 openmpi-bin patchelf python3 libarchive-dev libpython3-dev && \
     apt-get install -y libssl-dev && \
 # Optimization related
     pip3 install --pre --no-cache --upgrade bigdl-nano[pytorch_112,inference] vit_pytorch && \


### PR DESCRIPTION
## Description
Remove python3-pip in apt.

### 1. Why the change?

Pip is already installed in base image.
