### PR TITLE
Pentest fix: Missing Input Validation "SSRF"

### DIFF
--- a/python/chronos/example/auto_model/autoprophet_nyc_taxi.py
+++ b/python/chronos/example/auto_model/autoprophet_nyc_taxi.py
@@ -23,26 +23,8 @@ from bigdl.chronos.autots.model.auto_prophet import AutoProphet
 from bigdl.orca.common import init_orca_context, stop_orca_context
 
 
-from urllib.parse import urlparse
-from os.path import exists
-from bigdl.dllib.utils import log4Error
-
-
-def is_local_and_existing_uri(uri):
-    parsed_uri = urlparse(uri)
-
-    log4Error.invalidInputError(not parsed_uri.scheme or parsed_uri.scheme == 'file',
-                                "Not Local File!")
-
-    log4Error.invalidInputError(not parsed_uri.netloc or parsed_uri.netloc.lower() == 'localhost',
-                                "Not Local File!")
-
-    log4Error.invalidInputError(exists(parsed_uri.path),
-                                "File Not Exist!")
-
 def get_data(args):
     dataset = args.datadir if args.datadir else args.url
-    is_local_and_existing_uri(dataset)
     df = pd.read_csv(dataset, parse_dates=[0])
     return df
 

--- a/python/chronos/example/auto_model/autoprophet_nyc_taxi.py
+++ b/python/chronos/example/auto_model/autoprophet_nyc_taxi.py
@@ -23,8 +23,26 @@ from bigdl.chronos.autots.model.auto_prophet import AutoProphet
 from bigdl.orca.common import init_orca_context, stop_orca_context
 
 
+from urllib.parse import urlparse
+from os.path import exists
+from bigdl.dllib.utils import log4Error
+
+
+def is_local_and_existing_uri(uri):
+    parsed_uri = urlparse(uri)
+
+    log4Error.invalidInputError(not parsed_uri.scheme or parsed_uri.scheme == 'file',
+                                "Not Local File!")
+
+    log4Error.invalidInputError(not parsed_uri.netloc or parsed_uri.netloc.lower() == 'localhost',
+                                "Not Local File!")
+
+    log4Error.invalidInputError(exists(parsed_uri.path),
+                                "File Not Exist!")
+
 def get_data(args):
     dataset = args.datadir if args.datadir else args.url
+    is_local_and_existing_uri(dataset)
     df = pd.read_csv(dataset, parse_dates=[0])
     return df
 

--- a/python/chronos/example/distributed/sparkdf_training_nyc_taxi.py
+++ b/python/chronos/example/distributed/sparkdf_training_nyc_taxi.py
@@ -24,7 +24,22 @@ from bigdl.chronos.forecaster import TCNForecaster
 from bigdl.chronos.metric.forecast_metrics import Evaluator
 import numpy as np
 from sklearn.preprocessing import StandardScaler
+from urllib.parse import urlparse
+from os.path import exists
+from bigdl.dllib.utils import log4Error
 
+
+def is_local_and_existing_uri(uri):
+    parsed_uri = urlparse(uri)
+
+    log4Error.invalidInputError(not parsed_uri.scheme or parsed_uri.scheme == 'file',
+                                "Not Local File!")
+
+    log4Error.invalidInputError(not parsed_uri.netloc or parsed_uri.netloc.lower() == 'localhost',
+                                "Not Local File!")
+
+    log4Error.invalidInputError(exists(parsed_uri.path),
+                                "File Not Exist!")
 
 def generate_spark_df(dataset_path):
     spark = OrcaContext.get_spark_session()
@@ -49,6 +64,7 @@ def generate_spark_df(dataset_path):
 
 
 def get_csv(args):
+    is_local_and_existing_uri(args.datadir)
     dataset_path = args.datadir
     if args.datadir is None:
         with requests.get(args.url) as r:

--- a/python/chronos/example/distributed/sparkdf_training_nyc_taxi.py
+++ b/python/chronos/example/distributed/sparkdf_training_nyc_taxi.py
@@ -64,7 +64,6 @@ def generate_spark_df(dataset_path):
 
 
 def get_csv(args):
