### PR TITLE
LLM: Optimize transformer int4 loading

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -49,8 +49,11 @@ def _replace_with_int4_linear(model, modules_to_not_convert=None,
         if param.data.device == torch.device('meta'):
             from accelerate.utils.modeling import set_module_tensor_to_device
             param = model_state_dict[name]
-            set_module_tensor_to_device(model, name, "cpu", torch.empty(*param.size(), dtype=torch.float32))
-   
+            set_module_tensor_to_device(model,
+                                        name,
+                                        "cpu",
+                                        torch.empty(*param.size(), dtype=torch.float32))
+
     for name, module in model.named_children():
         if current_key_name is None:
             current_key_name = []
@@ -107,6 +110,5 @@ def ggml_convert_int4(model, convert_shape_only=False):
             "an issue on github if you think this is a bug."
         )
     else:
-        # model.to(torch.float32)
-        pass
+        model.to(torch.float32)
     return model

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -44,6 +44,13 @@ import warnings
 def _replace_with_int4_linear(model, modules_to_not_convert=None,
                               current_key_name=None, convert_shape_only=False):
     has_been_replaced = False
+    model_state_dict = model.state_dict()
+    for name, param in model.named_parameters():
+        if param.data.device == torch.device('meta'):
+            from accelerate.utils.modeling import set_module_tensor_to_device
+            param = model_state_dict[name]
+            set_module_tensor_to_device(model, name, "cpu", torch.empty(*param.size(), dtype=torch.float32))
+   
     for name, module in model.named_children():
         if current_key_name is None:
             current_key_name = []
@@ -82,6 +89,7 @@ def _replace_with_int4_linear(model, modules_to_not_convert=None,
                 module,
                 modules_to_not_convert,
                 current_key_name,
+                convert_shape_only,
             )
     return model, has_been_replaced
 
@@ -99,5 +107,6 @@ def ggml_convert_int4(model, convert_shape_only=False):
             "an issue on github if you think this is a bug."
         )
     else:
-        model.to(torch.float32)
+        # model.to(torch.float32)
+        pass
     return model

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -17,6 +17,7 @@
 
 # Some parts of this file is adapted from
 # https://github.com/huggingface/transformers/blob/v4.30.2/src/transformers/utils/bitsandbytes.py
+# and https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py
 # which is licensed under Apache License 2.0:
 #
 # Copyright 2021 The HuggingFace Inc. team. All rights reserved.
@@ -44,6 +45,13 @@ import warnings
 def _replace_with_int4_linear(model, modules_to_not_convert=None,
                               current_key_name=None, convert_shape_only=False):
     has_been_replaced = False
+
+    # Through our method, certain layers that were initialized on the device "meta"
+    # (associated with the lazy initialization strategy of low_cpu_mem_usage) are not
+    # being correctly moved back to the CPU device for some reason. Therefore, we are
+    # moving these layers back to the CPU here in order to prevent the occurrence
+    # of NoImplementnError. Details refer to:
+    # https://github.com/huggingface/transformers/blob/main/src/transformers/modeling_utils.py#L3110
     model_state_dict = model.state_dict()
     for name, param in model.named_parameters():
         if param.data.device == torch.device('meta'):

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -87,9 +87,9 @@ class _BaseAutoModelClass:
             model = cls.convert_quant(model, qtype, *args, **kwargs)
         elif load_in_low_bit:
             load_in_low_bit = load_in_low_bit.lower()
-            invalidInputError(qtype in ggml_tensor_qtype,
-                            f"Unknown load_in_low_bit value: {qtype},"
-                            f" excepted q4_0, q4_1, q5_0, q5_1, q8_0.")
+            invalidInputError(load_in_low_bit in ggml_tensor_qtype,
+                              f"Unknown load_in_low_bit value: {load_in_low_bit},"
+                              f" excepted q4_0, q4_1, q5_0, q5_1, q8_0.")
             qtype = ggml_tensor_qtype[load_in_low_bit]
             model = cls.convert_quant(model, qtype, *args, **kwargs)
 

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -48,6 +48,10 @@ class _BaseAutoModelClass:
         if bigdl_transformers_int4:
             # Avoid KeyError
             kwargs["ignore_mismatched_sizes"] = True
+            # Speed up when loading model
+            kwargs["low_cpu_mem_usage"] = True
+            # Avoid reading from local file at the first initialization
+            kwargs["state_dict"] = {}
 
         model = cls.HF_Model.from_pretrained(*args, **kwargs)
         print("Note: If there are warnings about mismatched during the loading process, "

--- a/python/llm/src/bigdl/llm/transformers/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/utils.py
@@ -52,9 +52,6 @@ WEIGHTS_NAME = "pytorch_model.bin"
 
 def extract_local_archive_file(pretrained_model_name_or_path, subfolder, variant):
     pretrained_model_name_or_path = str(pretrained_model_name_or_path)
-    print(os.path.join(pretrained_model_name_or_path,
-                       subfolder,
-                       _add_variant(WEIGHTS_NAME, variant)))
     if os.path.isfile(
         os.path.join(pretrained_model_name_or_path, subfolder, _add_variant(WEIGHTS_NAME, variant))
     ):


### PR DESCRIPTION
## Description

In this PR we optimize transformer int4 model loading speed by:

1. using `low_cpu_mem_usage` to let huggingface original api to init model without init its weights at first, and also allocate the memory no more than  ~1x model size CPU memory as the official description introduces.
2. Directly pass an empty state_dict to from_pretained to avoid reading from local file at the first initialization(this weights will be abort)

Test shows that our loading benefits from this pr:

original vicuna 13B without low_cpu_mem_usage :55.64694786071777s

... with low_cpu_mem_usage: 9.221513748168945s

load and quantization: 32.92671084403992s

load int4 without optimization:  53.27334189414978s

load int4 with low_cpu_mem_usage: 7.347492694854736s

load int4 with low_cpu_mem_usage and without state_dict:  5.813234806060791s

Sanity Check:
```python

from bigdl.llm.transformers import AutoModelForCausalLM
from transformers import LlamaTokenizer

llama_model_path = "/home/ruonan/models/vicuna-13b/"
# llama_model_path = "/mnt/disk2/models/merged_gpt4all_llama_7b"
output_dir = "./vicuna-13b"

import time

start = time.time()
model = AutoModelForCausalLM.from_pretrained(llama_model_path,
                                             load_in_4bit=True)
during = time.time() - start
model.save_pretrained(output_dir)

start = time.time()
model = AutoModelForCausalLM.from_pretrained(output_dir)
during_0 = time.time() - start

tokenizer = LlamaTokenizer.from_pretrained(llama_model_path)
input = "what is AI?"
input_token = tokenizer(input, return_tensors="pt")
output_token = model.generate(**input_token)

summary = tokenizer.batch_decode(output_token,
                                 skip_special_tokens=True,
                                 spaces_between_special_tokens=False)
print(summary)

print(f"quan time {during}, load time {during_0}")
```
output:
```
Note: If there are warnings about mismatched during the loading process, please ignore them as it is part of the normal flow. The model will be reconverted to the format of BigDL after loading.
./vicuna-13b/pytorch_model.bin
/opt/anaconda3/envs/changmin-chatllm/lib/python3.9/site-packages/transformers/generation/utils.py:1313: UserWarning: Using `max_length`'s default (20) to control the generation length. This behaviour is deprecated and will be removed from the config in v5 of Transformers -- we recommend using `max_new_tokens` to control the maximum length of the generation.
  warnings.warn(
['what is AI?\n\nArtificial intelligence (AI) is the simulation of human']
```