### PR TITLE
LLM: add chatglm-6b example for transformer_int4 usage

### DIFF
--- a/python/llm/example/transformers_int4.py
+++ b/python/llm/example/transformers_int4.py
@@ -23,12 +23,13 @@ from transformers import LlamaTokenizer, AutoTokenizer
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Transformer INT4 example')
-    parser.add_argument('--repo-id-or-model-path', type=str,
+    parser.add_argument('--repo-id-or-model-path', type=str, default="decapoda-research/llama-7b-hf",
+                        choices=['decapoda-research/llama-7b-hf', 'THUDM/chatglm-6b'],
                         help='The huggingface repo id for the larga language model to be downloaded'
                              ', or the path to the huggingface checkpoint folder')
     args = parser.parse_args()
-    repo_id_or_model_path = args.repo_id_or_model_path
-    if repo_id_or_model_path == 'decapoda-research/llama-7b-hf':
+    model_path = args.repo_id_or_model_path
+    if model_path == 'decapoda-research/llama-7b-hf':
         # load_in_4bit=True in bigdl.llm.transformers will convert
         # the relevant layers in the model into int4 format
         model = AutoModelForCausalLM.from_pretrained(model_path, load_in_4bit=True)
@@ -44,7 +45,7 @@ if __name__ == '__main__':
             end = time.time()
         print(output_str)
         print(f'Inference time: {end-st} s')
-    elif repo_id_or_model_path == 'THUDM/chatglm-6b':
+    elif model_path == 'THUDM/chatglm-6b':
         model = AutoModel.from_pretrained(model_path, trust_remote_code=True, load_in_4bit=True)
         tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
 

--- a/python/llm/example/transformers_int4.py
+++ b/python/llm/example/transformers_int4.py
@@ -16,21 +16,45 @@
 
 import torch
 import os
-from bigdl.llm.transformers import AutoModelForCausalLM
-from transformers import LlamaTokenizer
+import time
+import argparse
+from bigdl.llm.transformers import AutoModelForCausalLM, AutoModel
+from transformers import LlamaTokenizer, AutoTokenizer
 
 if __name__ == '__main__':
-    model_path = 'decapoda-research/llama-7b-hf'
+    parser = argparse.ArgumentParser(description='Transformer INT4 example')
+    parser.add_argument('--repo-id-or-model-path', type=str,
+                        help='The huggingface repo id for the larga language model to be downloaded'
+                             ', or the path to the huggingface checkpoint folder')
+    args = parser.parse_args()
+    repo_id_or_model_path = args.repo_id_or_model_path
+    if repo_id_or_model_path == 'decapoda-research/llama-7b-hf':
+        # load_in_4bit=True in bigdl.llm.transformers will convert
+        # the relevant layers in the model into int4 format
+        model = AutoModelForCausalLM.from_pretrained(model_path, load_in_4bit=True)
+        tokenizer = LlamaTokenizer.from_pretrained(model_path)
 
-    # load_in_4bit=True in bigdl.llm.transformers will convert
-    # the relevant layers in the model into int4 format
-    model = AutoModelForCausalLM.from_pretrained(model_path, load_in_4bit=True)
-    tokenizer = LlamaTokenizer.from_pretrained(model_path)
+        input_str = "Once upon a time, there existed a little girl who liked to have adventures. She wanted to go to places and meet new people, and have fun"
 
-    input_str = "Once upon a time, there existed a little girl who liked to have adventures. She wanted to go to places and meet new people, and have fun"
+        with torch.inference_mode():
+            st = time.time()
+            input_ids = tokenizer.encode(input_str, return_tensors="pt")
+            output = model.generate(input_ids, do_sample=False, max_new_tokens=32)
+            output_str = tokenizer.decode(output[0], skip_special_tokens=True)
+            end = time.time()
+        print(output_str)
+        print(f'Inference time: {end-st} s')
+    elif repo_id_or_model_path == 'THUDM/chatglm-6b':
+        model = AutoModel.from_pretrained(model_path, trust_remote_code=True, load_in_4bit=True)
+        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
 
-    with torch.inference_mode():
-        input_ids = tokenizer.encode(input_str, return_tensors="pt")
-        output = model.generate(input_ids, do_sample=False, max_new_tokens=32)
-        output_str = tokenizer.decode(output[0], skip_special_tokens=True)
-    print(output_str)
+        input_str = "晚上睡不着应该怎么办"
+
+        with torch.inference_mode():
+            st = time.time()
+            input_ids = tokenizer.encode(input_str, return_tensors="pt")
+            output = model.generate(input_ids, do_sample=False, max_new_tokens=32)
+            output_str = tokenizer.decode(output[0], skip_special_tokens=True)
+            end = time.time()
+        print(output_str)
+        print(f'Inference time: {end-st} s')


### PR DESCRIPTION
## Description

Add chatglm-6b examples in `examples/transformer_int4.py`

### 1. Why the change?

Show how to use chatglm-6b with our new transformer api.

### 2. User API changes

No change.

### 3. Summary of the change 

Add chatglm-6b examples in `examples/transformer_int4.py`

### 4. How to test?
- [ ] Unit test
- [x] Local test on Windows

