### PR TITLE
LLM: support tensor input of native int4 `generate`

### DIFF
--- a/python/llm/src/bigdl/llm/ggml/model/generation/utils.py
+++ b/python/llm/src/bigdl/llm/ggml/model/generation/utils.py
@@ -101,9 +101,9 @@ class GenerationMixin:
 
     def generate(
         self,
-        inputs: Union[Optional[Sequence[int]],
-                      Sequence[Sequence[int]],
-                      Optional[torch.Tensor]]=None,
+        inputs: Optional[Union[Sequence[int],
+                         Sequence[Sequence[int]],
+                         torch.Tensor]]=None,
         max_new_tokens: int = 128,
         top_k: int = 40,
         top_p: float = 0.95,
@@ -118,9 +118,9 @@ class GenerationMixin:
         mirostat_eta: float = 0.1,
         stop: Optional[Union[str, List[str]]]=[],  # TODO: rebase to support stopping_criteria
         **kwargs,
-    ) -> Union[Optional[Sequence[int]],
-               Sequence[Sequence[int]],
-               None]:
+    ) -> Optional[Union[Sequence[int],
+                  Sequence[Sequence[int]],
+                  None]]:
         # TODO: modify docs
         """Create a generator of tokens from a prompt.
 

--- a/python/llm/src/bigdl/llm/ggml/model/generation/utils.py
+++ b/python/llm/src/bigdl/llm/ggml/model/generation/utils.py
@@ -22,6 +22,7 @@
 
 from typing import Optional, Union, Sequence, List
 from bigdl.llm.utils.common import invalidInputError
+import torch
 
 
 class GenerationMixin:
@@ -101,7 +102,8 @@ class GenerationMixin:
     def generate(
         self,
         inputs: Union[Optional[Sequence[int]],
-                      Sequence[Sequence[int]]]=None,
+                      Sequence[Sequence[int]],
+                      Optional[torch.Tensor]]=None,
         max_new_tokens: int = 128,
         top_k: int = 40,
         top_p: float = 0.95,
@@ -140,6 +142,8 @@ class GenerationMixin:
         Yields:
             The generated tokens.
         """
+        if isinstance(inputs, torch.Tensor):
+            inputs = inputs.tolist()
         if inputs and len(inputs) > 0:
             if not isinstance(inputs[0], Sequence):
                 inputs = [inputs]


### PR DESCRIPTION
## Description

Related to https://github.com/intel-analytics/BigDL/issues/8615.

### 1. Why the change?

Currently, our native int4 `generate` method only support int/List(int) type as input token id. 
So when use `tokens_id = tokenizer(prompt, return_tensors="pt").input_ids` which is quite common in huggingface, there exists error.
Support tensor input in this PR.

### 2. User API changes

Now, we also support usage:
```python
tokens_id = tokenizer(prompt, return_tensors="pt").input_ids # Use HuggingFace transformers tokenizer
output_tokens_id = llm.generate(tokens_id)
```

### 4. How to test?
- [x] Unit test
- [x] Local test