### PR TITLE
Pentest fix: fix Improper Resource Shutdown or Release of Resource (Second half)

### DIFF
--- a/python/orca/example/learn/tf2/yolov3/yoloV3.py
+++ b/python/orca/example/learn/tf2/yolov3/yoloV3.py
@@ -188,53 +188,52 @@ YOLOV3_TINY_LAYER_LIST = [
 
 
 def load_darknet_weights(model, weights_file, tiny=False):
-    wf = open(weights_file, 'rb')
-    major, minor, revision, seen, _ = np.fromfile(wf, dtype=np.int32, count=5)
+    with open(weights_file, 'rb') as wf:
+        major, minor, revision, seen, _ = np.fromfile(wf, dtype=np.int32, count=5)
 
-    if tiny:
-        layers = YOLOV3_TINY_LAYER_LIST
-    else:
-        layers = YOLOV3_LAYER_LIST
+        if tiny:
+            layers = YOLOV3_TINY_LAYER_LIST
+        else:
+            layers = YOLOV3_LAYER_LIST
 
-    for layer_name in layers:
-        sub_model = model.get_layer(layer_name)
-        for i, layer in enumerate(sub_model.layers):
-            if not layer.name.startswith('conv2d'):
-                continue
-            batch_norm = None
-            if i + 1 < len(sub_model.layers) and \
-                    sub_model.layers[i + 1].name.startswith('batch_norm'):
-                batch_norm = sub_model.layers[i + 1]
+        for layer_name in layers:
+            sub_model = model.get_layer(layer_name)
+            for i, layer in enumerate(sub_model.layers):
+                if not layer.name.startswith('conv2d'):
+                    continue
+                batch_norm = None
+                if i + 1 < len(sub_model.layers) and \
+                        sub_model.layers[i + 1].name.startswith('batch_norm'):
+                    batch_norm = sub_model.layers[i + 1]
 
-            filters = layer.filters
-            size = layer.kernel_size[0]
-            in_dim = layer.get_input_shape_at(0)[-1]
+                filters = layer.filters
+                size = layer.kernel_size[0]
+                in_dim = layer.get_input_shape_at(0)[-1]
 
-            if batch_norm is None:
-                conv_bias = np.fromfile(wf, dtype=np.float32, count=filters)
-            else:
-                # darknet [beta, gamma, mean, variance]
-                bn_weights = np.fromfile(
-                    wf, dtype=np.float32, count=4 * filters)
-                # tf [gamma, beta, mean, variance]
-                bn_weights = bn_weights.reshape((4, filters))[[1, 0, 2, 3]]
+                if batch_norm is None:
+                    conv_bias = np.fromfile(wf, dtype=np.float32, count=filters)
+                else:
+                    # darknet [beta, gamma, mean, variance]
+                    bn_weights = np.fromfile(
+                        wf, dtype=np.float32, count=4 * filters)
+                    # tf [gamma, beta, mean, variance]
+                    bn_weights = bn_weights.reshape((4, filters))[[1, 0, 2, 3]]
 
-            # darknet shape (out_dim, in_dim, height, width)
-            conv_shape = (filters, in_dim, size, size)
-            conv_weights = np.fromfile(
-                wf, dtype=np.float32, count=np.product(conv_shape))
-            # tf shape (height, width, in_dim, out_dim)
-            conv_weights = conv_weights.reshape(
-                conv_shape).transpose([2, 3, 1, 0])
+                # darknet shape (out_dim, in_dim, height, width)
+                conv_shape = (filters, in_dim, size, size)
+                conv_weights = np.fromfile(
+                    wf, dtype=np.float32, count=np.product(conv_shape))
+                # tf shape (height, width, in_dim, out_dim)
+                conv_weights = conv_weights.reshape(
+                    conv_shape).transpose([2, 3, 1, 0])
 
-            if batch_norm is None:
-                layer.set_weights([conv_weights, conv_bias])
-            else:
-                layer.set_weights([conv_weights])
-                batch_norm.set_weights(bn_weights)
+                if batch_norm is None:
+                    layer.set_weights([conv_weights, conv_bias])
+                else:
+                    layer.set_weights([conv_weights])
+                    batch_norm.set_weights(bn_weights)
 
-    invalidInputError(len(wf.read()) == 0, 'failed to read all data')
-    wf.close()
+        invalidInputError(len(wf.read()) == 0, 'failed to read all data')
 
 
 def freeze_all(model, frozen=True):
@@ -627,8 +626,8 @@ def main():
         return model
 
     # prepare data
-    class_map = {name: idx for idx, name in enumerate(
-        open(options.names).read().splitlines())}
+    with open(options.names, 'rb') as f:
+        class_map = {name: idx for idx, name in enumerate(f.read().splitlines())}
     dataset_path = os.path.join(options.data_dir, "VOCdevkit")
     voc_train_path = os.path.join(options.output_data, "train_dataset")
     voc_val_path = os.path.join(options.output_data, "val_dataset")

--- a/python/orca/example/learn/tf2/yolov3/yoloV3.py
+++ b/python/orca/example/learn/tf2/yolov3/yoloV3.py
@@ -626,7 +626,7 @@ def main():
         return model
 
     # prepare data
-    with open(options.names, 'rb') as f:
+    with open(options.names) as f:
         class_map = {name: idx for idx, name in enumerate(f.read().splitlines())}
     dataset_path = os.path.join(options.data_dir, "VOCdevkit")
     voc_train_path = os.path.join(options.output_data, "train_dataset")

--- a/python/orca/src/bigdl/orca/data/file.py
+++ b/python/orca/src/bigdl/orca/data/file.py
@@ -62,7 +62,7 @@ def open_text(path: str) -> List[str]:
         if path.startswith("file://"):
             path = path[len("file://"):]
         lines = []
-        with open(path, 'rb') as f:
+        with open(path) as f:
             for line in f:
                 lines.append(line)
     return [line.strip() for line in lines]
@@ -97,9 +97,7 @@ def open_image(path: str) -> "JpegImageFile":
         key = "/".join(path_parts)
         data = s3_client.get_object(Bucket=bucket, Key=key)
         with BytesIO(data["Body"].read()) as f:
-            image = Image.open(f)
-            image.load()
-        return image
+            return Image.open(f)
     else:  # Local path
         if path.startswith("file://"):
             path = path[len("file://"):]
@@ -391,9 +389,9 @@ def put_local_dir_tree_to_remote(local_dir: str, remote_dir: str):
                     logger.warning(err.decode('utf-8'))
                     return -1
         cmd = 'hdfs dfs -put -f {}/* {}/'.format(local_dir, remote_dir)
-        process = subprocess.run(cmd, capture_output=True)
-        if process.returncode != 0:
-            logger.error("Error: {}".format(str(process.stderr)))
+        p = subprocess.run(cmd, capture_output=True)
+        if p.returncode != 0:
+            logger.error("Error: {}".format(str(p.stderr)))
             return -1
         return 0
     elif remote_dir.startswith("s3"):  # s3://bucket/file_path

--- a/python/orca/src/bigdl/orca/data/file.py
+++ b/python/orca/src/bigdl/orca/data/file.py
@@ -436,14 +436,14 @@ def put_local_file_to_remote(local_path: str, remote_path: str,
         p = subprocess.run(cmd, capture_output=True)
         if p.returncode != 0:
             logger.error("Cannot upload file {} to {}: error: {}"
-                         .format(local_path, remote_path, p.stderr))
+                         .format(local_path, remote_path, str(p.stderr)))
             return -1
         if filemode:
             chmod_cmd = 'hdfs dfs -chmod {} {}'.format(filemode, remote_path)
             p = subprocess.run(chmod_cmd, capture_output=True)
             if p.returncode != 0:
                 logger.error("Cannot upload file {} to {}: error: {}"
-                             .format(local_path, remote_path, p.stderr))
+                             .format(local_path, remote_path, str(p.stderr)))
                 return -1
         return 0
     elif remote_path.startswith("s3"):  # s3://bucket/file_path