-    is_local_and_existing_uri(args.datadir)
     dataset_path = args.datadir
     if args.datadir is None:
         with requests.get(args.url) as r:
@@ -76,6 +75,7 @@ def get_csv(args):
                 csv_writer.writerow(row)
             f.close()
             dataset_path = 'nyc_taxi.csv'
+    is_local_and_existing_uri(dataset_path)
     return dataset_path
 
 

--- a/python/friesian/example/serving/similarity_client.py
+++ b/python/friesian/example/serving/similarity_client.py
@@ -31,13 +31,13 @@ def is_local_and_existing_uri(uri):
     parsed_uri = urlparse(uri)
 
     log4Error.invalidInputError(not parsed_uri.scheme or parsed_uri.scheme == 'file',
-        "Not Local File!")
+                                "Not Local File!")
 
     log4Error.invalidInputError(not parsed_uri.netloc or parsed_uri.netloc.lower() == 'localhost',
-        "Not Local File!")
+                                "Not Local File!")
 
     log4Error.invalidInputError(exists(parsed_uri.path),
-        "File Not Exist!")
+                                "File Not Exist!")
 
 if 'http_proxy' in os.environ:
     del os.environ['http_proxy']

--- a/python/friesian/example/serving/similarity_client.py
+++ b/python/friesian/example/serving/similarity_client.py
@@ -24,20 +24,20 @@ import time
 import threading
 from urllib.parse import urlparse
 from os.path import exists
+from bigdl.dllib.utils import log4Error
+
 
 def is_local_and_existing_uri(uri):
     parsed_uri = urlparse(uri)
 
-    # Check if the scheme is empty or 'file'
-    if parsed_uri.scheme and parsed_uri.scheme != 'file':
-        raise Exception("Not Local File!")
+    log4Error.invalidInputError(not parsed_uri.scheme or parsed_uri.scheme == 'file',
+        "Not Local File!")
 
-    # Check if the network location is empty or 'localhost'
-    if parsed_uri.netloc and parsed_uri.netloc.lower() != 'localhost':
-        raise Exception("Not Local File!")
+    log4Error.invalidInputError(not parsed_uri.netloc or parsed_uri.netloc.lower() == 'localhost',
+        "Not Local File!")
 
-    if not exists(parsed_uri.path):
-        raise Exception("File Not Exist!")
+    log4Error.invalidInputError(exists(parsed_uri.path),
+        "File Not Exist!")
 
 if 'http_proxy' in os.environ:
     del os.environ['http_proxy']

--- a/python/friesian/example/serving/similarity_client.py
+++ b/python/friesian/example/serving/similarity_client.py
@@ -22,7 +22,22 @@ import pandas as pd
 import argparse
 import time
 import threading
+from urllib.parse import urlparse
+from os.path import exists
 
+def is_local_and_existing_uri(uri):
+    parsed_uri = urlparse(uri)
+
+    # Check if the scheme is empty or 'file'
+    if parsed_uri.scheme and parsed_uri.scheme != 'file':
+        raise Exception("Not Local File!")
+
+    # Check if the network location is empty or 'localhost'
+    if parsed_uri.netloc and parsed_uri.netloc.lower() != 'localhost':
+        raise Exception("Not Local File!")
+
+    if not exists(parsed_uri.path):
+        raise Exception("File Not Exist!")
 
 if 'http_proxy' in os.environ:
     del os.environ['http_proxy']
@@ -94,6 +109,7 @@ if __name__ == '__main__':
     logging.basicConfig(filename="client.log", level=logging.INFO)
     args = parser.parse_args()
 
+    is_local_and_existing_uri(args.data_dir)
     df = pd.read_parquet(args.data_dir)
     id_list = df["tweet_id"].unique()
     n_thread = 4

--- a/python/friesian/example/wnd/recsys2021/convert_train.py
+++ b/python/friesian/example/wnd/recsys2021/convert_train.py
@@ -36,6 +36,7 @@ def is_local_and_existing_uri(uri):
     log4Error.invalidInputError(exists(parsed_uri.path),
                                 "File Not Exist!")
 
