### PR TITLE
LLM: fix match in setup.py

### DIFF
--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -99,7 +99,9 @@ def obtain_lib_urls():
             for binary in binarys:
                 if binary in binary_url:
                     continue
-                if binary in text:
+                # Filename hard matching
+                match_pattern = "\"name\":\"{}\"".format(binary)
+                if match_pattern in text:
                     lib_url = url + binary
                     binary_url[binary] = lib_url
                     download_num -= 1


### PR DESCRIPTION
## Description
Fuzzy search can cause incorrect downloading of `quantize-llama` when only `quantize-llama.exe` exists
Change to a file name hard match to avoid this issue.

### How to test?
- [x] Unit test
