### PR TITLE
Optimize transformer int4 memory footprint

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -61,6 +61,7 @@ def _replace_with_quant_linear(model, qtype, modules_to_not_convert=None,
                                         name,
                                         "cpu",
                                         torch.empty(*param.size(), dtype=torch.float32))
+    del model_state_dict
 
     for name, module in model.named_children():
         if current_key_name is None:


### PR DESCRIPTION
## Description

Optimize transformer int4 memory footprint.

The `model_state_dict` holds references of old FP tensors which will not be released after `model_state_dict` goes out of scope.

### Before
![image](https://github.com/intel-analytics/BigDL/assets/10561966/7d3bcadc-94a0-442d-9c7c-f8ddfa67dba7)

### After
![image](https://github.com/intel-analytics/BigDL/assets/10561966/52a4debb-e3b3-4482-b01d-da7ba0a617b3)
