### PR TITLE
spark3.4 scala part

### DIFF
--- a/.github/actions/dllib-scala-ut-action/action.yml
+++ b/.github/actions/dllib-scala-ut-action/action.yml
@@ -9,14 +9,14 @@ runs:
         export SPARK_LOCAL_HOSTNAME=localhost
         export KERAS_BACKEND=tensorflow
         cd scala
-        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.optim" "-Dtest=com.intel.analytics.bigdl.dllib.optim.*Test" test -P spark_3.x -Dspark.version=3.1.3 
-        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.models" "-Dtest=com.intel.analytics.bigdl.dllib.models.*Test" test -P spark_3.x -Dspark.version=3.1.3 
-        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.estimator" "-Dtest=com.intel.analytics.bigdl.dllib.estimator.*Test" test -P spark_3.x -Dspark.version=3.1.3  
-        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.nnframes" "-Dtest=com.intel.analytics.bigdl.dllib.nnframes.*Test" test -P spark_3.x -Dspark.version=3.1.3 
-        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.feature" "-Dtest=com.intel.analytics.bigdl.dllib.feature.*Test" test -P spark_3.x -Dspark.version=3.1.3
-        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.utils.intermediate" "-Dtest=com.intel.analytics.bigdl.dllib.utils.intermediate.*Test" test -P spark_3.x -Dspark.version=3.1.3
-        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.utils.tf" "-Dtest=com.intel.analytics.bigdl.dllib.utils.tf.*Test" test -P spark_3.x -Dspark.version=3.1.3
-        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.utils.python.api" "-Dtest=com.intel.analytics.bigdl.dllib.utils.python.api.*Test" test -P spark_3.x -Dspark.version=3.1.3
+        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.optim" "-Dtest=com.intel.analytics.bigdl.dllib.optim.*Test" test -P spark_3.x -Dspark.version=3.4.1 
+        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.models" "-Dtest=com.intel.analytics.bigdl.dllib.models.*Test" test -P spark_3.x -Dspark.version=3.4.1 
+        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.estimator" "-Dtest=com.intel.analytics.bigdl.dllib.estimator.*Test" test -P spark_3.x -Dspark.version=3.4.1
+        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.nnframes" "-Dtest=com.intel.analytics.bigdl.dllib.nnframes.*Test" test -P spark_3.x -Dspark.version=3.4.1
+        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.feature" "-Dtest=com.intel.analytics.bigdl.dllib.feature.*Test" test -P spark_3.x -Dspark.version=3.4.1
+        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.utils.intermediate" "-Dtest=com.intel.analytics.bigdl.dllib.utils.intermediate.*Test" test -P spark_3.x -Dspark.version=3.4.1
+        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.utils.tf" "-Dtest=com.intel.analytics.bigdl.dllib.utils.tf.*Test" test -P spark_3.x -Dspark.version=3.4.1
+        mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.utils.python.api" "-Dtest=com.intel.analytics.bigdl.dllib.utils.python.api.*Test" test -P spark_3.x -Dspark.version=3.4.1
         #need python requirements
         #mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.keras" "-Dtest=com.intel.analytics.bigdl.dllib.keras.*Test" test -P spark_3.x -Dspark.version=3.1.3 
         #mvn "-DwildcardSuites=com.intel.analytics.bigdl.dllib.nn.mkldnn" "-Dtest=com.intel.analytics.bigdl.dllib.nn.mkldnn.*Test" test -P spark_3.x -Dspark.version=3.1.3 

--- a/.github/actions/friesian-scala-ut-action/action.yml
+++ b/.github/actions/friesian-scala-ut-action/action.yml
@@ -39,4 +39,4 @@ runs:
         export KERAS_BACKEND=tensorflow
         cd scala
         mvn "-DwildcardSuites=com.intel.analytics.bigdl.friesian" "-Dtest=com.intel.analytics.bigdl.friesian.*Test" test -P serving,spark_2.x -Dspark.version=2.4.6 "-Dspark.master=local[*]" -pl "!ppml"
-        mvn "-DwildcardSuites=com.intel.analytics.bigdl.friesian" "-Dtest=com.intel.analytics.bigdl.friesian.*Test" test -P serving,spark_3.x -Dspark.version=3.1.3 "-Dspark.master=local[*]"
+        mvn "-DwildcardSuites=com.intel.analytics.bigdl.friesian" "-Dtest=com.intel.analytics.bigdl.friesian.*Test" test -P serving,spark_3.x -Dspark.version=3.4.1 "-Dspark.master=local[*]"