@@ -484,7 +484,7 @@ def put_local_files_with_prefix_to_remote(local_path_prefix: str, remote_dir: st
         cmd = 'hdfs dfs -put -f {}* {}'.format(local_path_prefix, remote_dir)
         p = subprocess.run(cmd, capture_output=True)
         if p.returncode != 0:
-            logger.error("Error: {}".format(p.stderr))
+            logger.error("Error: {}".format(str(p.stderr)))
             return -1
         return 0
     elif remote_dir.startswith("s3"):  # s3://bucket/file_path
@@ -521,7 +521,7 @@ def get_remote_file_to_local(remote_path: str, local_path: str) -> int:
         cmd = 'hdfs dfs -get {} {}'.format(remote_path, local_path)
         p = subprocess.run(cmd, capture_output=True)
         if p.returncode != 0:
-            logger.error("Error: {}".format(p.stderr))
+            logger.error("Error: {}".format(str(p.stderr)))
             return -1
         return 0
     elif remote_path.startswith("s3"):  # s3://bucket/file_path
@@ -552,7 +552,7 @@ def get_remote_dir_to_local(remote_dir: str, local_dir: str) -> int:
         cmd = 'hdfs dfs -get {} {}'.format(remote_dir, local_dir)
         p = subprocess.run(cmd, capture_output=True)
         if p.returncode != 0:
-            logger.error("Error: {}".format(p.stderr))
+            logger.error("Error: {}".format(str(p.stderr)))
             return -1
         return 0
     elif remote_dir.startswith("s3"):  # s3://bucket/file_path
@@ -589,7 +589,7 @@ def get_remote_files_with_prefix_to_local(remote_path_prefix: str,
         cmd = 'hdfs dfs -get {}* {}'.format(remote_path_prefix, local_dir)
         p = subprocess.run(cmd, capture_output=True)
         if p.returncode != 0:
-            logger.error("Error: {}".format(p.stderr))
+            logger.error("Error: {}".format(str(p.stderr)))
             return -1
         return 0
     elif remote_path_prefix.startswith("s3"):  # s3://bucket/file_path

--- a/python/orca/src/bigdl/orca/data/file.py
+++ b/python/orca/src/bigdl/orca/data/file.py
@@ -393,7 +393,7 @@ def put_local_dir_tree_to_remote(local_dir: str, remote_dir: str):
         cmd = 'hdfs dfs -put -f {}/* {}/'.format(local_dir, remote_dir)
         process = subprocess.run(cmd, capture_output=True)
         if process.returncode != 0:
-            logger.error("Error: {}".format(process.stderr))
+            logger.error("Error: {}".format(str(process.stderr)))
             return -1
         return 0
     elif remote_dir.startswith("s3"):  # s3://bucket/file_path

--- a/python/orca/src/bigdl/orca/data/file.py
+++ b/python/orca/src/bigdl/orca/data/file.py
@@ -62,8 +62,9 @@ def open_text(path: str) -> List[str]:
         if path.startswith("file://"):
             path = path[len("file://"):]
         lines = []
-        for line in open(path):
-            lines.append(line)
+        with open(path, 'rb') as f:
+            for line in f:
+                lines.append(line)
     return [line.strip() for line in lines]
 
 
@@ -95,7 +96,10 @@ def open_image(path: str) -> "JpegImageFile":
         bucket = path_parts.pop(0)
         key = "/".join(path_parts)
         data = s3_client.get_object(Bucket=bucket, Key=key)
-        return Image.open(BytesIO(data["Body"].read()))
+        with BytesIO(data["Body"].read()) as f:
+            image = Image.open(f)
+            image.load()
+        return image
     else:  # Local path
         if path.startswith("file://"):
             path = path[len("file://"):]
@@ -270,7 +274,6 @@ def write_text(path: str, text: str) -> int:
         fs = pa.hdfs.connect()
         with fs.open(path, 'wb') as f:
             result = f.write(text.encode('utf-8'))
-            f.close()
             return result
     elif path.startswith("s3"):  # s3://bucket/file_path
         access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
@@ -288,7 +291,6 @@ def write_text(path: str, text: str) -> int:
             path = path[len("file://"):]
         with open(path, 'w') as f:
             result = f.write(text)
-            f.close()
             return result
 
 
@@ -341,8 +343,8 @@ def put_local_dir_to_remote(local_dir: str, remote_dir: str):
     if remote_dir.startswith("hdfs"):  # hdfs://url:port/file_path
         import pyarrow as pa
         host_port = remote_dir.split("://")[1].split("/")[0].split(":")
-        classpath = subprocess.Popen(["hadoop", "classpath", "--glob"],
-                                     stdout=subprocess.PIPE).communicate()[0]
+        with subprocess.Popen(["hadoop", "classpath", "--glob"], stdout=subprocess.PIPE) as p:
+            classpath = p.communicate()[0]
         os.environ["CLASSPATH"] = classpath.decode("utf-8")
         if len(host_port) > 1:
             fs = pa.hdfs.connect(host=host_port[0], port=int(host_port[1]))
@@ -375,24 +377,25 @@ def put_local_dir_to_remote(local_dir: str, remote_dir: str):
 def put_local_dir_tree_to_remote(local_dir: str, remote_dir: str):
     if remote_dir.startswith("hdfs"):  # hdfs://url:port/file_path
         test_cmd = 'hdfs dfs -ls {}'.format(remote_dir)
-        process = subprocess.Popen(test_cmd, shell=True,
-                                   stdout=subprocess.PIPE,
-                                   stderr=subprocess.PIPE)
-        out, err = process.communicate()
-        if process.returncode != 0:
-            if 'No such file or directory' in err.decode('utf-8'):
-                mkdir_cmd = 'hdfs dfs -mkdir -p {}'.format(remote_dir)
-                mkdir_process = subprocess.Popen(mkdir_cmd, shell=True)
-                ret = mkdir_process.wait()
-                if ret != 0:
-                    return ret
-            else:
-                # ls remote dir error
-                logger.warning(err.decode('utf-8'))
-                return -1
+        with subprocess.Popen(test_cmd, shell=True, stdout=subprocess.PIPE,
+                              stderr=subprocess.PIPE) as process:
+            out, err = process.communicate()
+            if process.returncode != 0:
+                if 'No such file or directory' in err.decode('utf-8'):
+                    mkdir_cmd = 'hdfs dfs -mkdir -p {}'.format(remote_dir)
+                    mkdir_process = subprocess.run(mkdir_cmd, capture_output=True)
+                    if mkdir_process.returncode != 0:
+                        return mkdir_process.returncode
+                else:
+                    # ls remote dir error
+                    logger.warning(err.decode('utf-8'))
+                    return -1
         cmd = 'hdfs dfs -put -f {}/* {}/'.format(local_dir, remote_dir)
-        process = subprocess.Popen(cmd, shell=True)
-        return process.wait()
+        process = subprocess.run(cmd, capture_output=True)
+        if process.returncode != 0:
+            logger.error("Error: {}".format(process.stderr))
+            return -1
+        return 0
     elif remote_dir.startswith("s3"):  # s3://bucket/file_path
         access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
         secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
@@ -429,18 +432,19 @@ def put_local_dir_tree_to_remote(local_dir: str, remote_dir: str):
 def put_local_file_to_remote(local_path: str, remote_path: str,
                              filemode: Optional[int] = None) -> int:
     if remote_path.startswith("hdfs"):  # hdfs://url:port/file_path
-        try:
-            cmd = 'hdfs dfs -put -f {} {}'.format(local_path, remote_path)
-            process = subprocess.Popen(cmd, shell=True)
-            process.wait()
-            if filemode:
-                chmod_cmd = 'hdfs dfs -chmod {} {}'.format(filemode, remote_path)
-                process = subprocess.Popen(chmod_cmd, shell=True)
-                process.wait()
-        except Exception as e:
+        cmd = 'hdfs dfs -put -f {} {}'.format(local_path, remote_path)
+        p = subprocess.run(cmd, capture_output=True)
+        if p.returncode != 0:
             logger.error("Cannot upload file {} to {}: error: {}"
-                         .format(local_path, remote_path, str(e)))
+                            .format(local_path, remote_path, p.stderr))
             return -1
+        if filemode:
+            chmod_cmd = 'hdfs dfs -chmod {} {}'.format(filemode, remote_path)
+            p = subprocess.run(chmod_cmd, capture_output=True)
+            if p.returncode != 0:
+                logger.error("Cannot upload file {} to {}: error: {}"
+                                .format(local_path, remote_path, p.stderr))
+                return -1
         return 0
     elif remote_path.startswith("s3"):  # s3://bucket/file_path
         access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
@@ -478,8 +482,11 @@ def put_local_files_with_prefix_to_remote(local_path_prefix: str, remote_dir: st
     file_list = glob.glob(local_path_prefix + "*")
     if remote_dir.startswith("hdfs"):  # hdfs://url:port/file_path
         cmd = 'hdfs dfs -put -f {}* {}'.format(local_path_prefix, remote_dir)
-        process = subprocess.Popen(cmd, shell=True)
-        return process.wait()
+        p = subprocess.run(cmd, capture_output=True)
+        if p.returncode != 0:
+            logger.error("Error: {}".format(p.stderr))
+            return -1
+        return 0
     elif remote_dir.startswith("s3"):  # s3://bucket/file_path
         access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
         secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
@@ -512,8 +519,11 @@ def put_local_files_with_prefix_to_remote(local_path_prefix: str, remote_dir: st
 def get_remote_file_to_local(remote_path: str, local_path: str) -> int:
     if remote_path.startswith("hdfs"):  # hdfs://url:port/file_path
         cmd = 'hdfs dfs -get {} {}'.format(remote_path, local_path)
-        process = subprocess.Popen(cmd, shell=True)
-        return process.wait()
+        p = subprocess.run(cmd, capture_output=True)
+        if p.returncode != 0:
+            logger.error("Error: {}".format(p.stderr))
+            return -1
+        return 0
     elif remote_path.startswith("s3"):  # s3://bucket/file_path
         access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
         secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
@@ -540,8 +550,11 @@ def get_remote_file_to_local(remote_path: str, local_path: str) -> int:
 def get_remote_dir_to_local(remote_dir: str, local_dir: str) -> int:
     if remote_dir.startswith("hdfs"):  # hdfs://url:port/file_path
         cmd = 'hdfs dfs -get {} {}'.format(remote_dir, local_dir)
-        process = subprocess.Popen(cmd, shell=True)
-        return process.wait()
+        p = subprocess.run(cmd, capture_output=True)
+        if p.returncode != 0:
+            logger.error("Error: {}".format(p.stderr))
+            return -1
+        return 0
     elif remote_dir.startswith("s3"):  # s3://bucket/file_path
         access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
         secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
@@ -574,8 +587,11 @@ def get_remote_files_with_prefix_to_local(remote_path_prefix: str,
     prefix = os.path.basename(remote_path_prefix)
     if remote_path_prefix.startswith("hdfs"):  # hdfs://url:port/file_path
         cmd = 'hdfs dfs -get {}* {}'.format(remote_path_prefix, local_dir)
-        process = subprocess.Popen(cmd, shell=True)
-        return process.wait()
+        p = subprocess.run(cmd, capture_output=True)
+        if p.returncode != 0:
+            logger.error("Error: {}".format(p.stderr))
+            return -1
+        return 0
     elif remote_path_prefix.startswith("s3"):  # s3://bucket/file_path
         access_key_id = os.environ["AWS_ACCESS_KEY_ID"]
         secret_access_key = os.environ["AWS_SECRET_ACCESS_KEY"]
@@ -619,21 +635,14 @@ def enable_multi_fs_load_static(load_func: Callable) -> Callable:
             from bigdl.dllib.utils.file_utils import append_suffix
             file_name = str(uuid.uuid1())
             file_name = append_suffix(file_name, path.strip("/").split("/")[-1])
-            temp_path = os.path.join(tempfile.gettempdir(), file_name)
-            if is_file(path):
-                get_remote_file_to_local(path, temp_path)
-            else:
-                os.mkdir(temp_path)
-                get_remote_dir_to_local(path, temp_path)
-            try:
-                return load_func(temp_path, *args, **kwargs)
-            finally:
-                if os.path.isdir(temp_path):
-                    import shutil
-                    shutil.rmtree(temp_path)
+            with tempfile.gettempdir() as tmpdir:
+                temp_path = os.path.join(tmpdir, file_name)
+                if is_file(path):
+                    get_remote_file_to_local(path, temp_path)
                 else:
-                    os.remove(temp_path)
-
+                    os.mkdir(temp_path)
+                    get_remote_dir_to_local(path, temp_path)
+                return load_func(temp_path, *args, **kwargs)
     return fs_load
 
 
@@ -650,13 +659,10 @@ def enable_multi_fs_save(save_func: Callable) -> Callable:
             from bigdl.dllib.utils.file_utils import append_suffix
             file_name = str(uuid.uuid1())
             file_name = append_suffix(file_name, path)
-            temp_path = os.path.join(tempfile.gettempdir(), file_name)
-
-            try:
+            with tempfile.gettempdir() as tmpdir:
+                temp_path = os.path.join(tmpdir, file_name)
                 result = save_func(obj, temp_path, *args, **kwargs)
                 put_local_file_to_remote(temp_path, path)
-            finally:
-                os.remove(temp_path)
             return result
 
     return fs_save
@@ -675,11 +681,9 @@ def enable_multi_fs_load(load_func: Callable) -> Callable:
             from bigdl.dllib.utils.file_utils import append_suffix
             file_name = str(uuid.uuid1())
             file_name = append_suffix(file_name, path)
-            temp_path = os.path.join(tempfile.gettempdir(), file_name)
-            get_remote_file_to_local(path, temp_path)
-            try:
+            with tempfile.gettempdir() as tmpdir:
+                temp_path = os.path.join(tmpdir, file_name)
+                get_remote_file_to_local(path, temp_path)
                 return load_func(obj, temp_path, *args, **kwargs)
-            finally:
-                os.remove(temp_path)
 
     return fs_load

--- a/python/orca/src/bigdl/orca/data/file.py
+++ b/python/orca/src/bigdl/orca/data/file.py
@@ -436,14 +436,14 @@ def put_local_file_to_remote(local_path: str, remote_path: str,
         p = subprocess.run(cmd, capture_output=True)
         if p.returncode != 0:
             logger.error("Cannot upload file {} to {}: error: {}"
-                            .format(local_path, remote_path, p.stderr))
+                         .format(local_path, remote_path, p.stderr))
             return -1
         if filemode:
             chmod_cmd = 'hdfs dfs -chmod {} {}'.format(filemode, remote_path)
             p = subprocess.run(chmod_cmd, capture_output=True)
             if p.returncode != 0:
                 logger.error("Cannot upload file {} to {}: error: {}"
-                                .format(local_path, remote_path, p.stderr))
+                             .format(local_path, remote_path, p.stderr))
                 return -1
         return 0
     elif remote_path.startswith("s3"):  # s3://bucket/file_path

--- a/python/orca/src/bigdl/orca/data/file.py
+++ b/python/orca/src/bigdl/orca/data/file.py
@@ -633,7 +633,7 @@ def enable_multi_fs_load_static(load_func: Callable) -> Callable:
             from bigdl.dllib.utils.file_utils import append_suffix
             file_name = str(uuid.uuid1())
             file_name = append_suffix(file_name, path.strip("/").split("/")[-1])
-            with tempfile.gettempdir() as tmpdir:
+            with tempfile.TemporaryDirectory() as tmpdir:
                 temp_path = os.path.join(tmpdir, file_name)
                 if is_file(path):
                     get_remote_file_to_local(path, temp_path)
@@ -657,7 +657,7 @@ def enable_multi_fs_save(save_func: Callable) -> Callable:
             from bigdl.dllib.utils.file_utils import append_suffix
             file_name = str(uuid.uuid1())
             file_name = append_suffix(file_name, path)
-            with tempfile.gettempdir() as tmpdir:
+            with tempfile.TemporaryDirectory() as tmpdir:
                 temp_path = os.path.join(tmpdir, file_name)
                 result = save_func(obj, temp_path, *args, **kwargs)
                 put_local_file_to_remote(temp_path, path)
@@ -679,7 +679,7 @@ def enable_multi_fs_load(load_func: Callable) -> Callable:
             from bigdl.dllib.utils.file_utils import append_suffix
             file_name = str(uuid.uuid1())
             file_name = append_suffix(file_name, path)
-            with tempfile.gettempdir() as tmpdir:
+            with tempfile.TemporaryDirectory() as tmpdir:
                 temp_path = os.path.join(tmpdir, file_name)
                 get_remote_file_to_local(path, temp_path)
                 return load_func(obj, temp_path, *args, **kwargs)

--- a/python/orca/src/bigdl/orca/data/file.py
+++ b/python/orca/src/bigdl/orca/data/file.py
@@ -638,7 +638,7 @@ def enable_multi_fs_load_static(load_func: Callable) -> Callable:
                 if is_file(path):
                     get_remote_file_to_local(path, temp_path)
                 else:
-                    os.mkdir(temp_path)
+                    os.makedirs(temp_path)
                     get_remote_dir_to_local(path, temp_path)
                 return load_func(temp_path, *args, **kwargs)
     return fs_load

--- a/python/orca/src/bigdl/orca/data/image/utils.py
+++ b/python/orca/src/bigdl/orca/data/image/utils.py
@@ -181,5 +181,5 @@ def pa_fs(path):
 def decode_imagebytes2PIL(image_btyes):
     from PIL import Image
     from io import BytesIO
-    imagebs = BytesIO(image_btyes)
-    return Image.open(imagebs)
+    with BytesIO(image_btyes) as imagebs:
+        return Image.open(imagebs)

--- a/python/orca/src/bigdl/orca/data/image/utils.py
+++ b/python/orca/src/bigdl/orca/data/image/utils.py
@@ -142,9 +142,9 @@ def dict_to_row(schema, row_dict):
                 img_bytes = f.read()
             row[k] = bytearray(img_bytes)
         elif schema_field.feature_type == FeatureType.NDARRAY:
-            memfile = BytesIO()
-            np.savez_compressed(memfile, arr=v)
-            row[k] = bytearray(memfile.getvalue())
+            with BytesIO() as memfile:
+                np.savez_compressed(memfile, arr=v)
+                row[k] = bytearray(memfile.getvalue())
         else:
             row[k] = v
     return pyspark.Row(**row)
@@ -167,9 +167,9 @@ def chunks(iterable: List[Dict[str, Union[str, int, float, "ndarray"]]],
 def pa_fs(path):
     import pyarrow as pa
     if path.startswith("hdfs"):  # hdfs://url:port/file_path
-        fs = pa.hdfs.connect()
-        path = path[len("hdfs://"):]
-        return path, fs
+        with pa.hdfs.connect() as fs:
+            path = path[len("hdfs://"):]
+            return path, fs
     elif path.startswith("s3"):
         invalidInputError(False, "aws s3 is not supported for now")
     else:  # Local path

--- a/python/orca/src/bigdl/orca/data/image/utils.py
+++ b/python/orca/src/bigdl/orca/data/image/utils.py
@@ -167,9 +167,9 @@ def chunks(iterable: List[Dict[str, Union[str, int, float, "ndarray"]]],
 def pa_fs(path):
     import pyarrow as pa
     if path.startswith("hdfs"):  # hdfs://url:port/file_path
-        with pa.hdfs.connect() as fs:
-            path = path[len("hdfs://"):]
-            return path, fs
+        fs = pa.hdfs.connect()
+        path = path[len("hdfs://"):]
+        return path, fs
     elif path.startswith("s3"):
         invalidInputError(False, "aws s3 is not supported for now")
     else:  # Local path

--- a/python/orca/src/bigdl/orca/learn/log_monitor.py
+++ b/python/orca/src/bigdl/orca/learn/log_monitor.py
@@ -150,15 +150,15 @@ def start_log_server(ip, port):
 
         """
         import zmq
-        context = zmq.Context()
-        socket = context.socket(zmq.REP)
-        socket.bind("tcp://{}:{}".format(ip, port))
-        logger.info("started log server on {}:{}".format(ip, port))
+        with zmq.Context() as context:
+            with context.socket(zmq.REP) as socket:
+                socket.bind("tcp://{}:{}".format(ip, port))
+                logger.info("started log server on {}:{}".format(ip, port))
 
-        while True:
-            message = socket.recv()
-            print(message.decode("utf-8"))
-            socket.send(b"received")
+                while True:
+                    message = socket.recv()
+                    print(message.decode("utf-8"))
+                    socket.send(b"received")
 
     import threading
     logger_thread = threading.Thread(
@@ -189,8 +189,8 @@ def stop_log_server(thread, ip, port):
         def stop_thread(thread):
             _async_raise(thread.ident, SystemExit)
 
-        context = zmq.Context()
-        socket = context.socket(zmq.REQ)
-        socket.connect("tcp://{}:{}".format(ip, port))
-        socket.send_string("shutdown log server")
+        with zmq.Context() as context:
+            with context.socket(zmq.REQ) as socket:
+                socket.connect("tcp://{}:{}".format(ip, port))
+                socket.send_string("shutdown log server")
         stop_thread(thread)

--- a/python/orca/src/bigdl/orca/learn/mxnet/utils.py
+++ b/python/orca/src/bigdl/orca/learn/mxnet/utils.py
@@ -20,7 +20,7 @@ from bigdl.dllib.utils.log4Error import *
 
 
 def find_free_port():
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("", 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return s.getsockname()[1]

--- a/python/orca/src/bigdl/orca/learn/pytorch/utils.py
+++ b/python/orca/src/bigdl/orca/learn/pytorch/utils.py
@@ -184,7 +184,7 @@ class TimerCollection:
 
 
 def find_free_port():
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("", 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return s.getsockname()[1]

--- a/python/orca/src/bigdl/orca/learn/tf/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf/tf_runner.py
@@ -47,7 +47,7 @@ logger = logging.getLogger(__name__)
 
 
 def find_free_port():
-    with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("", 0))
         s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         return s.getsockname()[1]

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -525,11 +525,11 @@ class TFRunner:
                         get_remote_file_to_local(filepath, temp_path)
                     else:
                         # savemodel format
-                        if os.path.exists(temp_path):
-                            os.makedirs(temp_path)
+                        os.makedirs(temp_path)
                         get_remote_dir_to_local(filepath, temp_path)
                     self.load_params["filepath"] = temp_path
                     local_model = self.process_model_load(**self.load_params)
+                    self.load_params["filepath"] = filepath
             try:
                 local_model.set_weights(self.model.get_weights())
             except Exception:
@@ -599,6 +599,7 @@ class TFRunner:
                     put_local_file_to_remote(temp_path, filepath)
                 else:
                     # savemodel format
+                    os.makedirs(temp_path)
                     put_local_dir_tree_to_remote(temp_path, filepath)
 
     def process_model_load(self, filepath, custom_objects, compile, options):
@@ -641,8 +642,7 @@ class TFRunner:
                 get_remote_file_to_local(filepath, temp_path)
             else:
                 # savemodel format
-                if os.path.exists(temp_path):
-                    os.makedirs(temp_path)
+                os.makedirs(temp_path)
                 get_remote_dir_to_local(filepath, temp_path)
             if self.backend == "tf-distributed":
                 with self.strategy.scope():

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -518,7 +518,7 @@ class TFRunner:
             else:
                 filepath = self.load_params["filepath"]
                 file_name = os.path.basename(filepath)
-                with tempfile.mkdtemp() as tempdir:
+                with tempfile.gettempdir() as tempdir:
                     temp_path = os.path.join(tempdir, file_name)
                     if is_file(filepath):
                         # h5 format
@@ -588,7 +588,7 @@ class TFRunner:
 
     def save_model(self, filepath, overwrite, include_optimizer, save_format, signatures, options):
         file_name = os.path.basename(filepath)
-        with tempfile.mkdtemp() as temp_dir:
+        with tempfile.gettempdir() as temp_dir:
             temp_path = os.path.join(temp_dir, file_name)
             self.model.save(filepath=temp_path, overwrite=overwrite, save_format=save_format,
                             include_optimizer=include_optimizer, signatures=signatures,
@@ -634,7 +634,7 @@ class TFRunner:
             options=options
         )
         file_name = os.path.basename(filepath)
-        with tempfile.mkdtemp() as tempdir:
+        with tempfile.gettempdir() as tempdir:
             temp_path = os.path.join(tempdir, file_name)
             if is_file(filepath):
                 # h5 format
@@ -654,7 +654,7 @@ class TFRunner:
 
     def save_weights(self, filepath, overwrite, save_format, options):
         file_name = os.path.basename(filepath)
-        with tempfile.mkdtemp() as temp_dir:
+        with tempfile.gettempdir() as temp_dir:
             temp_path = os.path.join(temp_dir, file_name)
             self.model.save_weights(temp_path, overwrite, save_format, options)
             if self.rank == 0:
@@ -676,7 +676,7 @@ class TFRunner:
     def load_remote_weights(self, filepath, by_name, skip_mismatch, options):
         """Loads all layer weights from a remote weight file (Tensorflow or HDF5 format)."""
         file_name = os.path.basename(filepath)
-        with tempfile.mkdtemp() as temp_dir:
+        with tempfile.gettempdir() as temp_dir:
             if is_file(filepath):
                 # h5 format
                 temp_path = os.path.join(temp_dir, file_name)

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -599,7 +599,6 @@ class TFRunner:
                     put_local_file_to_remote(temp_path, filepath)
                 else:
                     # savemodel format
-                    os.makedirs(temp_path)
                     put_local_dir_tree_to_remote(temp_path, filepath)
 
     def process_model_load(self, filepath, custom_objects, compile, options):

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -518,7 +518,7 @@ class TFRunner:
             else:
                 filepath = self.load_params["filepath"]
                 file_name = os.path.basename(filepath)
-                with tempfile.gettempdir() as tempdir:
+                with tempfile.TemporaryDirectory() as tempdir:
                     temp_path = os.path.join(tempdir, file_name)
                     if is_file(filepath):
                         # h5 format
@@ -588,7 +588,7 @@ class TFRunner:
 
     def save_model(self, filepath, overwrite, include_optimizer, save_format, signatures, options):
         file_name = os.path.basename(filepath)
-        with tempfile.gettempdir() as temp_dir:
+        with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = os.path.join(temp_dir, file_name)
             self.model.save(filepath=temp_path, overwrite=overwrite, save_format=save_format,
                             include_optimizer=include_optimizer, signatures=signatures,
@@ -634,7 +634,7 @@ class TFRunner:
             options=options
         )
         file_name = os.path.basename(filepath)
-        with tempfile.gettempdir() as tempdir:
+        with tempfile.TemporaryDirectory() as tempdir:
             temp_path = os.path.join(tempdir, file_name)
             if is_file(filepath):
                 # h5 format
@@ -654,7 +654,7 @@ class TFRunner:
 
     def save_weights(self, filepath, overwrite, save_format, options):
         file_name = os.path.basename(filepath)
-        with tempfile.gettempdir() as temp_dir:
+        with tempfile.TemporaryDirectory() as temp_dir:
             temp_path = os.path.join(temp_dir, file_name)
             self.model.save_weights(temp_path, overwrite, save_format, options)
             if self.rank == 0:
@@ -676,7 +676,7 @@ class TFRunner:
     def load_remote_weights(self, filepath, by_name, skip_mismatch, options):
         """Loads all layer weights from a remote weight file (Tensorflow or HDF5 format)."""
         file_name = os.path.basename(filepath)
-        with tempfile.gettempdir() as temp_dir:
+        with tempfile.TemporaryDirectory() as temp_dir:
             if is_file(filepath):
                 # h5 format
                 temp_path = os.path.join(temp_dir, file_name)

--- a/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
+++ b/python/orca/src/bigdl/orca/learn/tf2/tf_runner.py
@@ -518,17 +518,18 @@ class TFRunner:
             else:
                 filepath = self.load_params["filepath"]
                 file_name = os.path.basename(filepath)
-                temp_path = os.path.join(tempfile.mkdtemp(), file_name)
-                if is_file(filepath):
-                    # h5 format
-                    get_remote_file_to_local(filepath, temp_path)
-                else:
-                    # savemodel format
-                    if os.path.exists(temp_path):
-                        os.makedirs(temp_path)
-                    get_remote_dir_to_local(filepath, temp_path)
-                self.load_params["filepath"] = temp_path
-                local_model = self.process_model_load(**self.load_params)
+                with tempfile.mkdtemp() as tempdir:
+                    temp_path = os.path.join(tempdir, file_name)
+                    if is_file(filepath):
+                        # h5 format
+                        get_remote_file_to_local(filepath, temp_path)
+                    else:
+                        # savemodel format
+                        if os.path.exists(temp_path):
+                            os.makedirs(temp_path)
+                        get_remote_dir_to_local(filepath, temp_path)
+                    self.load_params["filepath"] = temp_path
+                    local_model = self.process_model_load(**self.load_params)
             try:
                 local_model.set_weights(self.model.get_weights())
             except Exception:
@@ -587,9 +588,8 @@ class TFRunner:
 
     def save_model(self, filepath, overwrite, include_optimizer, save_format, signatures, options):
         file_name = os.path.basename(filepath)
-        temp_dir = tempfile.mkdtemp()
-        temp_path = os.path.join(temp_dir, file_name)
-        try:
+        with tempfile.mkdtemp() as temp_dir:
+            temp_path = os.path.join(temp_dir, file_name)
             self.model.save(filepath=temp_path, overwrite=overwrite, save_format=save_format,
                             include_optimizer=include_optimizer, signatures=signatures,
                             options=options)
@@ -600,8 +600,6 @@ class TFRunner:
                 else:
                     # savemodel format
                     put_local_dir_tree_to_remote(temp_path, filepath)
-        finally:
-            shutil.rmtree(temp_dir)
 
     def process_model_load(self, filepath, custom_objects, compile, options):
         """Load the model from provided local filepath."""
@@ -636,16 +634,16 @@ class TFRunner:
             options=options
         )
         file_name = os.path.basename(filepath)
-        temp_path = os.path.join(tempfile.mkdtemp(), file_name)
-        if is_file(filepath):
-            # h5 format
-            get_remote_file_to_local(filepath, temp_path)
-        else:
-            # savemodel format
-            if os.path.exists(temp_path):
-                os.makedirs(temp_path)
-            get_remote_dir_to_local(filepath, temp_path)
-        try:
+        with tempfile.mkdtemp() as tempdir:
+            temp_path = os.path.join(tempdir, file_name)
+            if is_file(filepath):
+                # h5 format
+                get_remote_file_to_local(filepath, temp_path)
+            else:
+                # savemodel format
+                if os.path.exists(temp_path):
+                    os.makedirs(temp_path)
+                get_remote_dir_to_local(filepath, temp_path)
             if self.backend == "tf-distributed":
                 with self.strategy.scope():
                     self.model = self.process_model_load(temp_path, custom_objects, compile,
@@ -653,17 +651,11 @@ class TFRunner:
             else:
                 self.model = self.process_model_load(temp_path, custom_objects, compile,
                                                      options)
-        finally:
-            if os.path.isdir(temp_path):
-                shutil.rmtree(temp_path)
-            else:
-                os.remove(temp_path)
 
     def save_weights(self, filepath, overwrite, save_format, options):
         file_name = os.path.basename(filepath)
-        temp_dir = tempfile.mkdtemp()
-        temp_path = os.path.join(temp_dir, file_name)
-        try:
+        with tempfile.mkdtemp() as temp_dir:
+            temp_path = os.path.join(temp_dir, file_name)
             self.model.save_weights(temp_path, overwrite, save_format, options)
             if self.rank == 0:
                 if save_format == 'h5' or filepath.endswith('.h5') or filepath.endswith('.keras'):
@@ -673,8 +665,6 @@ class TFRunner:
                     # tf format
                     remote_dir = os.path.dirname(filepath)
                     put_local_files_with_prefix_to_remote(temp_path, remote_dir)
-        finally:
-            shutil.rmtree(temp_dir)
 
     def load_weights(self, filepath, by_name, skip_mismatch, options):
         """Loads all layer weights from a TensorFlow or an HDF5 weight file."""
@@ -686,23 +676,20 @@ class TFRunner:
     def load_remote_weights(self, filepath, by_name, skip_mismatch, options):
         """Loads all layer weights from a remote weight file (Tensorflow or HDF5 format)."""
         file_name = os.path.basename(filepath)
-        temp_dir = tempfile.mkdtemp()
-        if is_file(filepath):
-            # h5 format
-            temp_path = os.path.join(temp_dir, file_name)
-            get_remote_file_to_local(filepath, temp_path)
-        else:
-            # tensorflow format
-            prefix = os.path.basename(filepath)
-            get_remote_files_with_prefix_to_local(filepath, temp_dir)
-            temp_path = os.path.join(temp_dir, prefix)
-        try:
+        with tempfile.mkdtemp() as temp_dir:
+            if is_file(filepath):
+                # h5 format
+                temp_path = os.path.join(temp_dir, file_name)
+                get_remote_file_to_local(filepath, temp_path)
+            else:
+                # tensorflow format
+                prefix = os.path.basename(filepath)
+                get_remote_files_with_prefix_to_local(filepath, temp_dir)
+                temp_path = os.path.join(temp_dir, prefix)
             if options:
                 self.model.load_weights(temp_path, by_name, skip_mismatch, options)
             else:  # To support older TensorFlow versions such as 2.1
                 self.model.load_weights(temp_path, by_name, skip_mismatch)
-        finally:
-            shutil.rmtree(temp_dir)
 
     def shutdown(self):
         """Attempts to shut down the worker."""

--- a/python/ppml/src/bigdl/ppml/fl/utils.py
+++ b/python/ppml/src/bigdl/ppml/fl/utils.py
@@ -44,10 +44,9 @@ class FLTest(unittest.TestCase):
 
     def get_available_port(self, port_start, port_end):
         def is_available(p):            
-            sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            result = sock.connect_ex(('127.0.0.1', p))            
-            sock.close()
-            return result != 0
+            with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                result = sock.connect_ex(('127.0.0.1', p))            
+                return result != 0
         for p in range(port_start, port_end):
             if is_available(p):
                 return p


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

To fix second half `Improper Resource Shutdown or Release of Resource`
- [ ] \BigDL-main\python\orca\dev\test\pep8-1.7.0.py
- [x] \BigDL-main\python\orca\example\learn\tf2\yolov3\yoloV3.py
- [x] \BigDL-main\python\orca\src\bigdl\orca\data\file.py
- [ ] \BigDL-main\python\orca\src\bigdl\orca\data\image\parquet_dataset.py
- [ ] \BigDL-main\python\orca\src\bigdl\orca\data\image\pep8-1.7.0.py
- [x] \BigDL-main\python\orca\src\bigdl\orca\data\image\utils.py
- [x] **NOT FOUND** \BigDL-main\python\orca\src\bigdl\orca\learn\file.py
- [x] \BigDL-main\python\orca\src\bigdl\orca\learn\log_monitor.py
- [x] \BigDL-main\python\orca\src\bigdl\orca\learn\mxnet\utils.py
- [x] \BigDL-main\python\orca\src\bigdl\orca\learn\pytorch\utils.py
- [x] \BigDL-main\python\orca\src\bigdl\orca\learn\tf2\tf_runner.py
- [x] \BigDL-main\python\orca\src\bigdl\orca\learn\tf\tf_runner.py
- [x] **NOT FOUND** \BigDL-main\python\orca\test\bigdl\orca\learn\spark\test_estimator_openvino.py
- [ ] \BigDL-main\python\ppml\dev\pep8-1.7.0.py
- [x] \BigDL-main\python\ppml\src\bigdl\ppml\fl\utils.py
- [ ] \BigDL-main\python\serving\dev\pep8-1.7.0.py


### 2. User API changes

None.

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [x] Unit test

