### PR TITLE
Add usedforsecurity=False flag for test use of MD5 hash

### DIFF
--- a/python/friesian/test/bigdl/friesian/feature/test_table.py
+++ b/python/friesian/test/bigdl/friesian/feature/test_table.py
@@ -170,7 +170,7 @@ class TestTable(TestCase):
         df = spark.createDataFrame(data, schema)
         tbl = FeatureTable(df)
         hash_str = lambda x: hashlib.md5(str(x).encode('utf-8', 'strict'),
-                             usedforsecurity=False).hexdigest()
+                                         usedforsecurity=False).hexdigest()
         hash_int = lambda x: int(hash_str(x), 16) % 100
         hash_value = []
         for row in df.collect():

--- a/python/friesian/test/bigdl/friesian/feature/test_table.py
+++ b/python/friesian/test/bigdl/friesian/feature/test_table.py
@@ -169,7 +169,7 @@ class TestTable(TestCase):
                              StructField("C", IntegerType(), True)])
         df = spark.createDataFrame(data, schema)
         tbl = FeatureTable(df)
-        hash_str = lambda x: hashlib.md5(str(x).encode('utf-8', 'strict')).hexdigest()
+        hash_str = lambda x: hashlib.md5(str(x).encode('utf-8', 'strict'), usedforsecurity=False).hexdigest()
         hash_int = lambda x: int(hash_str(x), 16) % 100
         hash_value = []
         for row in df.collect():
@@ -219,7 +219,7 @@ class TestTable(TestCase):
                                     "each element in cross_col_names should be None or string"):
             tbl.cross_hash_encode([["A", "B", "C"]], [100], [0x14])
 
-        cross_hash_str = lambda x: hashlib.md5(str(x).encode('utf-8', 'strict')).hexdigest()
+        cross_hash_str = lambda x: hashlib.md5(str(x).encode('utf-8', 'strict'), usedforsecurity=False).hexdigest()
         cross_hash_int = lambda x: int(cross_hash_str(x), 16) % 100
         cross_hash_value = []
         for row in cross_hash_df.collect():

--- a/python/friesian/test/bigdl/friesian/feature/test_table.py
+++ b/python/friesian/test/bigdl/friesian/feature/test_table.py
@@ -169,7 +169,8 @@ class TestTable(TestCase):
                              StructField("C", IntegerType(), True)])
         df = spark.createDataFrame(data, schema)
         tbl = FeatureTable(df)
-        hash_str = lambda x: hashlib.md5(str(x).encode('utf-8', 'strict'), usedforsecurity=False).hexdigest()
+        hash_str = lambda x: hashlib.md5(str(x).encode('utf-8', 'strict'),
+                             usedforsecurity=False).hexdigest()
         hash_int = lambda x: int(hash_str(x), 16) % 100
         hash_value = []
         for row in df.collect():
@@ -219,7 +220,8 @@ class TestTable(TestCase):
                                     "each element in cross_col_names should be None or string"):
             tbl.cross_hash_encode([["A", "B", "C"]], [100], [0x14])
 
-        cross_hash_str = lambda x: hashlib.md5(str(x).encode('utf-8', 'strict'), usedforsecurity=False).hexdigest()
+        cross_hash_str = lambda x: hashlib.md5(str(x).encode('utf-8', 'strict'),
+                                               usedforsecurity=False).hexdigest()
         cross_hash_int = lambda x: int(cross_hash_str(x), 16) % 100
         cross_hash_value = []
         for row in cross_hash_df.collect():

--- a/python/friesian/test/bigdl/friesian/feature/test_table.py
+++ b/python/friesian/test/bigdl/friesian/feature/test_table.py
@@ -169,7 +169,7 @@ class TestTable(TestCase):
                              StructField("C", IntegerType(), True)])
         df = spark.createDataFrame(data, schema)
         tbl = FeatureTable(df)
-        hash_str = lambda x: hashlib.md5(str(x).encode('utf-8', 'strict'),
+        hash_str = lambda x: hashlib.new('md5', str(x).encode('utf-8', 'strict'),
                                          usedforsecurity=False).hexdigest()
         hash_int = lambda x: int(hash_str(x), 16) % 100
         hash_value = []
@@ -220,7 +220,7 @@ class TestTable(TestCase):
                                     "each element in cross_col_names should be None or string"):
             tbl.cross_hash_encode([["A", "B", "C"]], [100], [0x14])
 
-        cross_hash_str = lambda x: hashlib.md5(str(x).encode('utf-8', 'strict'),
+        cross_hash_str = lambda x: hashlib.new('md5', str(x).encode('utf-8', 'strict'),
                                                usedforsecurity=False).hexdigest()
         cross_hash_int = lambda x: int(cross_hash_str(x), 16) % 100
         cross_hash_value = []


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

Bandit scan has found use of weak MD5 hash, and if it's not for security use it can be allowed with `usedforsecurity=False` flag. 