### PR TITLE
[LLM] AVX512 runner updates

### DIFF
--- a/.github/workflows/llm_unit_tests_linux.yml
+++ b/.github/workflows/llm_unit_tests_linux.yml
@@ -53,7 +53,7 @@ jobs:
       matrix:
         python-version: ["3.9"]
     env:
-      THREAD_NUM: 6
+      THREAD_NUM: 24
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
## Description

Enable only 1 avx512 runner (instead of 4) for now. Because inference tests will take very long time when multiple native int4 tests start together.

TODO: Make inference tests fetching examples from local places, and only let the downloading happens when there are newer ckpt in the llm/ggml-actions/stable folder