### PR TITLE
[LLM] Set `torch_dtype` default value to `'auto'` for transformers low bit `from_pretrained` API

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -65,6 +65,8 @@ class _BaseAutoModelClass:
         if load_in_4bit or load_in_low_bit:
             # load int x-bit
             kwargs["low_cpu_mem_usage"] = True
+            # set default torch_dtype='auto'
+            kwargs["torch_dtype"] = kwargs.get("torch_dtype", 'auto')
             q_k = load_in_low_bit if load_in_low_bit else "sym_int4"
             model = cls.load_convert(q_k, *args, **kwargs)
         else:


### PR DESCRIPTION
## Description

Set `torch_dtype` default value to `'auto'` for transformers low bit `from_pretrained` API

### 1. Why the change?

https://github.com/intel-analytics/BigDL/pull/8590#issuecomment-1645109840

>https://github.com/analytics-zoo/nano/issues/451#issuecomment-1642901502
> https://huggingface.co/docs/transformers/main_classes/model#transformers.PreTrainedModel.from_pretrained.torch_dtype
>
> If we do not specify torch_dtype='auto' when loading model in 4 bit, default fp32 dtype could be used instead of what is specified in model's config.json. That is, 16 bit model may be loaded in fp32 at first, which could lead to 4XGB memory required for XB param models.
>
> torch_dtype='auto' will at first check the torch_dtype specified in model's config.json to load the model. That is, 16 bit model will be loaded in 16 bit at first, which requires 2XGB memory for XB param models (as we expected).

### 2. User API changes

N/A

Just for transformers low bit `from_pretrained` API, if `load_in_4bit` or `load_in_low_bit`, set default value for `torch_dtype` to `'auto'`:

### 3. How to test?
- [x] Local test on client linux machine
