### PR TITLE
LLM: fix chatglm2 output

### DIFF
--- a/python/llm/example/transformers/transformers_int4/transformers_int4_pipeline.py
+++ b/python/llm/example/transformers/transformers_int4/transformers_int4_pipeline.py
@@ -47,7 +47,7 @@ if __name__ == '__main__':
         print('Output:', output_str)
         print(f'Inference time: {end-st} s')
     elif model_path == 'THUDM/chatglm-6b':
-        model = AutoModel.from_pretrained(model_path, trust_remote_code=True, load_in_4bit=True)
+        model = AutoModel.from_pretrained(model_path, trust_remote_code=True, load_in_4bit=True, keep_in_fp32_modules=['output_layer'])
         tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
 
         input_str = "晚上睡不着应该怎么办"

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -109,8 +109,8 @@ def _replace_with_quant_linear(model, qtype, modules_to_not_convert=None,
     return model, has_been_replaced
 
 
-def ggml_convert_quant(model, qtype, convert_shape_only=False):
-    modules_to_not_convert = []  # ["lm_head"]
+def ggml_convert_quant(model, qtype, keep_in_fp32_modules=[], convert_shape_only=False):
+    modules_to_not_convert = keep_in_fp32_modules  # ["lm_head"]
     model, has_been_replaced = _replace_with_quant_linear(
         model, qtype, modules_to_not_convert, None, convert_shape_only=convert_shape_only
     )


### PR DESCRIPTION
## Description

Related to https://github.com/analytics-zoo/nano/issues/434
Because the output linear layer of chatglm2 is converted, the output quality becomes poor.

Add an extra argument `keep_in_fp32_modules` so that different models can choose specific layers not to convert. The default value is `[]` and this parameter only works when `load_in_4bit/load_in_low_bit/bigdl_transformers_low_bit=True`.

### 2. User API changes

```python
# chatglm2 for example
from bigdl.llm.transformers import AutoModel
model = AutoModel.from_pretrained(model_path, load_in_4bit=True, keep_in_fp32_modules=['output_layer'])
```

### 3. Summary of the change 

- Add an extra argument `keep_in_fp32_modules` in `ggml_convert_quant`
- modify example (btw, we are working to add more examples, the example for chatglm2 is temporary)

### 4. How to test?
- [ ] Unit test
- [x] Local test
