### PR TITLE
[LLM] Add more transformers int4 example (Dolly v2) 

### DIFF
--- a/python/llm/README.md
+++ b/python/llm/README.md
@@ -24,6 +24,7 @@ We may use any Hugging Face Transfomer models on `bigdl-llm`, and the following 
 | MOSS      | [link](example/transformers/transformers_int4/moss)      | 
 | Baichuan  | [link](example/transformers/transformers_int4/baichuan)  | 
 | Dolly-v1  | [link](example/transformers/transformers_int4/dolly_v1)  | 
+| Dolly-v2  | [link](example/transformers/transformers_int4/dolly_v2)  | 
 | RedPajama | [link1](example/transformers/native_int4), [link2](example/transformers/transformers_int4/redpajama) | 
 | Phoenix   | [link1](example/transformers/native_int4), [link2](example/transformers/transformers_int4/phoenix)   | 
 | StarCoder | [link1](example/transformers/native_int4), [link2](example/transformers/transformers_int4/starcoder) | 

--- a/python/llm/example/transformers/transformers_int4/README.md
+++ b/python/llm/example/transformers/transformers_int4/README.md
@@ -12,6 +12,7 @@ You can use BigDL-LLM to run any Huggingface Transformer models with INT4 optimi
 | MOSS      | [link](moss)      | 
 | Baichuan  | [link](baichuan)  | 
 | Dolly-v1  | [link](dolly_v1)  | 
+| Dolly-v2  | [link](dolly_v2)  | 
 | RedPajama | [link](redpajama) | 
 | Phoenix   | [link](phoenix)   | 
 | StarCoder | [link](starcoder) | 

