### PR TITLE
Nano: cast fp64 to fp32

### DIFF
--- a/python/nano/src/bigdl/nano/pytorch/model.py
+++ b/python/nano/src/bigdl/nano/pytorch/model.py
@@ -55,6 +55,9 @@ class AcceleratedLightningModule(AcceleratedModel, LightningModule):
             result = []
             for x in ts:
                 if isinstance(x, torch.Tensor):
+                    # cast float64 into float32
+                    if x.dtype == torch.float64:
+                        x = x.float()
                     result.append(x.cpu().detach().numpy())
                 elif isinstance(x, np.ndarray):
                     result.append(x)


### PR DESCRIPTION
## Description

During SD sdk development, @Litchilitchy find that there will be fp64 input.
So here we cast fp64 to fp32 automatically in `to_numpy` function.

### 1. Why the change?

For better support sd sdk development.

### 2. User API changes

No change.

### 3. Summary of the change 

- cast fp64 to fp32 automatically in `to_numpy` function

### 4. How to test?
- [x] Unit test