+
 def _parse_args():
     parser = ArgumentParser()
 

--- a/python/friesian/example/wnd/recsys2021/convert_train.py
+++ b/python/friesian/example/wnd/recsys2021/convert_train.py
@@ -19,6 +19,22 @@ from os import listdir
 from argparse import ArgumentParser
 import pandas as pd
 
+from urllib.parse import urlparse
+from os.path import exists
+from bigdl.dllib.utils import log4Error
+
+
+def is_local_and_existing_uri(uri):
+    parsed_uri = urlparse(uri)
+
+    log4Error.invalidInputError(not parsed_uri.scheme or parsed_uri.scheme == 'file',
+                                "Not Local File!")
+
+    log4Error.invalidInputError(not parsed_uri.netloc or parsed_uri.netloc.lower() == 'localhost',
+                                "Not Local File!")
+
+    log4Error.invalidInputError(exists(parsed_uri.path),
+                                "File Not Exist!")
 
 def _parse_args():
     parser = ArgumentParser()
@@ -36,6 +52,7 @@ if __name__ == '__main__':
 
     input_files = [f for f in listdir(args.input_folder) if f.endswith(".parquet")]
     for f in input_files:
+        is_local_and_existing_uri(os.path.join(args.input_folder, f))
         df = pd.read_parquet(os.path.join(args.input_folder, f))
         df = df.rename(columns={"text_ tokens": "text_tokens"})
         # This is a typo. Other typos include enaging...

