### PR TITLE
Fix Orca-Docker-Py39-Spark3 nightly test

### DIFF
--- a/.github/actions/orca/orca-docker-py39-spark3-action/action.yml
+++ b/.github/actions/orca/orca-docker-py39-spark3-action/action.yml
@@ -37,7 +37,7 @@ runs:
             --env https_proxy="http://child-prc.intel.com:913" \
             --name=${CONTAINER_NAME} \
             $IMAGE \
-            bash -c "pip install tensorflow==2.9.0 torch==1.7.1 pytest argparse && git clone https://github.com/intel-analytics/BigDL.git && cd BigDL/python/orca/dev/test && bash ./run-pytests-basic-env.sh && bash ./run-pytests-basic-pytorch.sh && bash ./run-pytests-basic-tf2.sh" 
+            bash -c "pip install tensorflow==2.9.0 torch==1.7.1 pytest argparse && export GIT_SSL_NO_VERIFY=1 && git clone https://github.com/intel-analytics/BigDL.git && cd BigDL/python/orca/dev/test && bash ./run-pytests-basic-env.sh && bash ./run-pytests-basic-pytorch.sh && bash ./run-pytests-basic-tf2.sh" 
 
         exit_status=$(docker wait ${CONTAINER_NAME})
 

--- a/.github/workflows/PR_validation.yml
+++ b/.github/workflows/PR_validation.yml
@@ -332,26 +332,6 @@ jobs:
       if: ${{ always() }}
       uses: ./.github/actions/remove-env
 
-  Orca-Docker-Py39-Spark3:
-    needs: changes
-    if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
-    runs-on: [self-hosted, Vilvarin]
-
-    steps:
-    - uses: actions/checkout@v3
-    - name: set env
-      env:
-        DEFAULT_IMAGE: '10.239.45.10/arda/intelanalytics/bigdl-orca'
-        DEFAULT_TAG: 'latest'
-      run: |
-        echo "TAG=${{ github.event.inputs.tag || env.DEFAULT_TAG }}" >> $GITHUB_ENV
-        echo "IMAGE=${{ github.event.inputs.image || env.DEFAULT_IMAGE }}" >> $GITHUB_ENV
-    - name: Run test
-      uses: ./.github/actions/orca/orca-docker-py39-spark3-action
-      with:
-        image: ${{env.IMAGE}}
-        image-tag: ${{env.TAG}}
-
   Orca-Pytest-Ray-Ctx-Py37-Spark3:
     needs: changes
     if: ${{ needs.changes.outputs.orca-pytest == 'true' }}

--- a/.github/workflows/PR_validation.yml
+++ b/.github/workflows/PR_validation.yml
@@ -332,6 +332,26 @@ jobs:
       if: ${{ always() }}
       uses: ./.github/actions/remove-env
 
+  Orca-Docker-Py39-Spark3:
+    needs: changes
+    if: ${{ needs.changes.outputs.orca-pytest == 'true' }}
+    runs-on: [self-hosted, Vilvarin]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: set env
+      env:
+        DEFAULT_IMAGE: '10.239.45.10/arda/intelanalytics/bigdl-orca'
+        DEFAULT_TAG: 'latest'
+      run: |
+        echo "TAG=${{ github.event.inputs.tag || env.DEFAULT_TAG }}" >> $GITHUB_ENV
+        echo "IMAGE=${{ github.event.inputs.image || env.DEFAULT_IMAGE }}" >> $GITHUB_ENV
+    - name: Run test
+      uses: ./.github/actions/orca/orca-docker-py39-spark3-action
+      with:
+        image: ${{env.IMAGE}}
+        image-tag: ${{env.TAG}}
+
   Orca-Pytest-Ray-Ctx-Py37-Spark3:
     needs: changes
     if: ${{ needs.changes.outputs.orca-pytest == 'true' }}


### PR DESCRIPTION
## Description
Orca-Docker-Py39-Spark3 nightly test failed when git clone
![image](https://github.com/intel-analytics/BigDL/assets/61072813/612fc645-7abb-467c-8641-5dace1c81f97)

`export GIT_SSL_NO_VERIFY=1` is a workaround to bypass verifying SSL
https://github.com/intel-analytics/BigDL/actions/runs/5409074853/jobs/9828803514 passed
<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

