### PR TITLE
uninstall bigdl-friesian-spark3

### DIFF
--- a/.github/actions/mac/friesian/mac-friesian-python-exampletest-tf2-pip-spark3/action.yml
+++ b/.github/actions/mac/friesian/mac-friesian-python-exampletest-tf2-pip-spark3/action.yml
@@ -8,7 +8,7 @@ runs:
       run: |
         source ~/.bash_profile
         source activate py37-tf2
-        pip uninstall -y bigdl-dllib bigdl-orca bigdl-chronos bigdl-orca-spark3 bigdl-dllib-spark3 bigdl-chronos-spark3  pyspark
+        pip uninstall -y bigdl-dllib bigdl-orca bigdl-chronos bigdl-orca-spark3 bigdl-dllib-spark3 bigdl-chronos-spark3 bigdl-friesian-spark3  pyspark
         export KERAS_BACKEND=tensorflow
         export SPARK_HOME=/opt/work/spark-3.4.1
         PATH="/usr/local/opt/gnu-tar/libexec/gnubin:$PATH"


### PR DESCRIPTION
## Description

When running [mac-friesian-python-exampletest-tf2-pip-spark3](https://github.com/intel-analytics/BigDL/tree/main/.github/actions/mac/friesian/mac-friesian-python-exampletest-tf2-pip-spark3), the package bigdl-friesian-spark3 is unable to be reinstalled, causing test execution errors.