### PR TITLE
LLM: Mute shape mismatch output

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -125,6 +125,8 @@ class _BaseAutoModelClass:
 
         # Avoid KeyError
         kwargs["ignore_mismatched_sizes"] = True
+        # Avoid reading from local file at the first initialization
+        kwargs["state_dict"] = {}
 
         # Maybe needed when extract_local_archive_file
         subfolder = kwargs.get("subfolder", "")

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -18,7 +18,7 @@ import transformers
 from transformers.configuration_utils import PretrainedConfig
 from .utils import extract_local_archive_file, load_state_dict, load
 from bigdl.llm.ggml.quantize import ggml_tensor_qtype
-from bigdl.llm.utils.common import invalidInputError
+from bigdl.llm.utils.common import invalidInputError, MuteHFLogger
 
 
 def save_low_bit(self, *args, **kwargs):
@@ -132,16 +132,10 @@ class _BaseAutoModelClass:
         subfolder = kwargs.get("subfolder", "")
         variant = kwargs.get("variant", None)
 
-        import logging
-        from transformers.modeling_utils import logger
         from .convert import ggml_convert_quant
-        old_level = logger.getEffectiveLevel()
-        # Mute shape mismatch output
-        logger.setLevel(logging.ERROR)
 
-        model = cls.HF_Model.from_pretrained(*args, **kwargs)
-
-        logger.setLevel(old_level)
+        with MuteHFLogger(logger=transformers.modeling_utils.logger):
+            model = cls.HF_Model.from_pretrained(*args, **kwargs)
 
         # add save_low_bit to pretrained model dynamically
         import types

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -115,9 +115,6 @@ class _BaseAutoModelClass:
         # Speed up when loading model
         kwargs["low_cpu_mem_usage"] = True
 
-        # set default torch_dtype='auto'
-        kwargs["torch_dtype"] = kwargs.get("torch_dtype", 'auto')
-
         qtype = ggml_tensor_qtype[bigdl_transformers_low_bit]
         # Note that the int4 linear layers cannot currently
         # be recorded in huggingface Pretrained Model or AutoConfig,

--- a/python/llm/src/bigdl/llm/utils/common/__init__.py
+++ b/python/llm/src/bigdl/llm/utils/common/__init__.py
@@ -19,5 +19,5 @@
 # Otherwise there would be module not found error in non-pip's setting as Python would
 # only search the first bigdl package and end up finding only one sub-package.
 
-from .log4Error import invalidInputError, invalidOperationError
+from .log4Error import invalidInputError, invalidOperationError, MuteHFLogger
 from .lazyimport import LazyImport

--- a/python/llm/src/bigdl/llm/utils/common/log4Error.py
+++ b/python/llm/src/bigdl/llm/utils/common/log4Error.py
@@ -39,3 +39,15 @@ def invalidOperationError(condition, errMsg, fixMsg=None, cause=None):
             raise cause
         else:
             raise RuntimeError(errMsg)
+
+class MuteHFLogger():
+    def __init__(self, logger, speak_level=logging.ERROR) -> None:
+        self.logger = logger
+        self.speak_level = speak_level
+        self.old_level = logger.getEffectiveLevel()
+
+    def __enter__(self):
+        self.logger.setLevel(self.speak_level)
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.logger.setLevel(self.old_level)


### PR DESCRIPTION
## Description

In this PR we mute huggingface logger when loading int4 model for a clean output.

Before:
```log
(changmim-llm) cpx@cpx-2:~/changmin/BigDL/python/llm$ python test_memory_load.py 
Some weights of LlamaForCausalLM were not initialized from the model checkpoint at /disk1/changmin/vicuna-13b-int4 and are newly initialized because the shapes did not match:
- model.layers.0.self_attn.q_proj.weight: found shape torch.Size([13926400]) in the checkpoint and torch.Size([5120, 5120]) in the model instantiated
- model.layers.0.self_attn.k_proj.weight: found shape torch.Size([13926400]) in the checkpoint and torch.Size([5120, 5120]) in the model instantiated
- model.layers.0.self_attn.v_proj.weight: found shape torch.Size([13926400]) in the checkpoint and torch.Size([5120, 5120]) in the model instantiated
......
You should probably TRAIN this model on a down-stream task to be able to use it for predictions and inference.
time during is  14.336107730865479
```

After:
```log
(changmim-llm) cpx@cpx-2:~/changmin/BigDL/python/llm$ python test_memory_load.py 
time during is  14.293046474456787
```