### PR TITLE
Chronos: update tensorflow support in installation doc

### DIFF
--- a/docs/readthedocs/source/_static/css/installation_panel.css
+++ b/docs/readthedocs/source/_static/css/installation_panel.css
@@ -16,7 +16,7 @@
     table-layout: fixed; /* make cells have even width */
 }
 
-.installation-panel-table tr td{
+.installation-panel-table tr, .installation-panel-table td{
     padding: 0.5rem;
     background-color: var(--pst-color-on-surface);
 }

--- a/docs/readthedocs/source/_static/css/installation_panel.css
+++ b/docs/readthedocs/source/_static/css/installation_panel.css
@@ -16,7 +16,7 @@
     table-layout: fixed; /* make cells have even width */
 }
 
-.installation-panel-table tr, td{
+.installation-panel-table tr td{
     padding: 0.5rem;
     background-color: var(--pst-color-on-surface);
 }

--- a/docs/readthedocs/source/doc/Chronos/Overview/install.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/install.md
@@ -137,3 +137,15 @@ Chronos can be simply installed using pip on native Windows, you could use the s
 2. `intel_extension_for_pytorch (ipex)` is unavailable for Windows now, so the related feature is not supported.
 
 For some known issues when installing and using Chronos on native Windows, you could refer to [windows_guide](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Howto/windows_guide.html).
+
+##### Install Chronos along with specific Tensorflow
+
+Currently, the default Tensorflow version of Chronos is 2.7. But Chronos is also validated on Tensorflow 2.8-2.12. If you want to use specific Tensorflow, please follow the table below to find the extra install command after installing Chronos.
+
+| TF version | Install CMD |
+| :-----: | :-----: |
+| 2.8 | pip install tensorflow==2.8.0 intel-tensorflow==2.8.0 |
+| 2.9 | pip install tensorflow==2.9.0 intel-tensorflow==2.9.1 |
+| 2.10 | pip install tensorflow==2.10.0 intel-tensorflow==2.10.0 |
+| 2.11 | pip install tensorflow==2.11.0 intel-tensorflow==2.11.0 |
+| 2.12 | pip install tensorflow==2.12.0 intel-tensorflow==2.12.0 protobuf==3.20.3 |

--- a/docs/readthedocs/source/doc/Chronos/Overview/install.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/install.md
@@ -142,13 +142,10 @@ For some known issues when installing and using Chronos on native Windows, you c
 
 Currently, the default Tensorflow version of Chronos is 2.7. But Chronos is also validated on Tensorflow 2.8-2.12. If you want to use specific Tensorflow, please follow the table below to find the extra install command after installing Chronos.
 
-```eval_rst
-
-    +--------+---------+
-    | TF version | Install CMD |
-    +========+=========+
-    | 2.8 | pip install tensorflow==2.8.0 intel-tensorflow==2.8.0 |
-    +--------+---------+
-    | 2.9 | pip install tensorflow==2.9.0 intel-tensorflow==2.9.1 |
-    +--------+---------+
-```
+| TF version       | Install CMD                                                                 |
+| ---------------- | --------------------------------------------------------------------------- |
+| **2.8**          | pip install tensorflow==2.8.0 intel-tensorflow==2.8.0                       |
+| **2.9**          | pip install tensorflow==2.9.0 intel-tensorflow==2.9.1                       |
+| **2.10**         | pip install tensorflow==2.10.0 intel-tensorflow==2.10.0                     |
+| **2.11**         | pip install tensorflow==2.11.0 intel-tensorflow==2.11.0                     |
+| **2.12**         | pip install tensorflow==2.12.0 intel-tensorflow==2.12.0 protobuf==3.20.3    |

--- a/docs/readthedocs/source/doc/Chronos/Overview/install.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/install.md
@@ -142,10 +142,12 @@ For some known issues when installing and using Chronos on native Windows, you c
 
 Currently, the default Tensorflow version of Chronos is 2.7. But Chronos is also validated on Tensorflow 2.8-2.12. If you want to use specific Tensorflow, please follow the table below to find the extra install command after installing Chronos.
 
-| TF version | Install CMD |
-| :-----: | :-----: |
-| 2.8 | pip install tensorflow==2.8.0 intel-tensorflow==2.8.0 |
-| 2.9 | pip install tensorflow==2.9.0 intel-tensorflow==2.9.1 |
-| 2.10 | pip install tensorflow==2.10.0 intel-tensorflow==2.10.0 |
-| 2.11 | pip install tensorflow==2.11.0 intel-tensorflow==2.11.0 |
-| 2.12 | pip install tensorflow==2.12.0 intel-tensorflow==2.12.0 protobuf==3.20.3 |
+.. eval_rst::
+
+    +--------+---------+---------+
+    | TF version | Install CMD |
+    +========+=========+=========+
+    | 2.8 | pip install tensorflow==2.8.0 intel-tensorflow==2.8.0 |
+    +--------+---------+---------+
+    | 2.9 | pip install tensorflow==2.9.0 intel-tensorflow==2.9.1 |
+    +--------+---------+---------+

--- a/docs/readthedocs/source/doc/Chronos/Overview/install.md
+++ b/docs/readthedocs/source/doc/Chronos/Overview/install.md
@@ -142,12 +142,13 @@ For some known issues when installing and using Chronos on native Windows, you c
 
 Currently, the default Tensorflow version of Chronos is 2.7. But Chronos is also validated on Tensorflow 2.8-2.12. If you want to use specific Tensorflow, please follow the table below to find the extra install command after installing Chronos.
 
-.. eval_rst::
+```eval_rst
 
-    +--------+---------+---------+
+    +--------+---------+
     | TF version | Install CMD |
-    +========+=========+=========+
+    +========+=========+
     | 2.8 | pip install tensorflow==2.8.0 intel-tensorflow==2.8.0 |
-    +--------+---------+---------+
+    +--------+---------+
     | 2.9 | pip install tensorflow==2.9.0 intel-tensorflow==2.9.1 |
-    +--------+---------+---------+
+    +--------+---------+
+```


### PR DESCRIPTION
## Description

Currently, the default Tensorflow version of Chronos is 2.7.
Although Chronos is validated on tf2.12, there exists conflict with Nano because of `protobuf`.
Temporarily update descriptions about extra install command of specific TF. `setup.py` will be updated after Nano support tf2.12.

### 4. How to test?
- [x] Unit test (validate tf2.8-2.12 in https://github.com/intel-analytics/BigDL/pull/8255/checks)
- [x] Document test (https://binbin-doc.readthedocs.io/en/update-tf-installation-doc/doc/Chronos/Overview/install.html)