### PR TITLE
[LLM] Add ` torch_dtype='auto'` when loading in 4 bit for transformers int4 examples

### DIFF
--- a/python/llm/example/transformers/transformers_int4/baichuan/generate.py
+++ b/python/llm/example/transformers/transformers_int4/baichuan/generate.py
@@ -42,6 +42,7 @@ if __name__ == '__main__':
     # which convert the relevant layers in the model into INT4 format
     model = AutoModelForCausalLM.from_pretrained(model_path,
                                                  load_in_4bit=True,
+                                                 torch_dtype='auto',
                                                  trust_remote_code=True)
 
     # Load tokenizer

--- a/python/llm/example/transformers/transformers_int4/chatglm/generate.py
+++ b/python/llm/example/transformers/transformers_int4/chatglm/generate.py
@@ -43,6 +43,7 @@ if __name__ == '__main__':
     # which convert the relevant layers in the model into INT4 format
     model = AutoModel.from_pretrained(model_path,
                                       load_in_4bit=True,
+                                      torch_dtype='auto',
                                       trust_remote_code=True)
 
     # Load tokenizer

--- a/python/llm/example/transformers/transformers_int4/chatglm2/generate.py
+++ b/python/llm/example/transformers/transformers_int4/chatglm2/generate.py
@@ -43,6 +43,7 @@ if __name__ == '__main__':
     # which convert the relevant layers in the model into INT4 format
     model = AutoModel.from_pretrained(model_path,
                                       load_in_4bit=True,
+                                      torch_dtype='auto',
                                       trust_remote_code=True)
 
     # Load tokenizer

--- a/python/llm/example/transformers/transformers_int4/dolly_v1/generate.py
+++ b/python/llm/example/transformers/transformers_int4/dolly_v1/generate.py
@@ -48,7 +48,8 @@ if __name__ == '__main__':
     # Load model in 4 bit,
     # which convert the relevant layers in the model into INT4 format
     model = AutoModelForCausalLM.from_pretrained(model_path,
-                                                 load_in_4bit=True)
+                                                 load_in_4bit=True,
+                                                 torch_dtype='auto')
 
     # Load tokenizer
     tokenizer = AutoTokenizer.from_pretrained(model_path)

--- a/python/llm/example/transformers/transformers_int4/dolly_v2/generate.py
+++ b/python/llm/example/transformers/transformers_int4/dolly_v2/generate.py
@@ -49,6 +49,7 @@ if __name__ == '__main__':
     # which convert the relevant layers in the model into INT4 format
     model = AutoModelForCausalLM.from_pretrained(model_path,
                                                  load_in_4bit=True,
+                                                 torch_dtype='auto',
                                                  trust_remote_code=True)
 
     # Load tokenizer

--- a/python/llm/example/transformers/transformers_int4/falcon/generate.py
+++ b/python/llm/example/transformers/transformers_int4/falcon/generate.py
@@ -43,6 +43,7 @@ if __name__ == '__main__':
     # which convert the relevant layers in the model into INT4 format
     model = AutoModelForCausalLM.from_pretrained(model_path,
                                                  load_in_4bit=True,
+                                                 torch_dtype='auto',
                                                  trust_remote_code=True)
 
     # Load tokenizer

--- a/python/llm/example/transformers/transformers_int4/internlm/generate.py
+++ b/python/llm/example/transformers/transformers_int4/internlm/generate.py
@@ -43,6 +43,7 @@ if __name__ == '__main__':
     # which convert the relevant layers in the model into INT4 format
     model = AutoModelForCausalLM.from_pretrained(model_path,
                                                  load_in_4bit=True,
+                                                 torch_dtype='auto',
                                                  trust_remote_code=True)
 
     # Load tokenizer

