### PR TITLE
[LLM] Fix test workflow workflow_call flag

### DIFF
--- a/.github/workflows/llm_unit_tests_linux.yml
+++ b/.github/workflows/llm_unit_tests_linux.yml
@@ -33,6 +33,7 @@ on:
       - '.github/actions/llm/langchain-test/action.yml'
       - '.github/actions/llm/download-llm-binary/action.yml'
   workflow_dispatch:
+  workflow_call:
 
 env:
   INT4_CKPT_DIR: ./llm/ggml-actions/stable

--- a/.github/workflows/llm_unit_tests_windows.yml
+++ b/.github/workflows/llm_unit_tests_windows.yml
@@ -19,6 +19,7 @@ on:
       - 'python/llm/**'
       - '.github/workflows/llm_unit_tests_windows.yml'
   workflow_dispatch:
+  workflow_call:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:


### PR DESCRIPTION
## Description

Add `workflow_call` flag for reusing linux/windows unittest workflow.
