### PR TITLE
[LLM] Add needs flag for nightly build

### DIFF
--- a/.github/workflows/llm-nightly-test.yml
+++ b/.github/workflows/llm-nightly-test.yml
@@ -81,6 +81,8 @@ jobs:
           ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
 
   llm-inference-test-on-linux:
+    needs: llm-nightly-convert-test-avx512
     uses: ./.github/workflows/llm_unit_tests_linux.yml
   llm-inference-test-on-windows:
+    needs: llm-nightly-convert-test-avx512
     uses: ./.github/workflows/llm_unit_tests_windows.yml


### PR DESCRIPTION
## Description

* Add `needs` flag to ensure nightly build runs in the correct order
