### PR TITLE
LLM: fix `n_batch` in starcoder pybinding

### DIFF
--- a/python/llm/src/bigdl/llm/ggml/model/starcoder/starcoder.py
+++ b/python/llm/src/bigdl/llm/ggml/model/starcoder/starcoder.py
@@ -363,7 +363,7 @@ class Starcoder(GenerationMixin):
                               input_ids=input_ids,
                               seed=self.seed,
                               n_threads=self.n_threads,
-                              n_batch=len(input_ids))
+                              n_batch=self.n_batch)
 
     def _generate(
         self,
@@ -432,4 +432,4 @@ class Starcoder(GenerationMixin):
                                input_ids=input_ids,
                                seed=self.seed,
                                n_threads=self.n_threads,
-                               n_batch=len(input_ids))
+                               n_batch=self.n_batch)


### PR DESCRIPTION
## Description

Similarly to bloom pybinding, fix `n_batch` to better manage memory usage

### 2. User API changes

None

### 4. How to test?
- [ ] Unit test
