### PR TITLE
LLM: fix `n_batch` in bloom pybinding

### DIFF
--- a/python/llm/src/bigdl/llm/ggml/model/bloom/bloom.py
+++ b/python/llm/src/bigdl/llm/ggml/model/bloom/bloom.py
@@ -359,7 +359,7 @@ class Bloom(GenerationMixin):
                           input_ids=input_ids,
                           seed=self.seed,
                           n_threads=self.n_threads,
-                          n_batch=len(input_ids))
+                          n_batch=self.n_batch)
 
     def _generate(
         self,
@@ -426,4 +426,4 @@ class Bloom(GenerationMixin):
                            input_ids=input_ids,
                            seed=self.seed,
                            n_threads=self.n_threads,
-                           n_batch=len(input_ids))
+                           n_batch=self.n_batch)


### PR DESCRIPTION
## Description

Fix `n_batch` in bloom pybinding to better manage memory usage

### 2. User API changes

None

### 4. How to test?
- [ ] Unit test
