### PR TITLE
LLM: transformer int4 save and load

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/__init__.py
+++ b/python/llm/src/bigdl/llm/transformers/__init__.py
@@ -15,5 +15,5 @@
 #
 
 from .convert import ggml_convert_int4
-from .model import AutoModelForCausalLM, AutoModel
+from .model import AutoModelForCausalLM, AutoModel, AutoModelForSeq2SeqLM
 from .modelling_bigdl import BigdlForCausalLM

--- a/python/llm/src/bigdl/llm/transformers/__init__.py
+++ b/python/llm/src/bigdl/llm/transformers/__init__.py
@@ -15,5 +15,5 @@
 #
 
 from .convert import ggml_convert_int4
-from .model import AutoModelForCausalLM, AutoModel, AutoModelForSeq2SeqLM
+from .model import AutoModelForCausalLM, AutoModel
 from .modelling_bigdl import BigdlForCausalLM

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -41,7 +41,8 @@ from bigdl.llm.transformers.linear_int4 import LinearInt4, ParamsInt4
 import warnings
 
 
-def _replace_with_int4_linear(model, modules_to_not_convert=None, current_key_name=None, convert_shape_only=False):
+def _replace_with_int4_linear(model, modules_to_not_convert=None,
+                              current_key_name=None, convert_shape_only=False):
     has_been_replaced = False
     for name, module in model.named_children():
         if current_key_name is None:
@@ -59,11 +60,12 @@ def _replace_with_int4_linear(model, modules_to_not_convert=None, current_key_na
                     )
 
                     # Copy the weights
-                    new_linear._parameters['weight'] = ParamsInt4(data=module.weight.data,
-                                                                  requires_grad=False,
-                                                                  quantized=False,
-                                                                  convert_shape_only=convert_shape_only,
-                                                                  _shape=None).to("cpu")
+                    paramsint4 = ParamsInt4(data=module.weight.data,
+                                            requires_grad=False,
+                                            quantized=False,
+                                            convert_shape_only=convert_shape_only,
+                                            _shape=None).to("cpu")
+                    new_linear._parameters['weight'] = paramsint4
                     if module.bias is not None:
                         new_linear._parameters['bias'] = nn.Parameter(module.bias.data).to("cpu")
 

--- a/python/llm/src/bigdl/llm/transformers/linear_int4.py
+++ b/python/llm/src/bigdl/llm/transformers/linear_int4.py
@@ -60,7 +60,6 @@ scale_size_in_bytes = 4
 block_size_in_bytes = QK // 2 + scale_size_in_bytes
 
 
