### PR TITLE
Nano: fix failed ipex quantized bert

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_api.py
@@ -47,7 +47,7 @@ def ipex_optimize(model: Any, optimizers: Any = None, dtype: Any = None,
 def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
                         use_jit=False, channels_last=None, thread_num=None,
                         inplace=False, jit_strict=True, jit_method=None,
-                        weights_prepack=None, enable_onednn=True,
+                        weights_prepack=None, enable_onednn=False,
                         example_kwarg_inputs=None):
     '''
     :param model: the model(nn.module) to be transform.
@@ -67,7 +67,7 @@ def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
            ``use_ipex=True``, otherwise will be ignored.
     :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph
            API, which provides a flexible API for aggressive fusion. Default to
-           ``True``, only valid when use_jit is ``True``, otherwise will be ignored.
+           ``False``, only valid when use_jit is ``True``, otherwise will be ignored.
     :param example_kwarg_inputs: keyword arguments of example inputs that will be passed
            to ``torch.jit.trace``. Default to None. Either this argument or input_sample
            should be specified when use_jit is ``True`` and torch > 2.0,
@@ -85,7 +85,7 @@ def PytorchIPEXJITModel(model, input_sample=None, use_ipex=False,
 def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
                             use_jit=False, channels_last=None, thread_num=None,
                             inplace=False, jit_strict=True, jit_method=None,
-                            weights_prepack=None, enable_onednn=True,
+                            weights_prepack=None, enable_onednn=False,
                             example_kwarg_inputs=None):
     '''
     :param model: the model(nn.module) to be transform.
@@ -105,7 +105,7 @@ def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
            ``use_ipex=True``, otherwise will be ignored.
     :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph
            API, which provides a flexible API for aggressive fusion. Default to
-           ``True``, only valid when use_jit is ``True``, otherwise will be ignored.
+           ``False``, only valid when use_jit is ``True``, otherwise will be ignored.
     :param example_kwarg_inputs: keyword arguments of example inputs that will be passed
            to ``torch.jit.trace``. Default to None. Either this argument or input_sample
            should be specified when use_jit is ``True`` and torch > 2.0,
@@ -123,7 +123,8 @@ def PytorchIPEXJITBF16Model(model, input_sample=None, use_ipex=False,
 def PytorchIPEXQuantizationModel(model, calib_data, q_config=None,
                                  input_sample=None, channels_last=None,
                                  thread_num=None, inplace=False,
-                                 jit_strict=True, example_kwarg_inputs=None):
+                                 jit_strict=True, example_kwarg_inputs=None,
+                                 enable_onednn=False):
     '''
     :param model: the model(nn.module) to be transform.
     :param calib_data: calibration data is required for static quantization.
@@ -140,13 +141,17 @@ def PytorchIPEXQuantizationModel(model, calib_data, q_config=None,
            to ``torch.jit.trace``. Default to None. Either this argument or input_sample
            should be specified when use_jit is ``True`` and torch > 2.0,
            otherwise will be ignored.
+    :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph
+           API, which provides a flexible API for aggressive fusion. Default to
+           ``False``.
     '''
     from .ipex_quantization_model import PytorchIPEXQuantizationModel
     return PytorchIPEXQuantizationModel(model, calib_data, q_config=q_config,
                                         input_sample=input_sample, channels_last=channels_last,
                                         thread_num=thread_num, inplace=inplace,
                                         jit_strict=jit_strict,
-                                        example_kwarg_inputs=example_kwarg_inputs)
+                                        example_kwarg_inputs=example_kwarg_inputs,
+                                        enable_onednn=enable_onednn)
 
 
 def PytorchIPEXPUModel(model, thread_num=None, precision="fp32", use_ipex=False):

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -231,7 +231,7 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
                                    jit_strict=status.get('jit_strict', True),
                                    jit_method=status.get('jit_method', None),
                                    weights_prepack=status.get('weights_prepack', None),