--- a/python/orca/example/automl/autoxgboost/AutoXGBoostRegressor.py
+++ b/python/orca/example/automl/autoxgboost/AutoXGBoostRegressor.py
@@ -30,13 +30,13 @@ def is_local_and_existing_uri(uri):
     parsed_uri = urlparse(uri)
 
     log4Error.invalidInputError(not parsed_uri.scheme or parsed_uri.scheme == 'file',
-        "Not Local File!")
+                                "Not Local File!")
 
     log4Error.invalidInputError(not parsed_uri.netloc or parsed_uri.netloc.lower() == 'localhost',
-        "Not Local File!")
+                                "Not Local File!")
 
     log4Error.invalidInputError(exists(parsed_uri.path),
-        "File Not Exist!")
+                                "File Not Exist!")
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(

--- a/python/orca/example/automl/autoxgboost/AutoXGBoostRegressor.py
+++ b/python/orca/example/automl/autoxgboost/AutoXGBoostRegressor.py
@@ -23,20 +23,20 @@ from bigdl.orca.automl.xgboost import AutoXGBRegressor
 from bigdl.orca.automl import hp
 from urllib.parse import urlparse
 from os.path import exists
+from bigdl.dllib.utils import log4Error
+
 
 def is_local_and_existing_uri(uri):
     parsed_uri = urlparse(uri)
 
-    # Check if the scheme is empty or 'file'
-    if parsed_uri.scheme and parsed_uri.scheme != 'file':
-        raise Exception("Not Local File!")
+    log4Error.invalidInputError(not parsed_uri.scheme or parsed_uri.scheme == 'file',
+        "Not Local File!")
 
-    # Check if the network location is empty or 'localhost'
-    if parsed_uri.netloc and parsed_uri.netloc.lower() != 'localhost':
-        raise Exception("Not Local File!")
+    log4Error.invalidInputError(not parsed_uri.netloc or parsed_uri.netloc.lower() == 'localhost',
+        "Not Local File!")
 
-    if not exists(parsed_uri.path):
-        raise Exception("File Not Exist!")
+    log4Error.invalidInputError(exists(parsed_uri.path),
+        "File Not Exist!")
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(

--- a/python/orca/example/automl/autoxgboost/AutoXGBoostRegressor.py
+++ b/python/orca/example/automl/autoxgboost/AutoXGBoostRegressor.py
@@ -21,7 +21,22 @@ from bigdl.dllib.utils.log4Error import invalidInputError
 from bigdl.orca import init_orca_context, stop_orca_context
 from bigdl.orca.automl.xgboost import AutoXGBRegressor
 from bigdl.orca.automl import hp
+from urllib.parse import urlparse
+from os.path import exists
 
+def is_local_and_existing_uri(uri):
+    parsed_uri = urlparse(uri)
+
+    # Check if the scheme is empty or 'file'
+    if parsed_uri.scheme and parsed_uri.scheme != 'file':
+        raise Exception("Not Local File!")
+
+    # Check if the network location is empty or 'localhost'
+    if parsed_uri.netloc and parsed_uri.netloc.lower() != 'localhost':
+        raise Exception("Not Local File!")
+
+    if not exists(parsed_uri.path):
+        raise Exception("File Not Exist!")
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
@@ -53,6 +68,7 @@ if __name__ == '__main__':
         init_orca_context(cluster_mode=opt.cluster_mode, cores=opt.cores, init_ray_on_spark=True)
 
     import pandas as pd
+    is_local_and_existing_uri(opt.path)
     df = pd.read_csv(opt.path, encoding='latin-1')
     df.rename(
         columns={

--- a/python/orca/example/learn/tf/image_segmentation/image_segmentation.py
+++ b/python/orca/example/learn/tf/image_segmentation/image_segmentation.py
@@ -34,6 +34,25 @@ from bigdl.orca.data import XShards
 from bigdl.orca.learn.tf.estimator import Estimator
 
 
+from urllib.parse import urlparse
+from os.path import exists
+from bigdl.dllib.utils import log4Error
+
+
+def is_local_and_existing_uri(uri):
+    parsed_uri = urlparse(uri)
+
+    log4Error.invalidInputError(not parsed_uri.scheme or parsed_uri.scheme == 'file',
+                                "Not Local File!")
+
+    log4Error.invalidInputError(not parsed_uri.netloc or parsed_uri.netloc.lower() == 'localhost',
+                                "Not Local File!")
+
+    log4Error.invalidInputError(exists(parsed_uri.path),
+                                "File Not Exist!")
+
+
+
 def load_data_from_zip(file_path, file):
     with zipfile.ZipFile(os.path.join(file_path, file), "r") as zip_ref:
         unzipped_file = zip_ref.namelist()[0]
@@ -62,6 +81,7 @@ def main(cluster_mode, max_epoch, file_path, batch_size, platform, non_interacti
     label_dir = os.path.join(file_path, "train_masks")
 
     # Here we only take the first 1000 files for simplicity
+    is_local_and_existing_uri(os.path.join(file_path, 'train_masks.csv'))
     df_train = pd.read_csv(os.path.join(file_path, 'train_masks.csv'))
     ids_train = df_train['img'].map(lambda s: s.split('.')[0])
     ids_train = ids_train[:1000]

--- a/python/orca/example/learn/tf/image_segmentation/image_segmentation.py
+++ b/python/orca/example/learn/tf/image_segmentation/image_segmentation.py
@@ -52,7 +52,6 @@ def is_local_and_existing_uri(uri):
                                 "File Not Exist!")
 
 
-
 def load_data_from_zip(file_path, file):
     with zipfile.ZipFile(os.path.join(file_path, file), "r") as zip_ref:
         unzipped_file = zip_ref.namelist()[0]

--- a/python/orca/example/tfpark/estimator/pre-made-estimator.py
+++ b/python/orca/example/tfpark/estimator/pre-made-estimator.py
@@ -43,6 +43,7 @@ def is_local_and_existing_uri(uri):
     log4Error.invalidInputError(exists(parsed_uri.path),
                                 "File Not Exist!")
 
+
 def make_input_fn(data_df, label_df, mode, batch_size=-1, batch_per_thread=-1):
     if mode == tf.estimator.ModeKeys.TRAIN:
         def input_function():

--- a/python/orca/example/tfpark/estimator/pre-made-estimator.py
+++ b/python/orca/example/tfpark/estimator/pre-made-estimator.py
@@ -26,6 +26,23 @@ from bigdl.orca.tfpark import TFDataset, TFEstimator
 from bigdl.orca.tfpark import ZooOptimizer
 
 
+from urllib.parse import urlparse
+from os.path import exists
+from bigdl.dllib.utils import log4Error
+
+
+def is_local_and_existing_uri(uri):
+    parsed_uri = urlparse(uri)
+
+    log4Error.invalidInputError(not parsed_uri.scheme or parsed_uri.scheme == 'file',
+                                "Not Local File!")
+
+    log4Error.invalidInputError(not parsed_uri.netloc or parsed_uri.netloc.lower() == 'localhost',
+                                "Not Local File!")
+
+    log4Error.invalidInputError(exists(parsed_uri.path),
+                                "File Not Exist!")
+
 def make_input_fn(data_df, label_df, mode, batch_size=-1, batch_per_thread=-1):
     if mode == tf.estimator.ModeKeys.TRAIN:
         def input_function():
@@ -51,6 +68,9 @@ if __name__ == "__main__":
     parser = OptionParser()
     parser.add_option("--data_dir", dest="data_dir")
     (options, args) = parser.parse_args(sys.argv)
+
+    is_local_and_existing_uri(os.path.join(options.data_dir, 'train.csv'))
+    is_local_and_existing_uri(os.path.join(options.data_dir, 'eval.csv'))
 
     dftrain = pd.read_csv(os.path.join(options.data_dir, 'train.csv'))
     dfeval = pd.read_csv(os.path.join(options.data_dir, 'eval.csv'))

--- a/python/ppml/example/benchmark/fgboost_benchmark/README.md
+++ b/python/ppml/example/benchmark/fgboost_benchmark/README.md
@@ -53,8 +53,8 @@ java -cp $PPML_JAR com.intel.analytics.bigdl.ppml.fl.example.benchmark.FGBoostRe
     --dataSize 10 --numRound 5
     
 # python cmd
-python python/ppml/example/benchmark/fgboost_benchmark/fgboost_dummy_data_benchmark.py 
-    --train_path scala/ppml/demo/data/house-prices-train-preprocessed.csv
-    --test_path scala/ppml/demo/data/house-prices-test-preprocessed.csv
+python python/ppml/example/benchmark/fgboost_benchmark/fgboost_real_data_benchmark.py \
+    --train_path scala/ppml/demo/data/house-prices-train-preprocessed.csv \
+    --test_path scala/ppml/demo/data/house-prices-test-preprocessed.csv \
     --data_size 10 --num_round 5
 ```

--- a/python/ppml/example/benchmark/fgboost_benchmark/fgboost_dummy_data_benchmark.py
+++ b/python/ppml/example/benchmark/fgboost_benchmark/fgboost_dummy_data_benchmark.py
@@ -48,7 +48,7 @@ if __name__ == '__main__':
     y = np.random.rand(args.data_size)
 
 
-    init_fl_context()
+    init_fl_context(1)
     fgboost_regression = FGBoostRegression(max_depth=3)
     ts = time.time()
     if args.has_label:

--- a/python/ppml/example/benchmark/fgboost_benchmark/fgboost_real_data_benchmark.py
+++ b/python/ppml/example/benchmark/fgboost_benchmark/fgboost_real_data_benchmark.py
@@ -23,20 +23,19 @@ from bigdl.ppml.fl.data_utils import *
 from bigdl.ppml.fl.algorithms.fgboost_regression import FGBoostRegression
 from urllib.parse import urlparse
 from os.path import exists
+from bigdl.dllib.utils import log4Error
 
 def is_local_and_existing_uri(uri):
     parsed_uri = urlparse(uri)
 
-    # Check if the scheme is empty or 'file'
-    if parsed_uri.scheme and parsed_uri.scheme != 'file':
-        raise Exception("Not Local File!")
+    log4Error.invalidInputError(not parsed_uri.scheme or parsed_uri.scheme == 'file',
+        "Not Local File!")
 
-    # Check if the network location is empty or 'localhost'
-    if parsed_uri.netloc and parsed_uri.netloc.lower() != 'localhost':
-        raise Exception("Not Local File!")
+    log4Error.invalidInputError(not parsed_uri.netloc or parsed_uri.netloc.lower() == 'localhost',
+        "Not Local File!")
 
-    if not exists(parsed_uri.path):
-        raise Exception("File Not Exist!")
+    log4Error.invalidInputError(exists(parsed_uri.path),
+        "File Not Exist!")
 
 
 if __name__ == '__main__':

--- a/python/ppml/example/benchmark/fgboost_benchmark/fgboost_real_data_benchmark.py
+++ b/python/ppml/example/benchmark/fgboost_benchmark/fgboost_real_data_benchmark.py
@@ -21,7 +21,22 @@ import time
 from bigdl.ppml.fl import *
 from bigdl.ppml.fl.data_utils import *
 from bigdl.ppml.fl.algorithms.fgboost_regression import FGBoostRegression
+from urllib.parse import urlparse
+from os.path import exists
 
+def is_local_and_existing_uri(uri):
+    parsed_uri = urlparse(uri)
+
+    # Check if the scheme is empty or 'file'
+    if parsed_uri.scheme and parsed_uri.scheme != 'file':
+        raise Exception("Not Local File!")
+
+    # Check if the network location is empty or 'localhost'
+    if parsed_uri.netloc and parsed_uri.netloc.lower() != 'localhost':
+        raise Exception("Not Local File!")
+
+    if not exists(parsed_uri.path):
+        raise Exception("File Not Exist!")
 
 
 if __name__ == '__main__':
@@ -45,6 +60,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     init_fl_context()
+    is_local_and_existing_uri(args.train_path)
     df_train = pd.read_csv(args.train_path)
     fgboost_regression = FGBoostRegression()
     
@@ -65,6 +81,7 @@ if __name__ == '__main__':
                            y_stacked.reshape(-1, y_stacked.shape[-1]),
                            num_round=args.num_round)
     
+    is_local_and_existing_uri(args.test_path)
     df_test = pd.read_csv(args.test_path)
     result = fgboost_regression.predict(df_test, feature_columns=df_x.columns)
     

--- a/python/ppml/example/benchmark/fgboost_benchmark/fgboost_real_data_benchmark.py
+++ b/python/ppml/example/benchmark/fgboost_benchmark/fgboost_real_data_benchmark.py
@@ -25,17 +25,18 @@ from urllib.parse import urlparse
 from os.path import exists
 from bigdl.dllib.utils import log4Error
 
+
 def is_local_and_existing_uri(uri):
     parsed_uri = urlparse(uri)
 
     log4Error.invalidInputError(not parsed_uri.scheme or parsed_uri.scheme == 'file',
-        "Not Local File!")
+                                "Not Local File!")
 
     log4Error.invalidInputError(not parsed_uri.netloc or parsed_uri.netloc.lower() == 'localhost',
-        "Not Local File!")
+                                "Not Local File!")
 
     log4Error.invalidInputError(exists(parsed_uri.path),
-        "File Not Exist!")
+                                "File Not Exist!")
 
 
 if __name__ == '__main__':

--- a/python/ppml/example/benchmark/fgboost_benchmark/fgboost_real_data_benchmark.py
+++ b/python/ppml/example/benchmark/fgboost_benchmark/fgboost_real_data_benchmark.py
@@ -59,7 +59,7 @@ if __name__ == '__main__':
                         help='The boosting rounds.')
     args = parser.parse_args()
 
-    init_fl_context()
+    init_fl_context(1)
     is_local_and_existing_uri(args.train_path)
     df_train = pd.read_csv(args.train_path)
     fgboost_regression = FGBoostRegression()

--- a/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/http/FrontEndApp.scala
+++ b/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/http/FrontEndApp.scala
@@ -82,16 +82,16 @@ object FrontEndApp extends Supportive with EncryptSupportive {
                  modelMetaDataList:
                  - !<ClusterServingMetaData>
                     modelName: "1"
-                    modelVersion:"1.0"
+                    modelVersion: "1.0"
                     redisHost: "localhost"
                     redisPort: "6381"
                     redisInputQueue: "serving_stream2"
                     redisOutputQueue: "cluster-serving_serving_stream2:"
-                 - !<InflerenceModelMetaData>
+                 - !<InferenceModelMetaData>
                     modelName: "1"
-                    modelVersion:"1.0"
-                    modelPath:"/"
-                    modelType:"OpenVINO"
+                    modelVersion: "1.0"
+                    modelPath: "/"
+                    modelType: "OpenVINO"
                     features:
                       - "a"
                       - "b"

--- a/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/http/FrontEndApp.scala
+++ b/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/http/FrontEndApp.scala
@@ -47,11 +47,14 @@ object FrontEndApp extends Supportive with EncryptSupportive {
   implicit val executionContext = system.dispatcher
   implicit val timeout: Timeout = Timeout(100, TimeUnit.SECONDS)
 
-  def isLocalURI(path: String): Boolean = {
+  def isLocalURI(path: String): Unit = {
     val uri = new URI(path)
     val scheme = uri.getScheme
-    if (scheme != null && !scheme.equalsIgnoreCase("file"))
+    if (scheme != null && !scheme.equalsIgnoreCase("file")) {
       logger.error(s"$path isn't a local file")
+    } else {
+      logger.info(s"$path is a local file")
+    }
   }
 
   def main(args: Array[String]): Unit = {

--- a/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/http/Frontend2.scala
+++ b/scala/serving/src/main/scala/com/intel/analytics/bigdl/serving/http/Frontend2.scala
@@ -52,11 +52,14 @@ object Frontend2 extends Supportive with EncryptSupportive {
   implicit val executionContext = system.dispatcher
   implicit val timeout: Timeout = Timeout(100, TimeUnit.SECONDS)
 
-  def isLocalURI(path: String): Boolean = {
+  def isLocalURI(path: String): Unit = {
     val uri = new URI(path)
     val scheme = uri.getScheme
-    if (scheme != null && !scheme.equalsIgnoreCase("file"))
+    if (scheme != null && !scheme.equalsIgnoreCase("file")) {
       logger.error(s"$path isn't a local file")
+    } else {
+      logger.info(s"$path is a local file")
+    }
   }
 
   def main(args: Array[String]): Unit = {


### PR DESCRIPTION
### 1. Why the change?

fix Missing Input Validation "SSRF"

- [x] \BigDL-main\python\ppml\example\benchmark\fgboost_benchmark\fgboost_real_data_benchmark.py:48
- [x] \BigDL-main\python\orca\example\automl\autoxgboost\AutoXGBoostRegressor.py:55
- [x] \BigDL-main\python\ppml\example\benchmark\fgboost_benchmark\fgboost_real_data_benchmark.py:68
- [x] \BigDL-main\python\orca\example\automl\autoxgboost\AutoXGBoostRegressor.py:80
- [x] \BigDL-main\python\friesian\example\serving\similarity_client.py:97
- [x] \BigDL-main\python\chronos\example\distributed\sparkdf_training_nyc_taxi.py:49
- [x] \BigDL-main\python\orca\example\learn\tf\image_segmentation\image_segmentation.py:65
- [x] \BigDL-main\python\friesian\example\wnd\train\convert_train.py\convert_train.py:39
- [x] \BigDL-main\python\orca\example\tfpark\estimator\pre-made-estimator.py:55
- [x] \BigDL-main\python\orca\example\tfpark\estimator\pre-made-estimator.py:56
- [x] \BigDL-main\python\chronos\example\auto_model\autoprophet_nyc_taxi.py:28 **(the dataset may come from url so this can't be fixed)**
- [x] \BigDL-main\scala\serving\src\main\scala\com\intel\analytics\bigdl\serving\http\Frontend2.scala:54
- [x] \BigDL-main\scala\serving\src\main\scala\com\intel\analytics\bigdl\serving\http\FrontEndApp.scala:49


### 2. User API changes

none

### 3. Summary of the change 

fix Missing Input Validation "SSRF"

### 4. How to test?

The repair logic of the python code is the same, adding functions for additional verification. It does not affect the original code logic, so choose an example for verification:
- [x] Verification on fgboost

Scala TEST:
- [x] --servableManagerConfPath