### PR TITLE
LLM: Disable transformer api `pretraining_tp`

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -72,7 +72,7 @@ class _BaseAutoModelClass:
             kwargs["low_cpu_mem_usage"] = True
             # set default torch_dtype='auto'
             kwargs["torch_dtype"] = kwargs.get("torch_dtype", 'auto')
-            # Avoid tensor parallel F.Linear Operations 
+            # Avoid tensor parallel F.Linear Operations
             if "pretraining_tp" in config_dict:
                 kwargs["pretraining_tp"] = 0
             q_k = load_in_low_bit if load_in_low_bit else "sym_int4"

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -74,7 +74,7 @@ class _BaseAutoModelClass:
             kwargs["torch_dtype"] = kwargs.get("torch_dtype", 'auto')
             # Avoid tensor parallel F.Linear Operations
             if "pretraining_tp" in config_dict:
-                kwargs["pretraining_tp"] = 0
+                kwargs["pretraining_tp"] = 1
             q_k = load_in_low_bit if load_in_low_bit else "sym_int4"
             model = cls.load_convert(q_k, *args, **kwargs)
         else:

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -72,6 +72,9 @@ class _BaseAutoModelClass:
             kwargs["low_cpu_mem_usage"] = True
             # set default torch_dtype='auto'
             kwargs["torch_dtype"] = kwargs.get("torch_dtype", 'auto')
+            # Avoid tensor parallel F.Linear Operations 
+            if "pretraining_tp" in config_dict:
+                kwargs["pretraining_tp"] = 0
             q_k = load_in_low_bit if load_in_low_bit else "sym_int4"
             model = cls.load_convert(q_k, *args, **kwargs)
         else:


### PR DESCRIPTION
## Description

To avoid linear parallel involved F.linear operation, we turn off `pretraining_tp` in large models.
https://github.com/analytics-zoo/nano/issues/482
![Uploading image.png…]()
