### PR TITLE
FIx Command Injection issues in Bigdl

### DIFF
--- a/python/dllib/src/bigdl/dllib/utils/spark.py
+++ b/python/dllib/src/bigdl/dllib/utils/spark.py
@@ -26,6 +26,7 @@ from bigdl.dllib.utils.utils import get_executor_conda_zoo_classpath
 from bigdl.dllib.utils.utils import get_zoo_bigdl_classpath_on_driver
 from bigdl.dllib.utils.utils import get_bigdl_class_version
 from bigdl.dllib.utils.utils import get_bigdl_image_workdir
+from bigdl.dllib.utils.utils import is_valid_ip_address
 from bigdl.dllib.utils.engine import get_bigdl_jars
 from bigdl.dllib.utils.log4Error import *
 
@@ -257,6 +258,7 @@ class SparkRunner:
             pyspark_home = os.path.abspath(pyspark.__file__ + "/../")
             zoo_standalone_home = os.path.abspath(__file__ + "/../../../share/dllib/bin/standalone")
             node_ip = get_node_ip()
+            invalidInputError(is_valid_ip_address(node_ip), "Invalid node IP address.")
             SparkRunner.standalone_env = {
                 "SPARK_HOME": pyspark_home,
                 "ZOO_STANDALONE_HOME": zoo_standalone_home,
@@ -264,6 +266,8 @@ class SparkRunner:
                 "SPARK_MASTER_HOST": node_ip}
             if 'JAVA_HOME' in os.environ:
                 SparkRunner.standalone_env["JAVA_HOME"] = os.environ["JAVA_HOME"]
+            if not os.path.isdir(zoo_standalone_home):
+                invalidInputError(False, "zoo_standalone_home should be a valid directory path.")
             # The scripts installed from pip don't have execution permission
             # and need to first give them permission.
             pro = subprocess.Popen(["chmod", "-R", "+x", "{}/sbin".format(zoo_standalone_home)])
@@ -283,7 +287,7 @@ class SparkRunner:
             else:
                 worker_script = "start-worker.sh"
             start_worker_pro = subprocess.Popen(
-                "{}/sbin/{} {}".format(zoo_standalone_home, worker_script, master),
+                ["{}/sbin/{}".format(zoo_standalone_home, worker_script), master],
                 shell=True, env=SparkRunner.standalone_env)
             _, status = os.waitpid(start_worker_pro.pid, 0)
             if status != 0:

--- a/python/dllib/src/bigdl/dllib/utils/utils.py
+++ b/python/dllib/src/bigdl/dllib/utils/utils.py
@@ -83,7 +83,7 @@ def detect_conda_env_name():
     # This only works for anaconda3
     import subprocess
     pro = subprocess.Popen(
-        "conda info",
+        ["conda", "info"],
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE)
@@ -282,3 +282,8 @@ def remove_batch(shape):
         return [remove_batch(s) for s in shape]
     else:
         return list(shape[1:])
+
+
+def is_valid_ip_address(ip):
+    pattern = r'^\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}$'
+    return re.match(pattern, ip) is not None

--- a/python/dllib/src/setup.py
+++ b/python/dllib/src/setup.py
@@ -20,6 +20,7 @@ import os
 import sys
 from shutil import copyfile, copytree, rmtree
 from setuptools import setup
+import subprocess
 
 long_description = '''
 BigDL DLlib is a distributed deep learning library for Apache Spark 
@@ -32,14 +33,9 @@ for more information.
 TEMP_PATH = "bigdl/share/dllib"
 dllib_src_path = os.path.abspath(__file__ + "/..")
 
-try:
-    exec(open(dllib_src_path + "/bigdl/dllib/version.py").read())
-except IOError:
-    print("Failed to load bigdl-dllib version file for packaging. "
-          "You need to run the release script instead.")
-    sys.exit(-1)
+command = open(os.path.join(dllib_src_path, "/bigdl/dllib/version.py"), 'r').read().strip()
+VERSION = command.split("=")[-1].strip("'")
 
-VERSION = __version__  # noqa
 PYSPARK_VERSION = '2.4.6'
 
 building_error_msg = """

--- a/python/dllib/src/setup.py
+++ b/python/dllib/src/setup.py
@@ -20,7 +20,6 @@ import os
 import sys
 from shutil import copyfile, copytree, rmtree
 from setuptools import setup
-import subprocess
 
 long_description = '''
 BigDL DLlib is a distributed deep learning library for Apache Spark 

