### PR TITLE
[LLM] Linux vnni build with ubuntu 18.04

### DIFF
--- a/.github/workflows/llm-binary-build.yml
+++ b/.github/workflows/llm-binary-build.yml
@@ -57,7 +57,7 @@ jobs:
           apt install -y build-essential
           apt install -y gcc-11 g++-11
           # install binutils
-          if [[ "$(ld -v | awk '{print  $NF}')" != "2.36.1"]]; then
+          if [[ "$(ld -v | awk '{print  $NF}')" != "2.36.1" ]]; then
             wget http://ftp.gnu.org/gnu/binutils/binutils-2.36.1.tar.gz
             tar xzf binutils-2.36.1.tar.gz
             cd binutils-2.36.1

--- a/.github/workflows/llm-binary-build.yml
+++ b/.github/workflows/llm-binary-build.yml
@@ -34,21 +34,48 @@ jobs:
           name: linux-avxvnni
 
   linux-build-avxvnni:
-    runs-on: [self-hosted, AVX2, almalinux8]
+    runs-on: [self-hosted, AVX2, ubuntu-18.04-lts]
     needs: check-linux-avxvnni-artifact
     if: needs.check-linux-avxvnni-artifact.outputs.if-exists == 'false'
     steps:
       - name: Set access token
         run: |
           echo "github_access_token=${GITHUB_ACCESS_TOKEN}" >> "$GITHUB_ENV"
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
       - name: Install Build Environment
         shell: bash
         run: |
           export http_proxy=${HTTP_PROXY}
           export https_proxy=${HTTPS_PROXY}
-          yum install -y gcc-toolset-11 cmake git
-          conda remove -n python39 --all -y
-          conda create -n python39 python=3.9 -y
+          add-apt-repository -y ppa:git-core/ppa
+          add-apt-repository -y ppa:ubuntu-toolchain-r/test
+          apt update
+          apt install -y git
+          apt install -y build-essential
+          apt install -y gcc-11 g++-11
+          # install binutils
+          if [[ "$(ld -v | awk '{print  $NF}')" != "2.36.1"]]; then
+            wget http://ftp.gnu.org/gnu/binutils/binutils-2.36.1.tar.gz
+            tar xzf binutils-2.36.1.tar.gz
+            cd binutils-2.36.1
+            ./configure
+            make 
+            make install
+            cd ..
+          fi
+          cd ..
+          if [ -f "cmake-3.27.1-linux-x86_64.tar.gz" ]; then
+            actual_sha256=$(sha256sum "cmake-3.27.1-linux-x86_64.tar.gz" | awk '{print $1}')
+            if [ "$actual_sha256" != "9fef63e1cf87cab1153f9433045df2e43c336e462518b0f5e52d2cc91d762cff" ]; then
+              wget https://github.com/Kitware/CMake/releases/download/v3.27.1/cmake-3.27.1-linux-x86_64.tar.gz
+            fi
+          else
+            wget https://github.com/Kitware/CMake/releases/download/v3.27.1/cmake-3.27.1-linux-x86_64.tar.gz
+          fi
+          tar zxvf cmake-3.27.1-linux-x86_64.tar.gz
       - uses: actions/checkout@v3
         with:
           repository: "intel-analytics/llm.cpp"
@@ -57,8 +84,12 @@ jobs:
       - name: Build binary
         shell: bash
         run: |
-          scl enable gcc-toolset-11 "cmake -B build"
-          scl enable gcc-toolset-11 "cmake --build build --config Release"
+          cmake_path="$(pwd)/../cmake-3.27.1-linux-x86_64/bin/cmake"
+          $cmake_path -B build
+          $cmake_path --build build --config Release
+        env:
+          CC: gcc-11
+          CXX: g++-11
       - name: Move release binary
         shell: bash
         run: |
@@ -82,10 +113,13 @@ jobs:
       - name: Build Chatglm
         shell: bash
         run: |
-          source activate python39
           cd src/chatglm
-          scl enable gcc-toolset-11 "cmake -B build"
-          scl enable gcc-toolset-11 "cmake --build build --config Release"
+          cmake_path="$(pwd)/../cmake-3.27.1-linux-x86_64/bin/cmake"
+          $cmake_path -B build
+          $cmake_path --build build --config Release
+        env:
+          CC: gcc-11
+          CXX: g++-11
       - name: Move Chatglm binaries
         shell: bash
         run: |
@@ -101,7 +135,6 @@ jobs:
         shell: bash
         run: |
           make clean
-          conda remove -n python39 --all -y
 
   check-linux-avx512-artifact:
     runs-on: ubuntu-latest
@@ -125,6 +158,8 @@ jobs:
       - name: Update Git
         shell: bash
         run: |
+          export http_proxy=${HTTP_PROXY}
+          export https_proxy=${HTTPS_PROXY}
           add-apt-repository -y ppa:git-core/ppa
           apt update
           apt install -y git

--- a/.github/workflows/llm-binary-build.yml
+++ b/.github/workflows/llm-binary-build.yml
@@ -113,8 +113,8 @@ jobs:
       - name: Build Chatglm
         shell: bash
         run: |
-          cd src/chatglm
           cmake_path="$(pwd)/../cmake-3.27.1-linux-x86_64/bin/cmake"
+          cd src/chatglm
           $cmake_path -B build
           $cmake_path --build build --config Release
         env:

--- a/.github/workflows/llm-binary-build.yml
+++ b/.github/workflows/llm-binary-build.yml
@@ -75,7 +75,7 @@ jobs:
           else
             wget https://github.com/Kitware/CMake/releases/download/v3.27.1/cmake-3.27.1-linux-x86_64.tar.gz
           fi
-          tar zxvf cmake-3.27.1-linux-x86_64.tar.gz
+          tar zxf cmake-3.27.1-linux-x86_64.tar.gz
       - uses: actions/checkout@v3
         with:
           repository: "intel-analytics/llm.cpp"
@@ -186,7 +186,7 @@ jobs:
           else
             wget https://github.com/Kitware/CMake/releases/download/v3.27.1/cmake-3.27.1-linux-x86_64.tar.gz
           fi
-          tar zxvf cmake-3.27.1-linux-x86_64.tar.gz
+          tar zxf cmake-3.27.1-linux-x86_64.tar.gz
       - name: Build avx512 binary
         shell: bash
         run: |


### PR DESCRIPTION
## Description

Ubuntu 18.04 and 20.04 cannot update the binutils version when installing gcc 11, resulting in the inability to correctly compile binary files of the linux avx vnni version. 
Update the binutils version so that ubuntu 18.04 can be compiled normally.
