### PR TITLE
[PPML] refine notebook service

### DIFF
--- a/ppml/trusted-bigdata/service/templates/bigdl-ppml-notebook-deployment.yaml
+++ b/ppml/trusted-bigdata/service/templates/bigdl-ppml-notebook-deployment.yaml
@@ -23,13 +23,15 @@ spec:
         - containerPort: {{ .Values.jupyterPort }}
           hostPort: {{ .Values.jupyterPort }}
         env:
+        - name: PCCS_URL
+          value: "{{ .Values.PCCSUrl }}"
         - name: RUNTIME_K8S_SPARK_IMAGE
           value: {{ .Values.imageName }}
         - name: RUNTIME_SPARK_MASTER
           value: {{ .Values.k8sMasterURL }}
         - name: SGX_ENABLED
-        {{- if eq .Values.TEEMode "tdx" }}
-          value: "false"
+        {{- if eq .Values.TEEMode "sgx" }}
+          value: "true"
         {{- else }}
           value: "true"
         {{- end }}
@@ -49,7 +51,7 @@ spec:
           mountPath: /var/lib/kubelet/device-plugins
         - name: aesm-socket
           mountPath: /var/run/aesmd/aesm.socket
-      resources:
+        resources:
           requests:
             cpu: 8
             memory: 32Gi

--- a/ppml/trusted-bigdata/service/templates/bigdl-ppml-notebook-deployment.yaml
+++ b/ppml/trusted-bigdata/service/templates/bigdl-ppml-notebook-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         {{- if eq .Values.TEEMode "sgx" }}
           value: "true"
         {{- else }}
-          value: "true"
+          value: "false"
         {{- end }}
         - name: JUPYTER_PORT
           value: "{{ .Values.jupyterPort }}"

--- a/ppml/trusted-bigdata/service/templates/bigdl-ppml-notebook-service.yaml
+++ b/ppml/trusted-bigdata/service/templates/bigdl-ppml-notebook-service.yaml
@@ -6,9 +6,12 @@ metadata:
   labels:
     app: bigdl-ppml-notebook
 spec:
+  type: LoadBalancer
   ports:
   - port: {{ .Values.jupyterPort }}
     targetPort: {{ .Values.jupyterPort }}
-  type: NodePort
   selector:
     app: bigdl-ppml-notebook
+  sessionAffinity: ClientIP
+  externalIPs:
+  - {{ .Values.notebookExternalIP }}

--- a/ppml/trusted-bigdata/service/templates/bigdl-ppml-service-role-binding.yaml
+++ b/ppml/trusted-bigdata/service/templates/bigdl-ppml-service-role-binding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRoleBinding
+kind: RoleBinding
 metadata:
-  name: bigdl-ppml-crb
+  name: bigdl-ppml-service-role-binding
   namespace: bigdl-ppml
 subjects:
   - kind: ServiceAccount
     name: bigdl-ppml-sa
     namespace: bigdl-ppml
 roleRef:
-  kind: ClusterRole
-  name: bigdl-ppml-cluster-role
+  kind: Role
+  name: bigdl-ppml-role
   apiGroup: rbac.authorization.k8s.io

--- a/ppml/trusted-bigdata/service/templates/bigdl-ppml-service-role.yaml
+++ b/ppml/trusted-bigdata/service/templates/bigdl-ppml-service-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: bigdl-ppml-role
+  name: bigdl-ppml-service-role
   namespace: bigdl-ppml
 rules:
   - apiGroups: [""]

--- a/ppml/trusted-bigdata/service/templates/bigdl-ppml-storage-role-binding.yaml
+++ b/ppml/trusted-bigdata/service/templates/bigdl-ppml-storage-role-binding.yaml
@@ -1,13 +1,13 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
-  name: bigdl-ppml-role-binding
+  name: bigdl-ppml-storage-role-binding
   namespace: bigdl-ppml
 subjects:
   - kind: ServiceAccount
     name: bigdl-ppml-sa
     namespace: bigdl-ppml
 roleRef:
-  kind: Role
-  name: bigdl-ppml-role
+  kind: ClusterRole
+  name: bigdl-ppml-cluster-role
   apiGroup: rbac.authorization.k8s.io

--- a/ppml/trusted-bigdata/service/templates/bigdl-ppml-storage-role.yaml
+++ b/ppml/trusted-bigdata/service/templates/bigdl-ppml-storage-role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: bigdl-ppml-cluster-role
+  name: bigdl-ppml-storage-role
   namespace: bigdl-ppml
 rules:
   - apiGroups: [""]

--- a/ppml/trusted-bigdata/service/templates/nfs-pv.yaml
+++ b/ppml/trusted-bigdata/service/templates/nfs-pv.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: nfs-pv
+  name: nfs-pv-bigdl-ppml-bigdata
   namespace: bigdl-ppml
 spec:
   capacity:

--- a/ppml/trusted-bigdata/service/values.yaml
+++ b/ppml/trusted-bigdata/service/values.yaml
@@ -3,6 +3,8 @@
 nfsServerIp: your_nfs_server_ip
 nfsPath: a_nfs_shared_folder_path_on_the_server
 imageName: bigdl-ppml-trusted-bigdata-gramine-reference-8g:2.4.0-SNAPSHOT # or replace with custom image of user
-TEEMode: sgx # sgx or tdx
+notebookExternalIP: an_available_ip_in_your_subnetwork_to_expose_notebook_service_externally
+TEEMode: sgx # sgx, tdx or native
+PCCSUrl: your_pccs_url # set to "" for native TEEMode
 jupyterPort: 12345
 k8sMasterURL: your_k8s_master_url # get this by: echo k8s://$(sudo kubectl cluster-info | grep 'https.*6443' -o -m 1)

--- a/ppml/trusted-bigdata/service/values.yaml
+++ b/ppml/trusted-bigdata/service/values.yaml
@@ -4,7 +4,7 @@ nfsServerIp: your_nfs_server_ip
 nfsPath: a_nfs_shared_folder_path_on_the_server
 imageName: bigdl-ppml-trusted-bigdata-gramine-reference-8g:2.4.0-SNAPSHOT # or replace with custom image of user
 notebookExternalIP: an_available_ip_in_your_subnetwork_to_expose_notebook_service_externally
-TEEMode: sgx # sgx, tdx or native
-PCCSUrl: your_pccs_url # set to "" for native TEEMode
+TEEMode: sgx # TEE mode of jupyter notebook, sgx, tdx or native
+PCCSUrl: your_pccs_url # set to "" for native TEEMode or no attestation needed
 jupyterPort: 12345
 k8sMasterURL: your_k8s_master_url # get this by: echo k8s://$(sudo kubectl cluster-info | grep 'https.*6443' -o -m 1)

--- a/ppml/trusted-bigdata/start-notebook.sh
+++ b/ppml/trusted-bigdata/start-notebook.sh
@@ -17,6 +17,13 @@
 #
 
 set -x
+
+# Set PCCS conf
+if [ "$PCCS_URL" != "" ] ; then
+    echo 'PCCS_URL='${PCCS_URL}'/sgx/certification/v3/' > /etc/sgx_default_qcnl.conf
+    echo 'USE_SECURE_CERT=FALSE' >> /etc/sgx_default_qcnl.conf
+fi
+
 cd /ppml
 export JUPYTER_RUNTIME_DIR=/ppml/jupyter/runtime
 export JUPYTER_DATA_DIR=/ppml/jupyter/data


### PR DESCRIPTION
## Description

support more TEE modes in notebook service and expose the service through VIP

### 1. Why the change?

to refine trusted bigdata frontend in TEE e.g. SGX and TDX

### 2. User API changes

need to set notebookExternalIP in values.yaml, which is an VIP to use as service IP

### 3. Summary of the change 

as title

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...