--- a/python/dllib/src/setup.py
+++ b/python/dllib/src/setup.py
@@ -31,10 +31,10 @@ for more information.
 '''
 
 TEMP_PATH = "bigdl/share/dllib"
+bigdl_home = os.path.abspath(__file__ + "/../../../..")
 dllib_src_path = os.path.abspath(__file__ + "/..")
 
-command = open(os.path.join(dllib_src_path, "/bigdl/dllib/version.py"), 'r').read().strip()
-VERSION = command.split("=")[-1].strip("'")
+VERSION = open(os.path.join(bigdl_home, 'python/version.txt'), 'r').read().strip()
 
 PYSPARK_VERSION = '2.4.6'
 

--- a/python/nano/src/bigdl/nano/deps/horovod/multiprocs_backend.py
+++ b/python/nano/src/bigdl/nano/deps/horovod/multiprocs_backend.py
@@ -53,6 +53,12 @@ class HorovodBackend(Backend):
 
             cwd_path = os.path.split(os.path.realpath(__file__))[0]
 
+            invalidInputError(os.path.isdir(cwd_path),
+                              "cwd_path should be a valid directory path.")
+            invalidInputError(os.path.isdir(temp_dir),
+                              "temp_dir should be a valid directory path.")
+            invalidInputError(nprocs > 0, "nprocs must be greater than 0")
+
             p = subprocess.Popen(["horovodrun", "-np", str(nprocs), "-H", f"localhost:{nprocs}",
                                   sys.executable, f"{cwd_path}/horovod_worker.py", temp_dir])
 

--- a/python/orca/src/bigdl/orca/learn/mxnet/estimator.py
+++ b/python/orca/src/bigdl/orca/learn/mxnet/estimator.py
@@ -154,7 +154,7 @@ class MXNetEstimator(OrcaRayEstimator):
         modified_env.update(env)
         # Need to contain system env to run bash
         # TODO: Need to kill this process manually?
-        subprocess.Popen("python -c 'import mxnet'", shell=True, env=modified_env)
+        subprocess.Popen(["python", "-c", "'import mxnet'"], shell=True, env=modified_env)
 
         ray.get([
             runner.setup_distributed.remote(envs[i], self.config,

--- a/python/orca/src/bigdl/orca/learn/mxnet/mxnet_runner.py
+++ b/python/orca/src/bigdl/orca/learn/mxnet/mxnet_runner.py
@@ -77,7 +77,7 @@ class MXNetRunner(object):
             modified_env = os.environ.copy()
             modified_env.update(env)
             # For servers, just import mxnet and no need to do anything else.
-            subprocess.Popen("python -c 'import mxnet'", shell=True, env=modified_env)
+            subprocess.Popen(["python", "-c", "'import mxnet'"], shell=True, env=modified_env)
 
     def train(self, train_data, epochs=1, batch_size=32,
               validation_data=None, train_resize_batch_num=None):

--- a/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
+++ b/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
@@ -213,9 +213,9 @@ class RayServiceFuncGenerator(object):
     def start_ray_daemon(python_loc, pid_to_watch, pgid_to_kill):
         daemon_path = os.path.join(os.path.dirname(__file__), "ray_daemon.py")
         invalidInputError(os.path.isdir(python_loc),
-                            "python_loc should be a valid directory path.")
+                          "python_loc should be a valid directory path.")
         invalidInputError(os.path.isdir(daemon_path),
-                            "daemon_path should be a valid directory path.")
+                          "daemon_path should be a valid directory path.")
         invalidInputError(pid_to_watch > 0,
                           "pid_to_watch should be a positive integer.")
         invalidInputError(pgid_to_kill > 0,

--- a/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
+++ b/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
@@ -212,6 +212,14 @@ class RayServiceFuncGenerator(object):
     @staticmethod
     def start_ray_daemon(python_loc, pid_to_watch, pgid_to_kill):
         daemon_path = os.path.join(os.path.dirname(__file__), "ray_daemon.py")
+        invalidInputError(os.path.isdir(python_loc),
+                            "python_loc should be a valid directory path.")
+        invalidInputError(os.path.isdir(daemon_path),
+                            "daemon_path should be a valid directory path.")
+        invalidInputError(pid_to_watch > 0,
+                          "pid_to_watch should be a positive integer.")
+        invalidInputError(pgid_to_kill > 0,
+                          "pgid_to_kill should be a positive integer.")
         start_daemon_command = ['nohup', python_loc, daemon_path, str(pid_to_watch),
                                 str(pgid_to_kill)]
         # put ray daemon process in its children's process group to avoid being killed by spark.


### PR DESCRIPTION
## Description

As pentest recommended, we:
1. Validate and sanitize all parameters that the user provides to the application
2. By passing the command and its arguments as a list, you can ensure that the command string is not interpreted as a single command, thereby preventing command injection.