### PR TITLE
change read num in decryptStream to the latest length of header

### DIFF
--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/BigDLEncrypt.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/BigDLEncrypt.scala
@@ -279,7 +279,7 @@ class BigDLEncrypt extends Crypto {
   protected def decryptStream(
         inputStream: DataInputStream,
         outputStream: DataOutputStream): Unit = {
-    val header = read(inputStream, 25)
+    val header = read(inputStream, 400)
     verifyHeader(header)
     while (inputStream.available() != 0) {
       val decrypted = decryptPart(inputStream, byteBuffer)


### PR DESCRIPTION
## Description

see in below

### 1. Why the change?

#8309 

### 2. User API changes

none

### 3. Summary of the change 

change read num in decryptStream to the latest length of header

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...