-                                   enable_onednn=status.get('enable_onednn', True),
+                                   enable_onednn=status.get('enable_onednn', False),
                                    compression=status.get('compression', "fp32"),)
 
     def _save_model(self, path, compression="fp32"):

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_quantization_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_quantization_model.py
@@ -113,8 +113,6 @@ class PytorchIPEXQuantizationModel(AcceleratedLightningModule):
 
         # convert to static quantized model
         self.model = convert(self.model)
-        # todo: fix in optimize
-        jit_strict=False
         with torch.no_grad():
             self.model = jit_convert(self.model, input_sample,
                                      jit_method='trace',
@@ -135,7 +133,6 @@ class PytorchIPEXQuantizationModel(AcceleratedLightningModule):
     def forward_step(self, *inputs):
         if self.channels_last is True:
             inputs = tuple(map(lambda x: x.to(memory_format=torch.channels_last), inputs))
-        print(*inputs)
         return self.model(*inputs)
 
     def on_forward_end(self, outputs):

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_quantization_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_quantization_model.py
@@ -113,6 +113,8 @@ class PytorchIPEXQuantizationModel(AcceleratedLightningModule):
 
         # convert to static quantized model
         self.model = convert(self.model)
+        # todo: fix in optimize
+        jit_strict=False
         with torch.no_grad():
             self.model = jit_convert(self.model, input_sample,
                                      jit_method='trace',
@@ -133,6 +135,7 @@ class PytorchIPEXQuantizationModel(AcceleratedLightningModule):
     def forward_step(self, *inputs):
         if self.channels_last is True:
             inputs = tuple(map(lambda x: x.to(memory_format=torch.channels_last), inputs))
+        print(*inputs)
         return self.model(*inputs)
 
     def on_forward_end(self, outputs):

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_quantization_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_quantization_model.py
@@ -29,7 +29,7 @@ class PytorchIPEXQuantizationModel(AcceleratedLightningModule):
     def __init__(self, model: torch.nn.Module, calib_data, q_config=None,
                  input_sample=None, channels_last=None, thread_num=None,
                  from_load=False, inplace=False, jit_strict=True,
-                 example_kwarg_inputs=None):
+                 example_kwarg_inputs=None, enable_onednn=False):
         """
         This is the accelerated model for pytorch and ipex/jit.
         All the external API is based on InferenceOptimizer, so what we have here is
@@ -59,6 +59,11 @@ class PytorchIPEXQuantizationModel(AcceleratedLightningModule):
                be passed to ``torch.jit.trace``. Default to ``None``. Either this
                argument or ``input_sample`` should be specified when ``use_jit`` is
                ``True`` and torch > 2.0, otherwise will be ignored.
+        :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN
+               Graph API, which provides a flexible API for aggressive fusion. Default to
+               ``False``. For more details, please refer https://github.com/
+               pytorch/pytorch/tree/master/torch/csrc/jit/codegen/
+               onednn#pytorch---onednn-graph-api-bridge.
         """
         super().__init__(model)
         if from_load:
@@ -66,7 +71,8 @@ class PytorchIPEXQuantizationModel(AcceleratedLightningModule):
             self.jit_strict = jit_strict
             self._nano_context_manager = generate_context_manager(accelerator="jit",
                                                                   precision="int8",
-                                                                  thread_num=thread_num)
+                                                                  thread_num=thread_num,
+                                                                  enable_onednn=enable_onednn)
             return
         self.channels_last = channels_last
         self.original_state_dict = model.state_dict()
@@ -76,7 +82,8 @@ class PytorchIPEXQuantizationModel(AcceleratedLightningModule):
             self.model = self.model.to(memory_format=torch.channels_last)
         self._nano_context_manager = generate_context_manager(accelerator="jit",
                                                               precision="int8",
-                                                              thread_num=thread_num)
+                                                              thread_num=thread_num,
+                                                              enable_onednn=enable_onednn)
         self.thread_num = thread_num
         if q_config is None:
             # default qconfig
@@ -144,7 +151,8 @@ class PytorchIPEXQuantizationModel(AcceleratedLightningModule):
         status.update({"channels_last": self.channels_last,
                        "checkpoint": "ckpt.pth",
                        "thread_num": self.thread_num,
-                       "jit_strict": self.jit_strict})
+                       "jit_strict": self.jit_strict,
+                       "enable_onednn": self.enable_onednn})
         return status
 
     @staticmethod
