### PR TITLE
[LLM] Remove concurrency group for binary build workflow

### DIFF
--- a/.github/workflows/llm-binary-build.yml
+++ b/.github/workflows/llm-binary-build.yml
@@ -3,7 +3,7 @@ name: LLM Binary Build
 # Cancel previous runs in the PR when you push new commits
 concurrency:
   group: ${{ github.workflow }}-llm-binary-build-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 # Controls when the action will run.
 on:

--- a/.github/workflows/llm-binary-build.yml
+++ b/.github/workflows/llm-binary-build.yml
@@ -1,9 +1,9 @@
 name: LLM Binary Build
 
 # Cancel previous runs in the PR when you push new commits
-concurrency:
-  group: ${{ github.workflow }}-llm-binary-build-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: false
+# concurrency:
+#   group: ${{ github.workflow }}-llm-binary-build-${{ github.event.pull_request.number || github.run_id }}
+#   cancel-in-progress: false
 
 # Controls when the action will run.
 on:


### PR DESCRIPTION
## Description

This [known issue](https://github.com/orgs/community/discussions/5435) will cause the binary build step in nightly tests to be canceled unexpectedly. We had to remove the concurrency group to ensure all binary build steps worked.
