### PR TITLE
LLM: fix inconsistency between output token number and `max_new_token`

### DIFF
--- a/python/llm/src/bigdl/llm/ggml/model/generation/utils.py
+++ b/python/llm/src/bigdl/llm/ggml/model/generation/utils.py
@@ -164,7 +164,7 @@ class GenerationMixin:
             res_list = []
             word_count = 0
             for token in tokens:
-                if word_count > max_new_tokens:
+                if word_count >= max_new_tokens:
                     break
                 res_list.append(token)
                 word_count += 1


### PR DESCRIPTION
## Description

When run native int4 pipeline, the actual output token number is always 1 more than `max_new_token` parameter.
In this PR, fix it.


### 2. User API changes

None

### 4. How to test?
- [x] Unit test
- [x] Local test