@@ -164,7 +172,8 @@ class PytorchIPEXQuantizationModel(AcceleratedLightningModule):
                                             from_load=from_load,
                                             thread_num=thread_num,
                                             inplace=inplace,
-                                            jit_strict=status["jit_strict"])
+                                            jit_strict=status["jit_strict"],
+                                            enable_onednn=status.get('enable_onednn', False))
 
     def _save_model(self, path, compression="fp32"):
         self.model.save(path / "ckpt.pth")

--- a/python/nano/src/bigdl/nano/pytorch/context_manager.py
+++ b/python/nano/src/bigdl/nano/pytorch/context_manager.py
@@ -25,7 +25,7 @@ class BaseContextManager(object):
 
     This context manager is used for providing no_grad context only.
     """
-    def __init__(self, thread_num=None, accelerator=None, enable_onednn=True):
+    def __init__(self, thread_num=None, accelerator=None, enable_onednn=False):
         self.infer_mode_string = "inference_mode"
         self.infer_mode = torch.inference_mode(mode=True)
         self.thread_num = thread_num
@@ -70,7 +70,7 @@ class AutocastContextManager(BaseContextManager):
     This context manager is used for providing no grad and autocast context,
     which is used for bf16 model.
     """
-    def __init__(self, thread_num=None, accelerator=None, enable_onednn=True):
+    def __init__(self, thread_num=None, accelerator=None, enable_onednn=False):
         super().__init__(thread_num=thread_num, accelerator=accelerator,
                          enable_onednn=enable_onednn)
         if compare_version("torch", operator.lt, "1.13.0"):
@@ -117,7 +117,7 @@ class XPUAutocastContextManager(AutocastContextManager):
 
 
 def generate_context_manager(accelerator=None, precision="fp32", thread_num=None,
-                             enable_onednn=True, use_xpu=False):
+                             enable_onednn=False, use_xpu=False):
     '''
     generate correct context manager according to different situation
     :param acclerator: str, the accelerator to use, we support "onnxruntime", "openvino",
@@ -126,7 +126,7 @@ def generate_context_manager(accelerator=None, precision="fp32", thread_num=None
     :param thread_num: int, the thread number to allocate, None for no limit.
     :param enable_onednn: Whether to use PyTorch JIT graph fuser based on oneDNN Graph
            API, which provides a flexible API for aggressive fusion. Default to
-           ``True``, only valid when accelerator="jit", otherwise will be ignored.
+           ``False``, only valid when accelerator="jit", otherwise will be ignored.
     :param use_xpu: if xpu model is used.
     '''
     if (precision != "bf16" and use_xpu is False) or precision == "fp32":

--- a/python/nano/src/bigdl/nano/pytorch/context_manager.py
+++ b/python/nano/src/bigdl/nano/pytorch/context_manager.py
@@ -50,12 +50,13 @@ class BaseContextManager(object):
                 # onednn fusion be added to torch from version 1.12
                 torch.jit.enable_onednn_fusion(False)
         torch.set_num_threads(self.original_thread_num)
-    
+
     def __getstate__(self):
         state = self.__dict__
-        del state['infer_mode']
+        if 'infer_mode' in state.keys():
+            del state['infer_mode']
         return state
-    
+
     def __setstate__(self, d):
         self.__dict__ = d
         if self.infer_mode_string == "inference_mode":

--- a/python/nano/src/bigdl/nano/pytorch/context_manager.py
+++ b/python/nano/src/bigdl/nano/pytorch/context_manager.py
@@ -36,6 +36,11 @@ class BaseContextManager(object):
     def __enter__(self):
         if self.thread_num is not None:
             torch.set_num_threads(self.thread_num)
+        if not hasattr(self, "infer_mode"):
+            if self.infer_mode_string == "inference_mode":
+                self.infer_mode = torch.inference_mode(mode=True)
+            else:
+                self.infer_mode = torch.no_grad()
         self.infer_mode.__enter__()
         if self.accelerator == "jit" and self.enable_onednn is True:
             if compare_version("torch", operator.ge, "1.12.0"):
