### PR TITLE
Optimize transformer int4 loading memory follow up

### DIFF
--- a/python/llm/example/transformers_int4.py
+++ b/python/llm/example/transformers_int4.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     if model_path == 'decapoda-research/llama-7b-hf':
         # load_in_4bit=True in bigdl.llm.transformers will convert
         # the relevant layers in the model into int4 format
-        model = AutoModelForCausalLM.from_pretrained(model_path, load_in_4bit=True)
+        model = AutoModelForCausalLM.from_pretrained(model_path, load_in_4bit=True, low_cpu_mem_usage=True)
         tokenizer = LlamaTokenizer.from_pretrained(model_path)
 
         input_str = "Once upon a time, there existed a little girl who liked to have adventures. She wanted to go to places and meet new people, and have fun"
@@ -46,7 +46,8 @@ if __name__ == '__main__':
         print(output_str)
         print(f'Inference time: {end-st} s')
     elif model_path == 'THUDM/chatglm-6b':
-        model = AutoModel.from_pretrained(model_path, trust_remote_code=True, load_in_4bit=True)
+        model = AutoModel.from_pretrained(model_path, trust_remote_code=True, load_in_4bit=True, low_cpu_mem_usage=True)
+        model.to(torch.float32)
         tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
 
         input_str = "晚上睡不着应该怎么办"

--- a/python/llm/example/transformers_int4.py
+++ b/python/llm/example/transformers_int4.py
@@ -32,7 +32,7 @@ if __name__ == '__main__':
     if model_path == 'decapoda-research/llama-7b-hf':
         # load_in_4bit=True in bigdl.llm.transformers will convert
         # the relevant layers in the model into int4 format
-        model = AutoModelForCausalLM.from_pretrained(model_path, load_in_4bit=True, low_cpu_mem_usage=True)
+        model = AutoModelForCausalLM.from_pretrained(model_path, load_in_4bit=True)
         tokenizer = LlamaTokenizer.from_pretrained(model_path)
 
         input_str = "Once upon a time, there existed a little girl who liked to have adventures. She wanted to go to places and meet new people, and have fun"
@@ -46,7 +46,7 @@ if __name__ == '__main__':
         print(output_str)
         print(f'Inference time: {end-st} s')
     elif model_path == 'THUDM/chatglm-6b':
-        model = AutoModel.from_pretrained(model_path, trust_remote_code=True, load_in_4bit=True, low_cpu_mem_usage=True)
+        model = AutoModel.from_pretrained(model_path, trust_remote_code=True, load_in_4bit=True)
         tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
 
         input_str = "晚上睡不着应该怎么办"

--- a/python/llm/example/transformers_int4.py
+++ b/python/llm/example/transformers_int4.py
@@ -47,7 +47,6 @@ if __name__ == '__main__':
         print(f'Inference time: {end-st} s')
     elif model_path == 'THUDM/chatglm-6b':
         model = AutoModel.from_pretrained(model_path, trust_remote_code=True, load_in_4bit=True, low_cpu_mem_usage=True)
-        model.to(torch.float32)
         tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
 
         input_str = "晚上睡不着应该怎么办"

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -71,6 +71,8 @@ def _replace_with_int4_linear(model, modules_to_not_convert=None, current_key_na
                     # Force requires grad to False to avoid unexpected errors
                     model._modules[name].requires_grad_(False)
 
+                    module.weight = None
+
         # Remove the last key for recursion
         if len(list(module.children())) > 0:
             _, has_been_replaced = _replace_with_int4_linear(

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -95,4 +95,6 @@ def ggml_convert_int4(model):
             "instead of Linear layers. Please double check your model architecture, or submit "
             "an issue on github if you think this is a bug."
         )
+    else:
+        model.to(torch.float32)
     return model

--- a/python/llm/src/bigdl/llm/transformers/linear_int4.py
+++ b/python/llm/src/bigdl/llm/transformers/linear_int4.py
@@ -171,7 +171,7 @@ def ggml_matmul_src1_x_src0_t(src0: torch.Tensor, src1: torch.Tensor, src0_shape
 
 
 class LinearInt4(nn.Linear):
-    def __init__(self, input_features, output_features, bias=True):
+    def __init__(self, input_features, output_features, bias=True, *args, **kwargs):
         super().__init__(input_features, output_features, bias)
         self.weight = ParamsInt4(self.weight.data, requires_grad=False,
                                  old_data=self.weight.data,
@@ -181,7 +181,6 @@ class LinearInt4(nn.Linear):
         self.weight_shape = (self.out_len, self.in_len)
 
     def forward(self, x: torch.Tensor):
-        # weights are cast automatically as Int8Params, but the bias has to be cast manually
         if self.bias is not None and self.bias.dtype != x.dtype:
             self.bias.data = self.bias.data.to(x.dtype)
 

--- a/python/llm/src/bigdl/llm/transformers/linear_int4.py
+++ b/python/llm/src/bigdl/llm/transformers/linear_int4.py
@@ -197,4 +197,4 @@ class LinearInt4(nn.Linear):
         if self.bias is not None:
             result += self.bias
 
-        return result
+        return result.to(x.dtype)

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -31,9 +31,8 @@ class _BaseAutoModelClass:
 
         if load_in_4bit:
             from .convert import ggml_convert_int4
-            model = model.to("cpu", torch.float32)
+            model = model.to("cpu")
             model = ggml_convert_int4(model)
-
         return model
 
 

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -27,6 +27,8 @@ class _BaseAutoModelClass:
                         *args,
                         **kwargs):
         load_in_4bit = kwargs.pop("load_in_4bit", False)
+        if load_in_4bit:
+            kwargs["low_cpu_mem_usage"] = True
         model = cls.HF_Model.from_pretrained(*args, **kwargs)
 
         if load_in_4bit:


### PR DESCRIPTION
## Description
Optimize transformer int4 loading memory follow up.

Further reduce memory footprint by using bitsandbytes code path inside HF transformers. 

(Totally a hacking implementation, might need to pin to a specific version of `transformers` and `bitsandbytes`)