--- a/python/llm/example/transformers/transformers_int4/moss/generate.py
+++ b/python/llm/example/transformers/transformers_int4/moss/generate.py
@@ -41,8 +41,9 @@ if __name__ == '__main__':
     # Load model in 4 bit,
     # which convert the relevant layers in the model into INT4 format
     model = AutoModelForCausalLM.from_pretrained(model_path,
-                                                 trust_remote_code=True,
-                                                 load_in_4bit=True)
+                                                 load_in_4bit=True,
+                                                 torch_dtype='auto',
+                                                 trust_remote_code=True)
 
     # Load tokenizer
     tokenizer = AutoTokenizer.from_pretrained(model_path,

--- a/python/llm/example/transformers/transformers_int4/mpt/generate.py
+++ b/python/llm/example/transformers/transformers_int4/mpt/generate.py
@@ -43,6 +43,7 @@ if __name__ == '__main__':
     # which convert the relevant layers in the model into INT4 format
     model = AutoModelForCausalLM.from_pretrained(model_path,
                                                  load_in_4bit=True,
+                                                 torch_dtype='auto',
                                                  trust_remote_code=True)
 
     # Load tokenizer

--- a/python/llm/example/transformers/transformers_int4/phoenix/generate.py
+++ b/python/llm/example/transformers/transformers_int4/phoenix/generate.py
@@ -40,8 +40,9 @@ if __name__ == '__main__':
     # Load model in 4 bit,
     # which convert the relevant layers in the model into INT4 format
     model = AutoModelForCausalLM.from_pretrained(model_path,
-                                                 trust_remote_code=True,
-                                                 load_in_4bit=True)
+                                                 load_in_4bit=True,
+                                                 torch_dtype='auto',
+                                                 trust_remote_code=True)
 
     # Load tokenizer
     tokenizer = AutoTokenizer.from_pretrained(model_path,

--- a/python/llm/example/transformers/transformers_int4/redpajama/generate.py
+++ b/python/llm/example/transformers/transformers_int4/redpajama/generate.py
@@ -41,8 +41,8 @@ if __name__ == '__main__':
     # Load model in 4 bit,
     # which convert the relevant layers in the model into INT4 format
     model = AutoModelForCausalLM.from_pretrained(model_path,
-                                                 torch_dtype='auto',
                                                  load_in_4bit=True,
+                                                 torch_dtype='auto',
                                                  trust_remote_code=True)
 
     # Load tokenizer

--- a/python/llm/example/transformers/transformers_int4/redpajama/generate.py
+++ b/python/llm/example/transformers/transformers_int4/redpajama/generate.py
@@ -41,8 +41,9 @@ if __name__ == '__main__':
     # Load model in 4 bit,
     # which convert the relevant layers in the model into INT4 format
     model = AutoModelForCausalLM.from_pretrained(model_path,
-                                                 trust_remote_code=True,
-                                                 load_in_4bit=True)
+                                                 torch_dtype='auto',
+                                                 load_in_4bit=True,
+                                                 trust_remote_code=True)
 
     # Load tokenizer
     tokenizer = AutoTokenizer.from_pretrained(model_path,

--- a/python/llm/example/transformers/transformers_int4/starcoder/generate.py
+++ b/python/llm/example/transformers/transformers_int4/starcoder/generate.py
@@ -41,6 +41,7 @@ if __name__ == '__main__':
     # which convert the relevant layers in the model into INT4 format
     model = AutoModelForCausalLM.from_pretrained(model_path,
                                                  load_in_4bit=True,
+                                                 torch_dtype='auto',
                                                  trust_remote_code=True)
 
     # Load tokenizer

--- a/python/llm/example/transformers/transformers_int4/vicuna/generate.py
+++ b/python/llm/example/transformers/transformers_int4/vicuna/generate.py
@@ -41,7 +41,8 @@ if __name__ == '__main__':
     # Load model in 4 bit,
     # which convert the relevant layers in the model into INT4 format
     model = AutoModelForCausalLM.from_pretrained(model_path,
-                                                 load_in_4bit=True)
+                                                 load_in_4bit=True,
+                                                 torch_dtype='auto')
 
     # Load tokenizer
     tokenizer = LlamaTokenizer.from_pretrained(model_path)

--- a/python/llm/example/transformers/transformers_int4/whisper/recognize.py
+++ b/python/llm/example/transformers/transformers_int4/whisper/recognize.py
@@ -42,7 +42,8 @@ if __name__ == '__main__':
     # Load model in 4 bit,
     # which convert the relevant layers in the model into INT4 format
     model = AutoModelForSpeechSeq2Seq.from_pretrained(model_path,
-                                                      load_in_4bit=True)
+                                                      load_in_4bit=True,
+                                                      torch_dtype='auto')
     model.config.forced_decoder_ids = None
 
     # Load processor


### PR DESCRIPTION
## Description

Add `torch_dtype='auto'` when loading in 4 bit for transformers int4 examples

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/451#issuecomment-1642901502
https://huggingface.co/docs/transformers/main_classes/model#transformers.PreTrainedModel.from_pretrained.torch_dtype

If we do not specify `torch_dtype='auto'` when loading model in 4 bit, default fp32 dtype could be used instead of what is specified in model's `config.json`. That is, 16 bit model may be loaded in fp32 at first, which could lead to 4XGB memory required for XB param models.

`torch_dtype='auto'` will at first check the `torch_dtype` specified in model's `config.json` to load the model. That is, 16 bit model will be loaded in 16 bit at first, which requires 2XGB memory for XB param models (as we expected).

**We will validate the improvement of `torch_dtype='auto' for each example later**