### PR TITLE
llm lora support

### DIFF
--- a/python/llm/src/bigdl/llm/utils/lora_util.py
+++ b/python/llm/src/bigdl/llm/utils/lora_util.py
@@ -1,0 +1,86 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ===========================================================================
+#
+# This file is adapted from
+# https://github.com/tloen/alpaca-lora/blob/main/export_hf_checkpoint.py
+#
+# Copyright 2023 Rohan Taori, Ishaan Gulrajani, Tianyi Zhang, Yann Dubois, Xuechen Li
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from peft import PeftModel
+from transformers.models.auto.tokenization_auto import get_tokenizer_config
+from transformers import AutoModelForCausalLM, AutoTokenizer, LlamaTokenizer  # noqa: F402
+
+def merge_and_export_lora_model(base_model, lora_id_or_path, output_path="./hf_ckpt"):
+    config = get_tokenizer_config(base_model)
+    if config.get("tokenizer_class", "AutoTokenizer") == 'LlamaTokenizer':
+        # Llama tokenizer load very slow with AutoTokenizer, use LlamaTokenizer here
+        tokenizer = LlamaTokenizer.from_pretrained(base_model)
+    else:
+        tokenizer = AutoTokenizer.from_pretrained(base_model)
+
+    base_model = AutoModelForCausalLM.from_pretrained(
+        base_model,
+        load_in_8bit=False,
+        torch_dtype=torch.float16,
+        device_map={"": "cpu"},
+    )
+
+    first_weight = base_model.model.layers[0].self_attn.q_proj.weight
+    first_weight_old = first_weight.clone()
+
+    lora_model = PeftModel.from_pretrained(
+        base_model,
+        lora_id_or_path,
+        device_map={"": "cpu"},
+        torch_dtype=torch.float16,
+    )
+
+    lora_weight = lora_model.base_model.model.model.layers[
+        0
+    ].self_attn.q_proj.weight
+
+    assert torch.allclose(first_weight_old, first_weight)
+
+    # merge weights - new merging method from peft
+    lora_model = lora_model.merge_and_unload()
+
+    lora_model.train(False)
+    lora_first_weight = lora_model.model.layers[0].self_attn.q_proj.weight
+
+    # did we do anything?
+    assert not torch.allclose(first_weight_old, first_weight)
+    assert torch.allclose(lora_first_weight, first_weight)
+
+    lora_model.save_pretrained(output_path)
+    tokenizer.save_pretrained(output_path)
+    return output_path
+
+if __name__ == '__main__':
+    merge_and_export_lora_model("huggyllama/llama-7b", "tloen/alpaca-lora-7b", "./hf_ckpt")


### PR DESCRIPTION
## Description

LLM convert supports Lora.

### 1. Why the change?

The user should merge the Lora with the base model before converting -> User can pass the base model and Lora id or path when converting.

### 2. User API changes

convert_model.py /d1/llm/models/llama-7b-hf --model-format pth --outfile /d1/llm/models/llama-7b-int4/ --model-family llama **--lora-id-or-path /d1/llm/models/gpt4all-lora** -p /d1/llm/models/temp_path

### 3. Summary of the change 

LLM convert supports Lora.

### 5. New dependencies

pip install peft
