### PR TITLE
istio sidecar for torchserve service

### DIFF
--- a/ppml/trusted-dl-serving/service/templates/backend_sidecar.yaml
+++ b/ppml/trusted-dl-serving/service/templates/backend_sidecar.yaml
@@ -1,0 +1,17 @@
+# backend sidecar receives and decodes TLS-encrypted connection from frontend
+{{- if eq .Values.istioTLSEnabled true }}
+apiVersion: networking.istio.io/v1alpha3
+kind: Sidecar
+metadata:
+  name: bigdl-torchserve-backend-sidecar
+  namespace: bigdl-ppml-serving
+spec:
+  workloadSelector:
+    labels:
+      backend: torchserve
+  ingress:
+  - port:
+      name: backendport
+      number: {{ .Values.backendPort }}
+      protocol: TCP
+{{- end }}

--- a/ppml/trusted-dl-serving/service/templates/destination-role.yaml
+++ b/ppml/trusted-dl-serving/service/templates/destination-role.yaml
@@ -1,0 +1,15 @@
+# DestinationRule defines how outbound traffic from frontend is handled
+{{- if eq .Values.istioTLSEnabled true }}
+apiVersion: networking.istio.io/v1alpha3
+kind: DestinationRule
+metadata:
+  name: bigdl-torchserve-frontend-destination-rule
+  namespace: bigdl-ppml-serving
+spec:
+  host: bigdl-torchserve-frontend-service.bigdl-ppml-serving.svc.cluster.local
+  trafficPolicy: # Apply to all ports
+    loadBalancer:
+      simple: ROUND_ROBIN
+    tls:
+      mode: ISTIO_MUTUAL
+{{- end }}

--- a/ppml/trusted-dl-serving/service/templates/frontend_sidecar.yaml
+++ b/ppml/trusted-dl-serving/service/templates/frontend_sidecar.yaml
@@ -1,0 +1,12 @@
+# frontend sidecar encrypts outcoming TCP connection from frontend to backend
+{{- if eq .Values.istioTLSEnabled true }}
+apiVersion: networking.istio.io/v1alpha3
+kind: Sidecar
+metadata:
+  name: bigdl-torchserve-frontend-sidecar
+  namespace: bigdl-ppml-serving
+spec:
+  egress:
+  - hosts:
+    - "bigdl-ppml-serving/bigdl-torchserve-frontend-service.bigdl-ppml-serving.svc.cluster.local"
+{{- end }}

--- a/ppml/trusted-dl-serving/service/templates/peer-authentication.yaml
+++ b/ppml/trusted-dl-serving/service/templates/peer-authentication.yaml
@@ -1,0 +1,14 @@
+# PeerAuthentication defines how inbound traffic to backend is handled
+{{- if eq .Values.istioTLSEnabled true }}
+apiVersion: security.istio.io/v1beta1
+kind: PeerAuthentication
+metadata:
+  name: bigdl-torchserve-frontend-peer-authentication
+  namespace: bigdl-ppml-serving
+spec:
+  selector:
+    matchLabels:
+      backend: torchserve
+  mtls:
+    mode: PERMISSIVE
+{{- end }}

--- a/ppml/trusted-dl-serving/service/values.schema.json
+++ b/ppml/trusted-dl-serving/service/values.schema.json
@@ -10,7 +10,8 @@
         "inferencePort",
         "managementPort",
         "metricsPort",
-        "backendPort"
+        "backendPort",
+	"istioTLSEnabled"
     ],
     "properties": {
       "imageName": {
@@ -43,6 +44,9 @@
       },
       "backendPort": {
         "type": "number"
+      },
+      "istioTLSEnabled": {
+	"type": "boolean"
       }
     }
 }

--- a/ppml/trusted-dl-serving/service/values.yaml
+++ b/ppml/trusted-dl-serving/service/values.yaml
@@ -9,3 +9,4 @@ inferencePort: 8085
 managementPort: 8081
 metricsPort: 8082
 backendPort: 9000
+istioTLSEnabled: false # istio TLS protects pod communication between backend and frontend, pls make sure istio has been installed in your cluster before enabling


### PR DESCRIPTION
## Description

Add istio sidecar etc. to enable auto TLS proxy for pod communication inside torchserve cluster

### 1. Why the change?

The TCP connection from frontend to backend is plaintext

### 2. User API changes

add a parameter in values.yaml to enable istio TLS

### 3. Summary of the change 

as title

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

optional and external: need to setup istio in user's cluster before enabling
