### PR TITLE
[LLM] Supports GPTQ convert in transfomers-like API, and supports folder outfile for `llm-convert`

### DIFF
--- a/python/llm/README.md
+++ b/python/llm/README.md
@@ -39,8 +39,9 @@ Here is an example to use `llm-convert` command line tool.
 # pth model
 llm-convert "/path/to/llama-7b-hf/" --model-format pth --outfile "/path/to/llama-7b-int4/" --model-family "llama"
 # gptq model
-llm-convert "/path/to/vicuna-13B-1.1-GPTQ-4bit-128g/" --model-format gptq --outfile "/path/to/out.bin" --model-family "llama"
+llm-convert "/path/to/vicuna-13B-1.1-GPTQ-4bit-128g/" --model-format gptq --outfile "/path/to/vicuna-13B-int4/" --model-family "llama"
 ```
+> An example GPTQ model can be found [here](https://huggingface.co/TheBloke/vicuna-13B-1.1-GPTQ-4bit-128g/tree/main)
 
 Here is an example to use `llm_convert` python API.
 ```bash

--- a/python/llm/example/transformers/int4_pipeline.py
+++ b/python/llm/example/transformers/int4_pipeline.py
@@ -44,9 +44,9 @@ def convert_and_load(repo_id_or_model_path, model_family, n_threads):
     #
     # model_path = repo_id_or_model_path
     # output_ckpt_path = llm_convert(
-    #     input_path=model_path,
-    #     output_path='./',
-    #     dtype='int4',
+    #     model=model_path,
+    #     outfile='./',
+    #     outtype='int4',
     #     model_family=model_family)
     #
     # llm = AutoModelForCausalLM.from_pretrained(

--- a/python/llm/example/transformers/int4_pipeline.py
+++ b/python/llm/example/transformers/int4_pipeline.py
@@ -40,7 +40,7 @@ def convert_and_load(repo_id_or_model_path, model_family, n_threads):
     # to convert the downloaded Huggungface checkpoint first,
     # and then load the binary checkpoint directly.
     #
-    # from bigdl.llm.ggml import llm_convert
+    # from bigdl.llm import llm_convert
     #
     # model_path = repo_id_or_model_path
     # output_ckpt_path = llm_convert(

--- a/python/llm/src/bigdl/llm/convert_model.py
+++ b/python/llm/src/bigdl/llm/convert_model.py
@@ -93,7 +93,7 @@ def llm_convert(model,
                                              check_args=["tokenizer_path"])
 
         output_filename = "bigdl_llm_{}_{}_from_gptq.bin".format(model_family,
-                                                       outtype.lower())
+                                                                 outtype.lower())
         outfile = os.path.join(outfile, output_filename)
 
         if "tokenizer_path" in _used_args:

--- a/python/llm/src/bigdl/llm/convert_model.py
+++ b/python/llm/src/bigdl/llm/convert_model.py
@@ -35,6 +35,43 @@ def llm_convert(model,
                 outtype='int4',
                 model_format="pth",
                 **kwargs):
+    """
+    This function is able to:
+
+        1. Convert Hugging Face llama-like / gpt-neox-like / bloom-like / starcoder-like
+           original model to lower precision in BigDL-LLM optimized GGML format
+        2. Convert GPTQ format llama-like model to BigDL-LLM optimized GGML format
+
+    :param model: Path to a **directory**:
+
+           1. If ``model_format='pth'``, the folder should be a huggingface checkpoint 
+              that are directly pulled from huggingface hub, for example ``./llama-7b-hf``.
+              This should be a dir path that contains: weight bin, tokenizer config,
+              tokenizer.model (required for llama) and added_tokens.json (if applied).
+              For lora finetuned model, the path should be pointed to a merged weight.
+           2. If ``model_format='gptq'``, the folder should contains weights in
+              pytorch's .pt format, and ``tokenizer.model``
+
+    :param outfile: Save path of output quantized model. You must pass a *directory* to
+           save all related output.
+    :param model_family: Which model family your input model belongs to.
+           Now ``llama``/``bloom``/``gptneox``/``starcoder`` has been supported.
+           If ``model_format='gptq'``, only ``llama`` is supported.
+    :param dtype: Which quantized precision will be converted.
+           If ``model_format='pth'``, `int4` and `int8` are supported,
+           meanwhile `int8` only works for `llama` and `gptneox`.
+           If ``model_format='gptq'``, only ``int4`` is supported.
+    :param model_format: Specify the model format to be converted. ``pth`` is for
+           original model checkpoint from Hugging Face. ``gptq`` is for GPTQ format model.
+    :param **kwargs: Supported keyword arguments includes:
+           
+           * ``tmp_path``: Valid when ``model_format='pth'``. It refers to the path
+             that stores the intermediate model during the conversion process.
+           * ``tokenizer_path``: Valid when ``model_format='gptq'``. It refers to the path
+             where ``tokenizer.model`` is located (if it is not in the ``model`` directory)
+
+    :return: the path string to the converted lower precision checkpoint.
+    """
     if model_format == "pth":
         _, _used_args = _special_kwarg_check(kwargs=kwargs,
                                              check_args=["tmp_path"])

