### PR TITLE
LLM: support starcoder in llm-cli

### DIFF
--- a/python/llm/src/bigdl/llm/cli/llm-cli
+++ b/python/llm/src/bigdl/llm/cli/llm-cli
@@ -53,6 +53,12 @@ function gptneox {
   eval "$command"
 }
 
+function starcoder {
+  command="$lib_dir/main-starcoder_$avx_flag -t $threads -n $n_predict ${filteredArguments[*]}"
+  echo "$command"
+  eval "$command"
+}
+
 # Remove model_family/x parameter
 filteredArguments=()
 while [[ $# -gt 0 ]]; do
@@ -91,6 +97,8 @@ elif [[ "$model_family" == "bloom" ]]; then
   bloom
 elif [[ "$model_family" == "gptneox" ]]; then
   gptneox
+elif [[ "$model_family" == "starcoder" ]]; then
+  starcoder
 else
   echo "Invalid model_family: $model_family"
   display_help

--- a/python/llm/src/bigdl/llm/cli/llm-cli.ps1
+++ b/python/llm/src/bigdl/llm/cli/llm-cli.ps1
@@ -40,6 +40,13 @@ function gptneox
     Invoke-Expression $command
 }
 
+function starcoder
+{
+    $command = "$lib_dir/main-starcoder.exe -t $threads -n $n_predict $filteredArguments"
+    Write-Host "$command"
+    Invoke-Expression $command
+}
+
 # Remove model_family/x parameter
 $filteredArguments = @()
 for ($i = 0; $i -lt $args.Length; $i++) {
@@ -78,6 +85,9 @@ switch ($model_family)
     }
     "gptneox" {
         gptneox
+    }
+    "starcoder" {
+        starcoder
     }
     default {
         Write-Host "Invalid model_family: $model_family"

--- a/python/llm/src/bigdl/llm/models.py
+++ b/python/llm/src/bigdl/llm/models.py
@@ -22,3 +22,4 @@
 from bigdl.llm.ggml.model.llama import Llama
 from bigdl.llm.ggml.model.gptneox import Gptneox
 from bigdl.llm.ggml.model.bloom import Bloom
+from bigdl.llm.ggml.model.starcoder import Starcoder

--- a/python/llm/src/bigdl/llm/utils/convert_util.py
+++ b/python/llm/src/bigdl/llm/utils/convert_util.py
@@ -1427,7 +1427,7 @@ def _convert_starcoder_hf_to_ggml(model_path, outfile_dir, outtype):
     model = AutoModelForCausalLM.from_pretrained(model_path, config=config,
                                                  torch_dtype=torch.float16
                                                  if outtype == "f16" else torch.float32,
-                                                 low_cpu_mem_usage=True,
+                                                 # low_cpu_mem_usage=True,
                                                  trust_remote_code=True,
                                                  offload_state_dict=True)
 


### PR DESCRIPTION
## Description

support starcoder in llm-cli.

### 1. Why the change?

support starcoder in llm-cli.

### 2. User API changes

No change, just support starcoder in llm-cli.
`llm-cli -x starcoder -m ./output_starcoder/bigdl_llm_starcoder_q4_0.bin -p "def print_hello_word(" -t 40 -n 64 -s 3`

### 3. Summary of the change 
- support starcoder in llm-cli
- update main.cpp to remove eos token(`<|endoftext|>`) in main output, and rebuild all 3 main binary file
- some small fix for convert and model

### 4. How to test?
- [ ] Unit test
- [x] Local test
Local test on a linux server
```bash
main: seed = 3
loading bigdl-llm model: loading model from '/disk0/ruonan/func_test/llm/output_starcoder/bigdl_llm_starcoder_q4_0.bin'
loading bigdl-llm model: n_vocab = 49280
loading bigdl-llm model: n_ctx   = 2048
loading bigdl-llm model: n_embd  = 2048
loading bigdl-llm model: n_head  = 16
loading bigdl-llm model: n_layer = 24
loading bigdl-llm model: ftype   = 2002
loading bigdl-llm model: qntvr   = 2
starcoder_model_load: ggml ctx size = 1542.88 MB
loading bigdl-llm model: memory size =   768.00 MB, n_mem = 49152
loading bigdl-llm model: model size  =   774.73 MB
extract_tests_from_file : No test file found.
test_gpt_tokenizer : 0 tests failed out of 0 tests.

system_info: n_threads = 40 / 160 | AVX = 1 | AVX2 = 1 | AVX512 = 1 | AVX512_VBMI = 0 | AVX512_VNNI = 1 | FMA = 1 | NEON = 0 | ARM_FMA = 0 | F16C = 1 | FP16_VA = 0 | WASM_SIMD = 0 | BLAS = 0 | SSE3 = 1 | VSX = 0 | 
bigdl-llm: prompt: 'def print_hello_word('
bigdl-llm: number of tokens in prompt = 7
bigdl-llm: token[0] =    563, def
bigdl-llm: token[1] =    942,  print
bigdl-llm: token[2] =     62, _
bigdl-llm: token[3] =   7196, hello
bigdl-llm: token[4] =     62, _
bigdl-llm: token[5] =   1003, word
bigdl-llm: token[6] =      7, (


def print_hello_word(word: str):
    print(f"Hello, {word}")


print_hello_word("World")

"""
You can print multiple values with comma

>>> print("Hello, World, and {name}".format(name="World"))
Hello, World, and World

>>>

bigdl-llm: mem per token =   313912 bytes
bigdl-llm:     load time =   479.41 ms
bigdl-llm:   sample time =    34.29 ms
bigdl-llm:  predict time =  1365.27 ms / 19.50 ms per token
bigdl-llm:    total time =  1928.46 ms
```