### PR TITLE
gptq2ggml: support loading safetensors model.

### DIFF
--- a/python/llm/src/bigdl/llm/convert_model.py
+++ b/python/llm/src/bigdl/llm/convert_model.py
@@ -104,8 +104,8 @@ def llm_convert(model,
         else:
             gptq_tokenizer_path = None
 
-        convert_gptq2ggml(model,
-                          outfile,
+        convert_gptq2ggml(model_path=model,
+                          output_path=outfile,
                           tokenizer_path=gptq_tokenizer_path,
                           )
         return outfile

--- a/python/llm/src/bigdl/llm/convert_model.py
+++ b/python/llm/src/bigdl/llm/convert_model.py
@@ -104,8 +104,8 @@ def llm_convert(model,
         else:
             gptq_tokenizer_path = None
 
-        convert_gptq2ggml(input_path=model,
-                          output_path=outfile,
+        convert_gptq2ggml(model,
+                          outfile,
                           tokenizer_path=gptq_tokenizer_path,
                           )
         return outfile

--- a/python/llm/src/bigdl/llm/convert_model.py
+++ b/python/llm/src/bigdl/llm/convert_model.py
@@ -98,6 +98,7 @@ def llm_convert(model,
                                                                  outtype.lower())
         outfile = os.path.join(outfile, output_filename)
 
+        # TODO: delete this when support AutoTokenizer
         if "tokenizer_path" in _used_args:
             gptq_tokenizer_path = _used_args["tokenizer_path"]
         else:

--- a/python/llm/src/bigdl/llm/gptq/convert/convert_gptq_to_ggml.py
+++ b/python/llm/src/bigdl/llm/gptq/convert/convert_gptq_to_ggml.py
@@ -28,6 +28,7 @@ import struct
 import numpy as np
 import torch
 from sentencepiece import SentencePieceProcessor
+from pathlib import Path
 from bigdl.llm.utils.common.log4Error import invalidInputError
 
 
@@ -158,13 +159,14 @@ def convert_q4(src_name, dst_name, model, fout, n_head, permute=False):
 
 
 def find_quantized_model_file(model_path):
+    model_path = Path(model_path)
     for ext in ['.safetensors', '.pt']:
         found = list(model_path.glob(f"*{ext}"))
         if len(found) > 0:
             if len(found) != 1:
                 warnings.warn(f'Detected {len(found)} {ext} model, use the first one {found[0]}.')
             print(f"Detected model file {found[0]}")
-            return found[0]
+            return str(found[0])
 
 
 def convert_gptq2ggml(model_path, output_path, tokenizer_path=None):

--- a/python/llm/src/bigdl/llm/gptq/convert/convert_gptq_to_ggml.py
+++ b/python/llm/src/bigdl/llm/gptq/convert/convert_gptq_to_ggml.py
@@ -190,7 +190,7 @@ def convert_gptq2ggml(model_path, output_path, tokenizer_path=None):
     n_head = {32: 32, 40: 40, 60: 52, 80: 64}[n_layer]
 
     if not tokenizer_path:
-        tokenizer_path = os.path.join(input_path, "tokenizer.model")
+        tokenizer_path = os.path.join(model_path, "tokenizer.model")
         invalidInputError(os.path.isfile(tokenizer_path),
                           f"tokenizer.model was not found under {tokenizer_path}."
                           f"Please specify the tokenizer-path")


### PR DESCRIPTION
## Description

support loading safetensors model

### 1. Why the change?

A lots of gptq models are serialized as safetensors

### 2. User API changes

User can use safetensors model when convert gptq to ggml.

### 3. Summary of the change 
User can use safetensors model when convert gptq to ggml.


