### PR TITLE
fix: delete entrypoint set of base image and llm image

### DIFF
--- a/ppml/base/Dockerfile
+++ b/ppml/base/Dockerfile
@@ -133,4 +133,3 @@ RUN cd /ppml && \
 
 ENV PYTHONPATH   /usr/lib/python3.9:/usr/lib/python3.9/lib-dynload:/usr/local/lib/python3.9/dist-packages:/usr/lib/python3/dist-packages:/ppml/bigdl-ppml/src
 WORKDIR /ppml
-ENTRYPOINT [ "/bin/bash" ]

--- a/ppml/trusted-bigdl-llm/base/Dockerfile
+++ b/ppml/trusted-bigdl-llm/base/Dockerfile
@@ -52,4 +52,3 @@ RUN pip3 install -r /opt/requirements.txt && \
     rm -rf /root/BigDL
 
 WORKDIR /ppml
-ENTRYPOINT [ "/bin/bash" ]


### PR DESCRIPTION
## Description

delete entrypoint set of base image and llm image

### Result

Before this PR, `docker run -itd $DOCKER_IMAGE` works but `docker run -itd $DOCKER_IMAGE bash` doesn't. Now both work.

### Technical Details

https://stackoverflow.com/questions/21553353/what-is-the-difference-between-cmd-and-entrypoint-in-a-dockerfile
Default `entrypoint` is `/bin/sh -c` and default `CMD` is `bash`. After the docker container starts, it will execute `entrypoint`+`CMD`. The part after the docker image name of `docker run` will replace the default `CMD`. If `entrypoint` is set to `/bin/bash`, `docker run -itd $DOCKER_IMAGE bash` will cause docker to run `bash bash`.