### PR TITLE
[LLM] Disable chatglm llm-cli unittest

### DIFF
--- a/.github/actions/llm/cli-test/action.yml
+++ b/.github/actions/llm/cli-test/action.yml
@@ -52,10 +52,10 @@ runs:
         
         llm-cli -t $THREAD_NUM -n 256 -x starcoder -m $STARCODER_INT4_CKPT_PATH -p 'def check_odd('
 
-    - name: Test chatglm llm-cli
-      shell: bash
-      run: |
-        source $CONDA_HOME/bin/activate bigdl-llm-test
-        $CONDA_HOME/bin/conda info
+    # - name: Test chatglm llm-cli
+    #   shell: bash
+    #   run: |
+    #     source $CONDA_HOME/bin/activate bigdl-llm-test
+    #     $CONDA_HOME/bin/conda info
         
-        llm-cli -t $THREAD_NUM -n 256 -x chatglm -m $CHATGLM_INT4_CKPT_PATH -p '你好'
+    #     llm-cli -t $THREAD_NUM -n 256 -x chatglm -m $CHATGLM_INT4_CKPT_PATH -p '你好'

--- a/.github/workflows/llm_unit_tests_linux.yml
+++ b/.github/workflows/llm_unit_tests_linux.yml
@@ -102,10 +102,10 @@ jobs:
             echo "Directory $STARCODER_INT4_CKPT_PATH not found. Downloading from FTP server..."
             wget --no-verbose $LLM_FTP_URL/${STARCODER_INT4_CKPT_PATH:2} -P $INT4_CKPT_DIR
           fi
-          if [ ! -d $CHATGLM_INT4_CKPT_PATH ]; then
-            echo "Directory $CHATGLM_INT4_CKPT_PATH not found. Downloading from FTP server..."
-            wget --no-verbose $LLM_FTP_URL/${CHATGLM_INT4_CKPT_PATH:2} -P $INT4_CKPT_DIR
-          fi
+          # if [ ! -d $CHATGLM_INT4_CKPT_PATH ]; then
+          #   echo "Directory $CHATGLM_INT4_CKPT_PATH not found. Downloading from FTP server..."
+          #   wget --no-verbose $LLM_FTP_URL/${CHATGLM_INT4_CKPT_PATH:2} -P $INT4_CKPT_DIR
+          # fi
           if [ ! -d $ORIGINAL_CHATGLM2_6B_PATH ]; then
             echo "Directory $ORIGINAL_CHATGLM2_6B_PATH not found. Downloading from FTP server..."
             wget -r -nH --no-verbose --cut-dirs=1 $LLM_FTP_URL/${ORIGINAL_CHATGLM2_6B_PATH:2} -P $LLM_DIR


### PR DESCRIPTION
## Description

Because clx lacks avx_vnni, it is necessary to disable chatglm test to ensure that unittest & nightly test can work.