--- a/python/llm/example/transformers/transformers_int4/dolly_v2/README.md
+++ b/python/llm/example/transformers/transformers_int4/dolly_v2/README.md
@@ -1,0 +1,71 @@
+# Dolly v2
+In this directory, you will find examples on how you could apply BigDL-LLM INT4 optimizations on Dolly v2 models. For illustration purposes, we utilize the [databricks/dolly-v2-12b](https://huggingface.co/databricks/dolly-v2-12b) as a reference Dolly v2 model.
+
+## 0. Requirements
+To run these examples with BigDL-LLM, we have some recommended requirements for your machine, please refer to [here](../README.md#recommended-requirements) for more information.
+
+## Example: Predict Tokens using `generate()` API
+In the example [generate.py](./generate.py), we show a basic use case for a Dolly v2 model to predict the next N tokens using `generate()` API, with BigDL-LLM INT4 optimizations.
+### 1. Install
+We suggest using conda to manage environment:
+```bash
+conda create -n llm python=3.9
+conda activate llm
+
+pip install bigdl-llm[all] # install bigdl-llm with 'all' option
+```
+
+### 2. Run
+```
+python ./generate.py --repo-id-or-model-path REPO_ID_OR_MODEL_PATH --prompt PROMPT --n-predict N_PREDICT
+```
+
+Arguments info:
+- `--repo-id-or-model-path REPO_ID_OR_MODEL_PATH`: argument defining the huggingface repo id for the Dolly v2 model to be downloaded, or the path to the huggingface checkpoint folder. It is default to be `'databricks/dolly-v2-12b'`.
+- `--prompt PROMPT`: argument defining the prompt to be infered (with integrated prompt format for chat). It is default to be `'What is AI?'`.
+- `--n-predict N_PREDICT`: argument defining the max number of tokens to predict. It is default to be `32`.
+
+> **Note**: When loading the model in 4-bit, BigDL-LLM converts linear layers in the model into INT4 format. In theory, a *X*B model saved in 16-bit will requires approximately 2*X* GB of memory for loading, and ~0.5*X* GB memory for further inference.
+>
+> Please select the appropriate size of the Dolly v2 model based on the capabilities of your machine.
+
+#### 2.1 Client
+On client Windows machine, it is recommended to run directly with full utilization of all cores:
+```powershell
+python ./generate.py 
+```
+
+#### 2.2 Server
+For optimal performance on server, it is recommended to set several environment variables (refer to [here](../README.md#best-known-configuration-on-linux) for more information), and run the example with all the physical cores of a single socket.
+
+E.g. on Linux,
+```bash
+# set BigDL-Nano env variables
+source bigdl-nano-init
+
+# e.g. for a server with 48 cores per socket
+export OMP_NUM_THREADS=48
+numactl -C 0-47 -m 0 python ./generate.py
+```
+
+#### 2.3 Sample Output
+#### [databricks/dolly-v2-12b](https://huggingface.co/databricks/dolly-v2-12b)
+```log
+Inference time: xxxx s
+-------------------- Prompt --------------------
+Below is an instruction that describes a task. Write a response that appropriately completes the request.
+
+### Instruction:
+What is AI?
+
+### Response:
+
+-------------------- Output --------------------
+Below is an instruction that describes a task. Write a response that appropriately completes the request.
+
+### Instruction:
+What is AI?
+
+### Response:
+Artificial Intelligence (AI) is the area of computer science concerned with building machines that can perform tasks normally associated with human intelligence, such as reasoning, learning,
+```

--- a/python/llm/example/transformers/transformers_int4/dolly_v2/generate.py
+++ b/python/llm/example/transformers/transformers_int4/dolly_v2/generate.py
@@ -48,10 +48,12 @@ if __name__ == '__main__':
     # Load model in 4 bit,
     # which convert the relevant layers in the model into INT4 format
     model = AutoModelForCausalLM.from_pretrained(model_path,
-                                                 load_in_4bit=True)
+                                                 load_in_4bit=True,
+                                                 trust_remote_code=True)
 
     # Load tokenizer
-    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    tokenizer = AutoTokenizer.from_pretrained(model_path,
+                                              trust_remote_code=True)
     
     # Generate predicted tokens
     with torch.inference_mode():

--- a/python/llm/example/transformers/transformers_int4/dolly_v2/generate.py
+++ b/python/llm/example/transformers/transformers_int4/dolly_v2/generate.py
@@ -1,0 +1,80 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+import time
+import argparse
+import numpy as np
+
+from bigdl.llm.transformers import AutoModelForCausalLM
+from transformers import AutoTokenizer
+
+# you could tune the prompt based on your own model,
+# here the prompt tuning refers to https://huggingface.co/databricks/dolly-v2-12b/blob/main/instruct_pipeline.py#L15
+DOLLY_V2_PROMPT_FORMAT = """Below is an instruction that describes a task. Write a response that appropriately completes the request.
+
+### Instruction:
+{prompt}
+
+### Response:
+"""
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Predict Tokens using `generate()` API for Dolly v2 model')
+    parser.add_argument('--repo-id-or-model-path', type=str, default="databricks/dolly-v2-12b",
+                        help='The huggingface repo id for the Dolly v2 model to be downloaded'
+                             ', or the path to the huggingface checkpoint folder')
+    parser.add_argument('--prompt', type=str, default="What is AI?",
+                        help='Prompt to infer')
+    parser.add_argument('--n-predict', type=int, default=32,
+                        help='Max tokens to predict')
+
+    args = parser.parse_args()
+    model_path = args.repo_id_or_model_path
+
+    # Load model in 4 bit,
+    # which convert the relevant layers in the model into INT4 format
+    model = AutoModelForCausalLM.from_pretrained(model_path,
+                                                 load_in_4bit=True)
+
+    # Load tokenizer
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    
+    # Generate predicted tokens
+    with torch.inference_mode():
+        prompt = DOLLY_V2_PROMPT_FORMAT.format(prompt=args.prompt)
+        input_ids = tokenizer.encode(prompt, return_tensors="pt")
+        end_key_token_id=tokenizer.encode("### End")[0]
+        st = time.time()
+        # if your selected model is capable of utilizing previous key/value attentions
+        # to enhance decoding speed, but has `"use_cache": false` in its model config,
+        # it is important to set `use_cache=True` explicitly in the `generate` function
+        # to obtain optimal performance with BigDL-LLM INT4 optimizations
+        output = model.generate(input_ids,
+                                max_new_tokens=args.n_predict,
+                                pad_token_id=tokenizer.pad_token_id,
+                                eos_token_id=end_key_token_id)
+        end = time.time()
+        end_token_position = None
+        end_token_positions = np.where(output[0] == end_key_token_id)[0]
+        if len(end_token_positions) > 0:
+            end_token_position = end_token_positions[0]
+        output_str = tokenizer.decode(output[0][:end_token_position], skip_special_tokens=False)
+        print(f'Inference time: {end-st} s')
+        print('-'*20, 'Prompt', '-'*20)
+        print(prompt)
+        print('-'*20, 'Output', '-'*20)
+        print(output_str)


### PR DESCRIPTION
## Description

Add model Dolly v2 to transformers int4 examples

### 1. Why the change?

Add more model-specific examples so that users can quickly get started using BigDL-LLM to run some popular open-source models in the community

### 2. User API changes

N/A

### 3. Summary of the change 

Add transformers int4 generate examples for Dolly v2 (scripts & README)

### 4. How to test?
- [x] Local test on Client
- [x] Local test on Server