--- a/scala/common/spark-version/2.0/pom.xml
+++ b/scala/common/spark-version/2.0/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
-            <version>3.2.4</version>
+            <version>${hadoop.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>3.2.4</version>
+            <version>${hadoop.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/scala/common/spark-version/3.0/pom.xml
+++ b/scala/common/spark-version/3.0/pom.xml
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
-            <version>3.2.4</version>
+            <version>${hadoop.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -55,13 +55,17 @@
                 <exclusion>
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-hdfs-client</artifactId>
+	        </exclusion>
+                <exclusion>
+                    <groupId>com.fasterxml.jackson.core</groupId>
+                    <artifactId>jackson-databind</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>3.2.4</version>
+            <version>${hadoop.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/scala/common/spark-version/3.0/pom.xml
+++ b/scala/common/spark-version/3.0/pom.xml
@@ -95,7 +95,15 @@
                 <exclusion>
                     <groupId>org.codehaus.jettison</groupId>
                     <artifactId>jettison</artifactId>
-                </exclusion>
+	        </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+	        </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+		</exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -139,7 +147,15 @@
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>
                     <artifactId>protobuf-java</artifactId>
-                </exclusion>
+	        </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+	        </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+		</exclusion>        
             </exclusions>
         </dependency>
         <dependency>
@@ -179,7 +195,15 @@
                 <exclusion>
                     <groupId>com.google.protobuf</groupId>
                     <artifactId>protobuf-java</artifactId>
-                </exclusion>
+	        </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+  	        </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-text</artifactId>
+		</exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
 	    <artifactId>hadoop-client</artifactId>
-	    <version>3.2.4</version>
+	    <version>${hadoop.version}</version>
             <scope>${spark-scope}</scope>
             <exclusions>
                 <exclusion>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>3.2.4</version>
+            <version>${hadoop.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -114,7 +114,15 @@
                 <exclusion>
                     <groupId>net.minidev</groupId>
                     <artifactId>json-smart</artifactId>
-                </exclusion>
+	        </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+	        </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+	        </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -140,6 +148,14 @@
                 <exclusion>
                     <groupId>log4j</groupId>
                     <artifactId>log4j</artifactId>
+	        </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-handler</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>io.netty</groupId>
+                    <artifactId>netty-transport-native-epoll</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>
@@ -226,7 +242,15 @@
                 <exclusion>
                     <groupId>org.apache.ivy</groupId>
                     <artifactId>ivy</artifactId>
-                </exclusion>
+	        </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+                    <artifactId>commons-lang3</artifactId>
+	        </exclusion>
+                <exclusion>
+                    <groupId>org.apache.commons</groupId>
+		    <artifactId>commons-text</artifactId>
+	        </exclusion>
             </exclusions>
         </dependency>
         <dependency>
@@ -292,6 +316,18 @@
             <artifactId>commons-compress</artifactId>
             <version>1.21</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.12.0</version>
+            <scope>${spark-scope}</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-text</artifactId>
+            <version>1.10.0</version>
+            <scope>${spark-scope}</scope>
+	</dependency>
 	<dependency>
             <groupId>org.scalanlp</groupId>
             <artifactId>breeze_${scala.major.version}</artifactId>
@@ -319,8 +355,8 @@
         </dependency>
 	<dependency>
             <groupId>ml.dmlc</groupId>
-            <artifactId>xgboost4j_${scala.major.version}</artifactId>
-            <version>1.1.2</version>
+            <artifactId>xgboost4j_2.12</artifactId>
+            <version>1.6.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.esotericsoftware.kryo</groupId>
@@ -334,8 +370,8 @@
         </dependency>
         <dependency>
             <groupId>ml.dmlc</groupId>
-            <artifactId>xgboost4j-spark_${scala.major.version}</artifactId>
-            <version>1.1.2</version>
+	    <artifactId>xgboost4j-spark_2.12</artifactId>
+            <version>1.6.2</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.esotericsoftware.kryo</groupId>

--- a/scala/friesian/pom.xml
+++ b/scala/friesian/pom.xml
@@ -234,7 +234,7 @@
         <dependency>
             <groupId>io.lettuce</groupId>
             <artifactId>lettuce-core</artifactId>
-            <version>6.1.6.RELEASE</version>
+            <version>6.2.4.RELEASE</version>
             <scope>${serving.scope}</scope>
             <exclusions>
                 <exclusion>

--- a/scala/friesian/pom.xml
+++ b/scala/friesian/pom.xml
@@ -137,7 +137,7 @@
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
-            <version>3.2.4</version>
+            <version>${hadoop.version}</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -160,7 +160,7 @@
         <native-maven-plugin.version>1.0-alpha-8</native-maven-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
 
-        <hadoop.version>3.2.4</hadoop.version>
+        <hadoop.version>3.3.4</hadoop.version>
 	<guava.version>32.0.1-jre</guava.version>
 	<json4s.version>3.7.0-M11</json4s.version>
         <thrift.path>thrift</thrift.path>

--- a/scala/pom.xml
+++ b/scala/pom.xml
@@ -161,7 +161,8 @@
         <maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
 
         <hadoop.version>3.2.4</hadoop.version>
-        <guava.version>32.0.1-jre</guava.version>
+	<guava.version>32.0.1-jre</guava.version>
+	<json4s.version>3.7.0-M11</json4s.version>
         <thrift.path>thrift</thrift.path>
         <thrift.version>0.9.2</thrift.version>
         <slf4j.version>1.7.7</slf4j.version>
@@ -187,7 +188,7 @@
         <data-store-url>http://download.tensorflow.org</data-store-url>
         <lightgbm.scope>provided</lightgbm.scope>
         <grpc.version>1.53.0</grpc.version>
-        <parquet.version>1.12.2</parquet.version>
+        <parquet.version>1.12.3</parquet.version>
 
     </properties>
 
@@ -812,10 +813,10 @@
                 <java.version>1.8</java.version>
                 <javac.version>1.8</javac.version>
                 <spark-version.project>3.0</spark-version.project>
-                <spark.version>3.1.3</spark.version>
+                <spark.version>3.4.1</spark.version>
                 <scala.major.version>2.12</scala.major.version>
-                <scala.version>2.12.10</scala.version>
-                <scala.macros.version>2.1.0</scala.macros.version>
+                <scala.version>2.12.15</scala.version>
+                <scala.macros.version>2.1.1</scala.macros.version>
                 <lightgbm.scope>compile</lightgbm.scope>
                 <maven.compiler.source>${java.version}</maven.compiler.source>
                 <maven.compiler.target>${java.version}</maven.compiler.target>
@@ -893,8 +894,8 @@
             <id>scala_2.12</id>
             <properties>
                 <scala.major.version>2.12</scala.major.version>
-                <scala.version>2.12.10</scala.version>
-                <scala.macros.version>2.1.0</scala.macros.version>
+                <scala.version>2.12.15</scala.version>
+                <scala.macros.version>2.1.1</scala.macros.version>
             </properties>
         </profile>
         <profile>

--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -131,6 +131,12 @@
             <version>1.1.2</version>
         </dependency>
         <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <version>${hadoop.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>1.21</version>

--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -113,13 +113,22 @@
                 <exclusion>
                     <groupId>org.apache.ivy</groupId>
                     <artifactId>ivy</artifactId>
-                </exclusion>
+	        </exclusion>
+                <exclusion>
+                    <groupId>org.scala-lang.modules</groupId>
+                    <artifactId>scala-parser-combinators_${scala.major.version}</artifactId>
+	        </exclusion>
             </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-text</artifactId>
             <version>1.10.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.scala-lang.modules</groupId>
+            <artifactId>scala-parser-combinators_${scala.major.version}</artifactId>
+            <version>1.1.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/scala/serving/pom.xml
+++ b/scala/serving/pom.xml
@@ -44,7 +44,7 @@
         <dependency>
             <groupId>org.json4s</groupId>
             <artifactId>json4s-jackson_${scala.major.version}</artifactId>
-            <version>3.7.0-M5</version>
+            <version>${json4s.version}</version>
         </dependency>
         <dependency>
             <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
## Description

Spark3.4
### 1. Why the change?

- [x] You need to update xgboost to latest version 1.7.6 to fix the java.lang.nosuchmethoderror org.json4s.jsondsl$.pair2assoc
- [x] common-lang3's version should be 3.12.0，or java11 can't be used.
- [x] Duplicated dependency jackson-databind should be excluded from json4s-jackson


### 2. Summary of the change 

1. version conflict `org.apache.commons:commons-lang3` hadoop use3.7.0, spark_core use 3.12.0
  ```
java.lang.NoSuchMethodError:org.apache.commons.text.StringSubstitutor.setEnableUndefinedVariableException(Z)Lorg/apache/commons/text/StringSubstitutor;
```
2. version conflict `org.apache.commons:commons-text` 
```
java.lang.NoSuchMethodError: org.apache.commons.text.StringSubstitutor.setEnableUndefinedVariableException(Z)Lorg/apache/commons/text/StringSubstitutor
```
3. version conflict in netty
4. Upgrade: hadoop, parquet, xgboost

