### PR TITLE
install git-lfs for ppml-trusted-bigdl-llm-tdx image

### DIFF
--- a/ppml/tdx/docker/trusted-bigdl-llm/Dockerfile
+++ b/ppml/tdx/docker/trusted-bigdl-llm/Dockerfile
@@ -22,6 +22,7 @@ RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
     apt install software-properties-common libunwind8-dev vim less -y && \
     add-apt-repository ppa:deadsnakes/ppa -y && \
     apt-get install -y python3.9 git curl wget libcrypto++6 libcrypto++-dev libcrypto++-utils && \
+    apt-get install -y git-lfs && \
     rm /usr/bin/python3 && \
     ln -s /usr/bin/python3.9 /usr/bin/python3 && \
     ln -s /usr/bin/python3 /usr/bin/python && \


### PR DESCRIPTION
## Description

This submission installs git-lfs in ppml-trusted-bigdl-llm-tdx image to facilitate the download of the model in the container.