-
 def ggml_convert_int4(tensor: torch.Tensor, convert_shape_only=False):
 
     invalidInputError(tensor.dtype == torch.float,
@@ -86,7 +85,8 @@ def ggml_convert_int4(tensor: torch.Tensor, convert_shape_only=False):
 
 
 class ParamsInt4(torch.nn.Parameter):
-    def __new__(cls, data=None, requires_grad=True, old_data=None, quantized=False, _shape=None, convert_shape_only=False):
+    def __new__(cls, data=None, requires_grad=True, old_data=None,
+                quantized=False, _shape=None, convert_shape_only=False):
         if data is None:
             data = torch.empty(0)
 

--- a/python/llm/src/bigdl/llm/transformers/linear_int4.py
+++ b/python/llm/src/bigdl/llm/transformers/linear_int4.py
@@ -60,7 +60,8 @@ scale_size_in_bytes = 4
 block_size_in_bytes = QK // 2 + scale_size_in_bytes
 
 
-def ggml_convert_int4(tensor: torch.Tensor):
+
+def ggml_convert_int4(tensor: torch.Tensor, convert_shape_only=False):
 
     invalidInputError(tensor.dtype == torch.float,
                       "Input tensor must be float32")
@@ -79,12 +80,13 @@ def ggml_convert_int4(tensor: torch.Tensor):
 
     hist = (ctypes.c_int64 * 16)()
 
-    ggml.ggml_quantize_q4_0(src, dst, n, k, hist)
+    if not convert_shape_only:
+        ggml.ggml_quantize_q4_0(src, dst, n, k, hist)
     return dst_tensor
 
 
 class ParamsInt4(torch.nn.Parameter):
-    def __new__(cls, data=None, requires_grad=True, old_data=None, quantized=False, _shape=None):
+    def __new__(cls, data=None, requires_grad=True, old_data=None, quantized=False, _shape=None, convert_shape_only=False):
         if data is None:
             data = torch.empty(0)
 
@@ -92,13 +94,14 @@ class ParamsInt4(torch.nn.Parameter):
         self.data = data
         self.quantized = quantized
         self._shape = _shape
+        self.convert_shape_only = convert_shape_only
         return self
 
     def quantize(self, device):
         if not self.quantized:
             w = self.data.contiguous().float()
             # self.old_data = self.data
-            w_4bit = ggml_convert_int4(w)
+            w_4bit = ggml_convert_int4(w, convert_shape_only=self.convert_shape_only)
             self.data = w_4bit
             self.quantized = True
             self._shape = w.shape

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -16,6 +16,7 @@
 
 import transformers
 import torch
+from .utils import extract_local_archive_file, load_state_dict, load
 
 
 class _BaseAutoModelClass:
@@ -29,12 +30,36 @@ class _BaseAutoModelClass:
         load_in_4bit = kwargs.pop("load_in_4bit", False)
         if load_in_4bit:
             kwargs["low_cpu_mem_usage"] = True
-        model = cls.HF_Model.from_pretrained(*args, **kwargs)
 
-        if load_in_4bit:
+        save_convert_pretrained = kwargs.pop("save_convert_pretrained", None)
+        load_convert_pretrained = kwargs.pop("load_convert_pretrained", False)
+        subfolder = kwargs.get("subfolder", "")
+        variant = kwargs.get("variant", None)
+        pretrained_model_name_or_path = kwargs.get("pretrained_model_name_or_path", None) \
+                                        if len(args) == 0 else args[0]
+
+        model = None
+        if load_convert_pretrained:
+            kwargs["ignore_mismatched_sizes"] = True    
+        model = cls.HF_Model.from_pretrained(*args, **kwargs)
+        if load_convert_pretrained:
+            from .convert import ggml_convert_int4
+            model = ggml_convert_int4(model, convert_shape_only=True)
+            archive_file = extract_local_archive_file(pretrained_model_name_or_path, subfolder, variant)
+            state_dict = load_state_dict(archive_file)
+            load(model, state_dict)
+            del state_dict
+        elif load_in_4bit:
             from .convert import ggml_convert_int4
             model = model.to("cpu")
             model = ggml_convert_int4(model)
+            if save_convert_pretrained:
+                print("save_convert_pretrained:", save_convert_pretrained)
+                model.save_pretrained(save_convert_pretrained)
+                config = model.config
+                config.quantized = True
+                config.save_pretrained(save_convert_pretrained)
+
         return model
 
 

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -45,8 +45,8 @@ class _BaseAutoModelClass:
         # Read load_convert_pretrained from config.json
         config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
 
-        ggml_linear_int4_converted = config_dict.pop("ggml_linear_int4_converted", False)
-        if ggml_linear_int4_converted:
+        bigdl_linear_int4_converted = config_dict.pop("bigdl_linear_int4_converted", False)
+        if bigdl_linear_int4_converted:
             # Avoid KeyError
             kwargs["ignore_mismatched_sizes"] = True
 
@@ -55,7 +55,7 @@ class _BaseAutoModelClass:
         # Note that the ggml_matmul_src1_x_src0_t operation cannot currently
         # be recorded in AutoConfig,
         # and this operation is not included in the core Hugging Face infrastructure.
-        if ggml_linear_int4_converted:
+        if bigdl_linear_int4_converted:
             from .convert import ggml_convert_int4
             # We forcefully modify the model's definition
             # and the tensor shape of int4 weights without quantization.
@@ -71,7 +71,7 @@ class _BaseAutoModelClass:
             from .convert import ggml_convert_int4
             model = model.to("cpu")
             model = ggml_convert_int4(model)
-            model.config.update({"ggml_linear_int4_converted": True,
+            model.config.update({"bigdl_linear_int4_converted": True,
                                  "quantized": True})
 
         return model

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -42,11 +42,11 @@ class _BaseAutoModelClass:
         # we can convert the model to quantized later.
         model = None
 
-        # Read load_convert_pretrained from config.json
+        # Read bigdl_transformers_int4 from config.json
         config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
 
-        bigdl_linear_int4_converted = config_dict.pop("bigdl_linear_int4_converted", False)
-        if bigdl_linear_int4_converted:
+        bigdl_transformers_int4 = config_dict.pop("bigdl_transformers_int4", False)
+        if bigdl_transformers_int4:
             # Avoid KeyError
             kwargs["ignore_mismatched_sizes"] = True
 
@@ -55,7 +55,7 @@ class _BaseAutoModelClass:
         # Note that the ggml_matmul_src1_x_src0_t operation cannot currently
         # be recorded in AutoConfig,
         # and this operation is not included in the core Hugging Face infrastructure.
-        if bigdl_linear_int4_converted:
+        if bigdl_transformers_int4:
             from .convert import ggml_convert_int4
             # We forcefully modify the model's definition
             # and the tensor shape of int4 weights without quantization.
@@ -71,8 +71,7 @@ class _BaseAutoModelClass:
             from .convert import ggml_convert_int4
             model = model.to("cpu")
             model = ggml_convert_int4(model)
-            model.config.update({"bigdl_linear_int4_converted": True,
-                                 "quantized": True})
+            model.config.update({"bigdl_transformers_int4": True})
 
         return model
 

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -16,7 +16,6 @@
 
 import transformers
 from transformers.configuration_utils import PretrainedConfig
-import json
 from .utils import extract_local_archive_file, load_state_dict, load
 
 
@@ -51,6 +50,9 @@ class _BaseAutoModelClass:
             kwargs["ignore_mismatched_sizes"] = True
 
         model = cls.HF_Model.from_pretrained(*args, **kwargs)
+        print("Note: If there are warnings about mismatched during the loading process, "
+              "please ignore them as it is part of the normal flow. "
+              "The model will be reconverted to the format of BigDL after loading.")
 
         # Note that the ggml_matmul_src1_x_src0_t operation cannot currently
         # be recorded in AutoConfig,

--- a/python/llm/src/bigdl/llm/transformers/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/utils.py
@@ -1,0 +1,89 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Some parts of this file is adapted from
+# https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py
+# which is licensed under the MIT license:
+#
+# MIT License
+#
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+import os
+from transformers.modeling_utils import _add_variant
+from typing import Union
+import torch
+from torch import nn
+
+
+WEIGHTS_NAME = "pytorch_model.bin"
+
+def extract_local_archive_file(pretrained_model_name_or_path, subfolder, variant):
+    pretrained_model_name_or_path = str(pretrained_model_name_or_path)
+    print(os.path.join(pretrained_model_name_or_path, subfolder, _add_variant(WEIGHTS_NAME, variant)))
+    if os.path.isfile(
+        os.path.join(pretrained_model_name_or_path, subfolder, _add_variant(WEIGHTS_NAME, variant))
+    ):
+        # Load from a PyTorch checkpoint
+        archive_file = os.path.join(
+            pretrained_model_name_or_path, subfolder, _add_variant(WEIGHTS_NAME, variant)
+        )
+        return archive_file
+    else:
+        raise EnvironmentError(
+            f"Error no file named {_add_variant(WEIGHTS_NAME, variant)}"
+            " found in directory"
+            f" {pretrained_model_name_or_path}."
+        )
+
+def load_state_dict(checkpoint_file: Union[str, os.PathLike]):
+    try:
+        return torch.load(checkpoint_file, map_location="cpu")
+    except Exception as e:
+        raise OSError(
+            f"Unable to load weights from pytorch checkpoint file for '{checkpoint_file}' "
+            f"at '{checkpoint_file}'. "
+        )
+
+# PyTorch's `_load_from_state_dict` does not copy parameters in a module's descendants
+# so we need to apply the function recursively.
+def load(module: nn.Module, state_dict, prefix=""):
+    args = (state_dict, prefix, {}, True, [], [], [])
+    # Parameters of module and children will start with prefix. We can exit early if there are none in this
+    # state_dict
+    if len([key for key in state_dict if key.startswith(prefix)]) > 0:
+            module._load_from_state_dict(*args)
+
+    for name, child in module._modules.items():
+        if child is not None:
+            load(child, state_dict, prefix + name + ".")

--- a/python/llm/test/convert/test_convert_model.py
+++ b/python/llm/test/convert/test_convert_model.py
@@ -17,9 +17,11 @@
 
 import pytest
 import os
+import tempfile
 from unittest import TestCase
 
 from bigdl.llm import llm_convert
+from bigdl.llm.transformers import AutoModelForCausalLM
 
 
 llama_model_path = os.environ.get('LLAMA_ORIGIN_PATH')
@@ -61,6 +63,14 @@ class TestConvertModel(TestCase):
                                            model_format="pth",
                                            outtype='int4')
         assert os.path.isfile(converted_model_path)
+
+    def test_transformer_convert_llama(self):
+        model = AutoModelForCausalLM.from_pretrained(llama_model_path,
+                                                     load_in_4bit=True)
+        tempdir = tempfile.mkdtemp(dir=output_dir)
+        model.save_pretrained(tempdir)
+        model = AutoModelForCausalLM.from_pretrained(tempdir)
+        assert model is not None
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Description

In this PR, we added support to save the results of the GGML int4 format conversion within the transformer API, which eliminates the need for redundant conversions in subsequent calls. However, please note that the **`ggml_matmul_src1_x_src0_t`** operation cannot currently be recorded in **`AutoConfig`**, and this operation is not included in the core Hugging Face infrastructure. Therefore, when using **`model.save_pretrained`**, it can only save the original PyTorch implementation of the model and cannot fully restore the converted model.

For loading the saved converted model, we forcefully modify the model's definition and the tensor shape of int4 weights without quantization, so that we can load the quantized model at last.


```python
from transformers import AutoTokenizer
from bigdl.llm.transformers import AutoModelForSeq2SeqLM

model_name="/root/changmin/bart-base"
# model_name="/root/changmin/BigDL/bart"
save_dir = "./bart"
tokenizer = AutoTokenizer.from_pretrained(model_name)
# Convert and save
model = AutoModelForSeq2SeqLM.from_pretrained(model_name, load_in_4bit=True)
model.save_pretrained(save_dir)
# Load back
model = AutoModelForSeq2SeqLM.from_pretrained(save_dir)

inputs = tokenizer("BART model pre-trained on English language. It was introduced in the paper BART: Denoising Sequence-to-Sequence Pre-training for Natural Language Generation, Translation, and Comprehension by Lewis et al. and first released in this repository.", return_tensors="pt")
outputs = model.generate(**inputs)

summary = tokenizer.batch_decode(outputs,
                                 skip_special_tokens=True,
                                 spaces_between_special_tokens=False,)

print("Abstract: ", summary)
# Abstract: ['BART model pre-trained on English language. It was introduced in the paper BART']

```

ggml int4 model will be marked as ggml_linear_int4_converted=True in config.json:
<img width="228" alt="image" src="https://github.com/intel-analytics/BigDL/assets/26900100/9e458b5f-54bf-4e72-af5f-1ba0e9197204">
