### PR TITLE
Add ./init.sh in torchserve scripts.

### DIFF
--- a/ppml/trusted-dl-serving/base/ppml/torchserve/backend-entrypoint.sh
+++ b/ppml/trusted-dl-serving/base/ppml/torchserve/backend-entrypoint.sh
@@ -8,6 +8,7 @@ MODEL_NAME=$MODEL_NAME
 local_pod_ip=$( hostname -I | awk '{print $1}' )
 
 cd /ppml || exit
+./init.sh
 
 # Set PCCS conf
 if [ "$PCCS_URL" != "" ] ; then

--- a/ppml/trusted-dl-serving/base/ppml/torchserve/frontend-entrypoint.sh
+++ b/ppml/trusted-dl-serving/base/ppml/torchserve/frontend-entrypoint.sh
@@ -12,6 +12,7 @@ if [ "$PCCS_URL" != "" ] ; then
 fi
 
 cd /ppml || exit
+./init.sh
 
 if [[ $SGX_ENABLED == "false" ]]; then
     if [ "$ATTESTATION" = "true" ]; then


### PR DESCRIPTION
## Description

Add ./init.sh in Torchserve scripts. 

### 1. Why the change?

To run Torchserve in SGX.

### 2. User API changes

None.