### PR TITLE
Restrict pillow version to be compatible with torch 1.7.1

### DIFF
--- a/.github/actions/orca/orca-exampletest-ray-py37-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-exampletest-ray-py37-spark3-action/nightly-test/action.yml
@@ -9,6 +9,7 @@ runs:
         source activate py37
         export SPARK_LOCAL_HOSTNAME=localhost
         pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3[ray]
+
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==1.15.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow-gan==2.0.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow-probability==0.7.0

--- a/.github/actions/orca/orca-exampletest-ray-py37-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-exampletest-ray-py37-spark3-action/nightly-test/action.yml
@@ -9,11 +9,12 @@ runs:
         source activate py37
         export SPARK_LOCAL_HOSTNAME=localhost
         pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3[ray]
-
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==1.15.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow-gan==2.0.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow-probability==0.7.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow-datasets==3.2.0
+#       torch 1.7.1 is tensorboard summary incompatible with pillow>=10.0.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pillow<10.0.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchvision==0.8.2
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchmetrics==0.10.0

--- a/.github/actions/orca/orca-exampletest-ray-py37-spark3-action/pr-test/action.yml
+++ b/.github/actions/orca/orca-exampletest-ray-py37-spark3-action/pr-test/action.yml
@@ -22,6 +22,8 @@ runs:
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow-gan==2.0.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow-probability==0.7.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow-datasets==3.2.0
+#       torch 1.7.1 is tensorboard summary incompatible with pillow>=10.0.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pillow<10.0.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchvision==0.8.2
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchmetrics==0.10.0

--- a/.github/actions/orca/orca-exampletest-ray-py38-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-exampletest-ray-py38-spark3-action/nightly-test/action.yml
@@ -11,6 +11,8 @@ runs:
         pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3[ray]
 
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==2.9.0
+#       torch 1.7.1 is tensorboard summary incompatible with pillow>=10.0.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pillow<10.0.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchvision==0.8.2
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchmetrics==0.10.0

--- a/.github/actions/orca/orca-exampletest-ray-py38-spark3-action/pr-test/action.yml
+++ b/.github/actions/orca/orca-exampletest-ray-py38-spark3-action/pr-test/action.yml
@@ -18,6 +18,8 @@ runs:
 
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} -r python/requirements/orca/requirements_ray.txt
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==2.9.0
+#       torch 1.7.1 is tensorboard summary incompatible with pillow>=10.0.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pillow<10.0.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchvision==0.8.2
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchmetrics==0.10.0

--- a/.github/actions/orca/orca-exampletest-ray-py39-spark3-action/nightly-test/action.yml
+++ b/.github/actions/orca/orca-exampletest-ray-py39-spark3-action/nightly-test/action.yml
@@ -11,6 +11,8 @@ runs:
         pip install -i https://pypi.python.org/simple --pre --upgrade bigdl-orca-spark3[ray]
 
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} tensorflow==2.9.0
+#       torch 1.7.1 is tensorboard summary incompatible with pillow>=10.0.0
+        pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} pillow<10.0.0
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torch==1.7.1
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchvision==0.8.2
         pip install -i ${GONDOLIN_PIP_MIRROR} --trusted-host ${GONDOLIN_TRUSTED_HOST} torchmetrics==0.10.0


### PR DESCRIPTION
For the latest pillow https://pypi.org/project/Pillow/10.0.0/ 10.0.0 released on 7.1, it is not compatible with our torch version in the test. Add the restriction of pillow version.
If later we upgrade torch in our tests, we can remove the restriction.

The latest pillow version can only be installed under python>=3.8.
To make our jobs compatible, I changed python3.7 as well.

https://github.com/intel-analytics/BigDL/actions/runs/5431793007/jobs/9886734413
https://github.com/intel-analytics/BigDL/actions/runs/5431793007/jobs/9886734237
https://github.com/intel-analytics/BigDL/actions/runs/5431793007/jobs/9886734342