@@ -56,13 +61,6 @@ class BaseContextManager(object):
         if 'infer_mode' in state.keys():
             del state['infer_mode']
         return state
-
-    def __setstate__(self, d):
-        self.__dict__ = d
-        if self.infer_mode_string == "inference_mode":
-            self.infer_mode = torch.inference_mode(mode=True)
-        else:
-            self.infer_mode = torch.no_grad()
 
 
 class AutocastContextManager(BaseContextManager):

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -479,8 +479,8 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                     else:
                         model(input_sample)
 
-                if option.ipex is True:
-                    # a temp workaround for strange bad optional access of ipex quantization model
+                if option.ipex is True and _precision == 'int8':
+                    # a temp workaround for strange bad optional access of ipex quantizated model
                     # warm up two times before inside context manager
                     func_test(acce_model, input_sample)
                     func_test(acce_model, input_sample)

--- a/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
+++ b/python/nano/src/bigdl/nano/pytorch/inference/optimizer.py
@@ -17,7 +17,6 @@
 import torch
 from torch import nn
 import time
-import copy
 import sigfig
 import multiprocessing as mp
 from typing import Dict, Callable, Tuple, Optional, List, Union, Sequence, Mapping
@@ -481,7 +480,7 @@ class InferenceOptimizer(BaseInferenceOptimizer):
                         model(input_sample)
 
                 if option.ipex is True:
-                    # TODO: temp workaround for strange bad optional access of ipex quantization model
+                    # a temp workaround for strange bad optional access of ipex quantization model
                     # warm up two times before inside context manager
                     func_test(acce_model, input_sample)
                     func_test(acce_model, input_sample)

--- a/python/nano/src/bigdl/nano/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/pytorch/model.py
@@ -43,6 +43,8 @@ class AcceleratedLightningModule(AcceleratedModel, LightningModule):
         super().train(mode)
 
     def forward_step(self, *inputs, **kwargs):
+        print(*inputs)
+        print(**kwargs)
         return self.model(*inputs, **kwargs)
 
     def on_forward_start_kwargs(self, **kwargs):

--- a/python/nano/src/bigdl/nano/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/pytorch/model.py
@@ -43,8 +43,6 @@ class AcceleratedLightningModule(AcceleratedModel, LightningModule):
         super().train(mode)
 
     def forward_step(self, *inputs, **kwargs):
-        print(*inputs)
-        print(**kwargs)
         return self.model(*inputs, **kwargs)
 
     def on_forward_start_kwargs(self, **kwargs):

--- a/python/nano/src/bigdl/nano/utils/pytorch/dataset.py
+++ b/python/nano/src/bigdl/nano/utils/pytorch/dataset.py
@@ -38,8 +38,12 @@ def remove_batch_dim_fn(loader):
         def recusive_remove(data):
             if isinstance(data, torch.Tensor):
                 return data.squeeze(0)
-            else:
+            elif isinstance(data, list) or isinstance(data, tuple):
                 return tuple([recusive_remove(x) for x in data])
+            elif isinstance(data, dict):
+                for key in data:
+                    data[key] = data[key].squeeze(0)
+                return data
         return recusive_remove(data)
     loader.collate_fn = warpper_fn
     return loader


### PR DESCRIPTION
## Description

To solve bug about ipex quantized bert inside `InferenceOptimizer.optimize()` reported by @Hanyu-Jin 

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/8466

### 2. User API changes

No change.

### 3. Summary of the change 

- Fix data preprocessing for dict input
- add `jit_strict` parameter for `InferencecOptimizer.optimize`
- update BaseContextManager to fix `TypeError: cannot pickle 'torch._C._InferenceMode' object` (model with torch.inference_mode() attached can't be pickled)
- `RuntimeError: bad optional access` of ipex quantized bert was caused by onednn, set dafault value to False and add `enable_onednn` parameter to `InferencecOptimizer.optimize`

### 4. How to test?
- [x] Unit test