--- a/python/llm/src/bigdl/llm/convert_model.py
+++ b/python/llm/src/bigdl/llm/convert_model.py
@@ -46,7 +46,7 @@ def llm_convert(model,
 
     :param model: Path to a **directory**:
 
-           1. If ``model_format='pth'``, the folder should be a huggingface checkpoint 
+           1. If ``model_format='pth'``, the folder should be a huggingface checkpoint
               that is directly pulled from huggingface hub, for example ``./llama-7b-hf``.
               This should be a dir path that contains: weight bin, tokenizer config,
               tokenizer.model (required for llama) and added_tokens.json (if applied).
@@ -66,7 +66,7 @@ def llm_convert(model,
     :param model_format: Specify the model format to be converted. ``pth`` is for
            original model checkpoint from Hugging Face. ``gptq`` is for GPTQ format model.
     :param **kwargs: Supported keyword arguments includes:
-           
+
            * ``tmp_path``: Valid when ``model_format='pth'``. It refers to the path
              that stores the intermediate model during the conversion process.
            * ``tokenizer_path``: Valid when ``model_format='gptq'``. It refers to the path

--- a/python/llm/src/bigdl/llm/convert_model.py
+++ b/python/llm/src/bigdl/llm/convert_model.py
@@ -92,13 +92,18 @@ def llm_convert(model,
         _, _used_args = _special_kwarg_check(kwargs=kwargs,
                                              check_args=["tokenizer_path"])
 
-        output_filename = "bigdl_llm_{}_{}.bin".format(model_family,
+        output_filename = "bigdl_llm_{}_{}_from_gptq.bin".format(model_family,
                                                        outtype.lower())
         outfile = os.path.join(outfile, output_filename)
 
+        if "tokenizer_path" in _used_args:
+            gptq_tokenizer_path = _used_args["tokenizer_path"]
+        else:
+            gptq_tokenizer_path = None
+
         convert_gptq2ggml(input_path=model,
                           output_path=outfile,
-                          tokenizer_path=_used_args["tokenizer_path"],
+                          tokenizer_path=gptq_tokenizer_path,
                           )
         return outfile
     else:

--- a/python/llm/src/bigdl/llm/convert_model.py
+++ b/python/llm/src/bigdl/llm/convert_model.py
@@ -19,6 +19,7 @@ from bigdl.llm.ggml.convert_model import convert_model as ggml_convert_model
 from bigdl.llm.gptq.convert.convert_gptq_to_ggml import convert_gptq2ggml
 from bigdl.llm.utils.common import invalidInputError
 import argparse
+import os
 
 
 def _special_kwarg_check(kwargs, check_args):
@@ -86,8 +87,15 @@ def llm_convert(model,
         invalidInputError(model_family == "llama" and outtype == 'int4',
                           "Convert GPTQ models should always "
                           "specify `--model-family llama --dtype int4` in the command line.")
+        invalidInputError(os.path.isdir(outfile),
+                          "The output_path {} was not a directory".format(outfile))
         _, _used_args = _special_kwarg_check(kwargs=kwargs,
                                              check_args=["tokenizer_path"])
+
+        output_filename = "bigdl_llm_{}_{}.bin".format(model_family,
+                                                       outtype.lower())
+        outfile = os.path.join(outfile, output_filename)
+
         convert_gptq2ggml(input_path=model,
                           output_path=outfile,
                           tokenizer_path=_used_args["tokenizer_path"],

--- a/python/llm/src/bigdl/llm/convert_model.py
+++ b/python/llm/src/bigdl/llm/convert_model.py
@@ -46,13 +46,14 @@ def llm_convert(model,
 
     :param model: Path to a **directory**:
 
-           1. If ``model_format='pth'``, the folder should be a huggingface checkpoint
-              that is directly pulled from huggingface hub, for example ``./llama-7b-hf``.
+           1. If ``model_format='pth'``, the folder should be a Hugging Face checkpoint
+              that is directly pulled from Hugging Face hub, for example ``./llama-7b-hf``.
               This should be a dir path that contains: weight bin, tokenizer config,
               tokenizer.model (required for llama) and added_tokens.json (if applied).
               For lora finetuned model, the path should be pointed to a merged weight.
-           2. If ``model_format='gptq'``, the folder should be be a huggingface checkpoint
-              that contains weights in pytorch's .pt format, and ``tokenizer.model``.
+           2. If ``model_format='gptq'``, the folder should be be a Hugging Face checkpoint
+              in GPTQ format, which contains weights in pytorch's .pt format,
+              and ``tokenizer.model``.
 
     :param outfile: Save path of output quantized model. You must pass a **directory** to
            save all related output.

--- a/python/llm/src/bigdl/llm/convert_model.py
+++ b/python/llm/src/bigdl/llm/convert_model.py
@@ -39,20 +39,21 @@ def llm_convert(model,
     This function is able to:
 
         1. Convert Hugging Face llama-like / gpt-neox-like / bloom-like / starcoder-like
-           original model to lower precision in BigDL-LLM optimized GGML format
-        2. Convert GPTQ format llama-like model to BigDL-LLM optimized GGML format
+           original model to lower precision in BigDL-LLM optimized GGML format.
+        2. Convert Hugging Face GPTQ format llama-like model to BigDL-LLM optimized
+           GGML format.
 
     :param model: Path to a **directory**:
 
            1. If ``model_format='pth'``, the folder should be a huggingface checkpoint 
-              that are directly pulled from huggingface hub, for example ``./llama-7b-hf``.
+              that is directly pulled from huggingface hub, for example ``./llama-7b-hf``.
               This should be a dir path that contains: weight bin, tokenizer config,
               tokenizer.model (required for llama) and added_tokens.json (if applied).
               For lora finetuned model, the path should be pointed to a merged weight.
-           2. If ``model_format='gptq'``, the folder should contains weights in
-              pytorch's .pt format, and ``tokenizer.model``
+           2. If ``model_format='gptq'``, the folder should be be a huggingface checkpoint
+              that contains weights in pytorch's .pt format, and ``tokenizer.model``.
 
-    :param outfile: Save path of output quantized model. You must pass a *directory* to
+    :param outfile: Save path of output quantized model. You must pass a **directory** to
            save all related output.
     :param model_family: Which model family your input model belongs to.
            Now ``llama``/``bloom``/``gptneox``/``starcoder`` has been supported.

--- a/python/llm/src/bigdl/llm/convert_model.py
+++ b/python/llm/src/bigdl/llm/convert_model.py
@@ -40,7 +40,7 @@ def llm_convert(model,
     This function is able to:
 
         1. Convert Hugging Face llama-like / gpt-neox-like / bloom-like / starcoder-like
-           original model to lower precision in BigDL-LLM optimized GGML format.
+           PyTorch model to lower precision in BigDL-LLM optimized GGML format.
         2. Convert Hugging Face GPTQ format llama-like model to BigDL-LLM optimized
            GGML format.
 
@@ -64,7 +64,8 @@ def llm_convert(model,
            meanwhile `int8` only works for `llama` and `gptneox`.
            If ``model_format='gptq'``, only ``int4`` is supported.
     :param model_format: Specify the model format to be converted. ``pth`` is for
-           original model checkpoint from Hugging Face. ``gptq`` is for GPTQ format model.
+           PyTorch model checkpoint from Hugging Face. ``gptq`` is for GPTQ format
+           model from Hugging Face.
     :param **kwargs: Supported keyword arguments includes:
 
            * ``tmp_path``: Valid when ``model_format='pth'``. It refers to the path
@@ -88,7 +89,7 @@ def llm_convert(model,
                           "Convert GPTQ models should always "
                           "specify `--model-family llama --dtype int4` in the command line.")
         invalidInputError(os.path.isdir(outfile),
-                          "The output_path {} was not a directory".format(outfile))
+                          "The output_path {} is not a directory".format(outfile))
         _, _used_args = _special_kwarg_check(kwargs=kwargs,
                                              check_args=["tokenizer_path"])
 

--- a/python/llm/src/bigdl/llm/ggml/convert_model.py
+++ b/python/llm/src/bigdl/llm/ggml/convert_model.py
@@ -30,7 +30,7 @@ def convert_model(input_path: str,
                   tmp_path: str = None):
     """
     Convert Hugging Face llama-like / gpt-neox-like / bloom-like / starcoder-like
-    original model to lower precision
+    PyTorch model to lower precision
 
     :param input_path: Path to a **directory** for huggingface checkpoint that is directly
             pulled from huggingface hub, for example `./llama-7b-hf`. This should be a dir

--- a/python/llm/src/bigdl/llm/ggml/convert_model.py
+++ b/python/llm/src/bigdl/llm/ggml/convert_model.py
@@ -29,9 +29,10 @@ def convert_model(input_path: str,
                   dtype: str = 'int4',
                   tmp_path: str = None):
     """
-    Convert Hugging Face llama-like / gpt-neox-like / bloom-like model to lower precision
+    Convert Hugging Face llama-like / gpt-neox-like / bloom-like / starcoder-like
+    original model to lower precision
 
-    :param input_path: Path to a *directory*  for huggingface checkpoint that are directly
+    :param input_path: Path to a **directory** for huggingface checkpoint that are directly
             pulled from huggingface hub, for example `./llama-7b-hf`. This should be a dir
             path that contains: weight bin, tokenizer config, tokenizer.model (required for
             llama) and added_tokens.json (if applied).
@@ -39,7 +40,7 @@ def convert_model(input_path: str,
     :param output_path: Save path of output quantized model. You must pass a *directory* to
             save all related output.
     :param model_family: Which model family your input model belongs to.
-            Now only `llama`/`bloom`/`gptneox`/`starcoder` are supported.
+            Now only ``llama``/``bloom``/``gptneox``/``starcoder`` are supported.
     :param dtype: Which quantized precision will be converted.
             Now only `int4` and `int8` are supported, and `int8` only works for `llama`
             and `gptneox`.

--- a/python/llm/src/bigdl/llm/ggml/convert_model.py
+++ b/python/llm/src/bigdl/llm/ggml/convert_model.py
@@ -32,12 +32,12 @@ def convert_model(input_path: str,
     Convert Hugging Face llama-like / gpt-neox-like / bloom-like / starcoder-like
     original model to lower precision
 
-    :param input_path: Path to a **directory** for huggingface checkpoint that are directly
+    :param input_path: Path to a **directory** for huggingface checkpoint that is directly
             pulled from huggingface hub, for example `./llama-7b-hf`. This should be a dir
             path that contains: weight bin, tokenizer config, tokenizer.model (required for
             llama) and added_tokens.json (if applied).
             For lora finetuned model, the path should be pointed to a merged weight.
-    :param output_path: Save path of output quantized model. You must pass a *directory* to
+    :param output_path: Save path of output quantized model. You must pass a **directory** to
             save all related output.
     :param model_family: Which model family your input model belongs to.
             Now only ``llama``/``bloom``/``gptneox``/``starcoder`` are supported.

--- a/python/llm/src/bigdl/llm/ggml/quantize.py
+++ b/python/llm/src/bigdl/llm/ggml/quantize.py
@@ -74,9 +74,9 @@ def quantize(input_path: str, output_path: str,
                        family('llama', 'bloom', 'gptneox', 'starcoder')",
                       "{} is not in the list.".format(model_family))
     invalidInputError(os.path.isfile(input_path),
-                      "The file {} was not found".format(input_path))
+                      "The file {} is not found".format(input_path))
     invalidInputError(os.path.isdir(output_path),
-                      "The output_path {} was not a directory".format(output_path))
+                      "The output_path {} is not a directory".format(output_path))
     # convert quantize type str into corresponding int value
     quantize_type_map = _quantize_type[model_family]
     output_filename = "bigdl_llm_{}_{}.bin".format(model_family,

--- a/python/llm/src/bigdl/llm/ggml/transformers/model.py
+++ b/python/llm/src/bigdl/llm/ggml/transformers/model.py
@@ -50,7 +50,8 @@ class AutoModelForCausalLM:
                   For lora fine tuned model, the path should be pointed to a merged weight.
 
                   If ``model_format='gptq'``, the folder should be be a Hugging Face checkpoint
-                  that contains weights in pytorch's .pt format, and ``tokenizer.model``.
+                  in GPTQ format, which contains weights in pytorch's .pt format,
+                  and ``tokenizer.model``.
 
                2. Path for converted BigDL-LLM optimized ggml binary checkpoint.
                   The checkpoint should be converted by ``bigdl.llm.llm_convert``.

--- a/python/llm/src/bigdl/llm/ggml/transformers/model.py
+++ b/python/llm/src/bigdl/llm/ggml/transformers/model.py
@@ -42,17 +42,17 @@ class AutoModelForCausalLM:
         """
         :param pretrained_model_name_or_path: We support 3 kinds of pretrained model checkpoint
 
-               1. Path to directory for Hugging Face checkpoint that are directly pulled from 
+               1. Path to directory for Hugging Face checkpoint that are directly pulled from
                   Hugging Face hub.
 
-                  If ``model_format='pth'``, the folder should contain: weight bin, tokenizer config,
-                  tokenizer.model (required for llama) and added_tokens.json (if applied).
+                  If ``model_format='pth'``, the folder should contain: weight bin, tokenizer
+                  config, tokenizer.model (required for llama) and added_tokens.json (if applied).
                   For lora fine tuned model, the path should be pointed to a merged weight.
 
                   If ``model_format='gptq'``, the folder should be be a Hugging Face checkpoint
                   that contains weights in pytorch's .pt format, and ``tokenizer.model``.
 
-               2. Path for converted BigDL-LLM optimized ggml binary checkpoint. 
+               2. Path for converted BigDL-LLM optimized ggml binary checkpoint.
                   The checkpoint should be converted by ``bigdl.llm.llm_convert``.
                3. A str for Hugging Face hub repo id.
 

--- a/python/llm/src/bigdl/llm/ggml/transformers/model.py
+++ b/python/llm/src/bigdl/llm/ggml/transformers/model.py
@@ -57,7 +57,8 @@ class AutoModelForCausalLM:
                3. A str for Hugging Face hub repo id.
 
         :param model_format: Specify the model format to be converted. ``pth`` is for
-               original model checkpoint from Hugging Face. ``gptq`` is for GPTQ format model.
+               PyTorch model checkpoint from Hugging Face. ``gptq`` is for GPTQ format
+               model from Hugging Face.
         :param model_family: The model family of the pretrained checkpoint.
                Currently we support ``"llama"``, ``"bloom"``, ``"gptneox"`` and ``"starcoder"``.
         :param dtype: Which quantized precision will be converted.


### PR DESCRIPTION
## Description

Supports GPTQ convert in transfomers-like API, and supports folder outfile for `llm-convert`

https://github.com/orgs/analytics-zoo/projects/21/views/3?pane=issue&itemId=31133158
https://github.com/orgs/analytics-zoo/projects/21/views/3?pane=issue&itemId=31133527

### 1. User API changes
- `bigdl.llm.llm_convert`: now `outfile` requires folder path as inputs
- `bigdl.llm.transformers.from_pretrained`: add param `model_format`

### 2. Summary of the change 
- Supports GPTQ convert in `bigdl.llm.transformers.from_pretrained`
- Unify `outfile` definition for `bigdl.llm.llm_convert`, now only folder path is valid
- Add docstrings for `bigdl.llm.llm_convert`
- Fix bug in `bigdl.llm.llm_convert`
- Revise related examples

### 3. How to test?
- [x] Local test
- [x] Unit test
