### PR TITLE
Enable Nano to receive memory files as input.

### DIFF
--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_bf16_model.py
@@ -103,7 +103,10 @@ class PytorchIPEXJITBF16Model(PytorchIPEXJITModel):
     @staticmethod
     def _load(path, model, inplace=False, input_sample=None):
         status = PytorchIPEXJITBF16Model._load_status(path)
-        checkpoint_path = path / status['checkpoint']
+        if isinstance(path, dict):
+            checkpoint_path = path[status['checkpoint']]
+        else:
+            checkpoint_path = path / status['checkpoint']
         if status["use_jit"]:
             if status['compression'] == "bf16":
                 invalidInputError(model is not None,

--- a/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
+++ b/python/nano/src/bigdl/nano/deps/ipex/ipex_inference_model.py
@@ -182,7 +182,10 @@ class PytorchIPEXJITModel(AcceleratedLightningModule):
     @staticmethod
     def _load(path, model, input_sample=None, inplace=False):
         status = PytorchIPEXJITModel._load_status(path)
-        checkpoint_path = path / status['checkpoint']
+        if isinstance(path, dict):
+            checkpoint_path = path[status['checkpoint']]
+        else:
+            checkpoint_path = path / status['checkpoint']
         if status["use_jit"]:
             if status['compression'] == "bf16":
                 invalidInputError(model is not None,

--- a/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
+++ b/python/nano/src/bigdl/nano/deps/neural_compressor/pytorch/quantized_model.py
@@ -71,10 +71,7 @@ class PytorchQuantizedModel(AcceleratedLightningModule):
         # so we should load weight using internal nn.Module also
         if isinstance(path, dict):
             weights_file = path['best_model.pt']
-            try:
-                stat_dict = torch.jit.load(weights_file)
-            except:
-                stat_dict = torch.load(weights_file)
+            stat_dict = torch.jit.load(weights_file)
             if isinstance(model, LightningModule) and compare_version("neural_compressor",
                                                                       operator.ge, "2.0"):
                 qmodel = PyTorchModel(load(stat_dict, model.model, example_inputs=example_inputs))

--- a/python/nano/src/bigdl/nano/utils/common/model.py
+++ b/python/nano/src/bigdl/nano/utils/common/model.py
@@ -72,9 +72,13 @@ class AcceleratedModel(ABC):
 
     @staticmethod
     def _load_status(path):
-        meta_path = Path(path) / "nano_model_meta.yml"
-        with open(meta_path, 'r') as f:
-            metadata = yaml.safe_load(f)
+        if isinstance(path, dict):
+            metadata = yaml.safe_load(path["nano_model_meta.yml"])
+            path["nano_model_meta.yml"].seek(0)
+        else:
+            meta_path = Path(path) / "nano_model_meta.yml"
+            with open(meta_path, 'r') as f:
+                metadata = yaml.safe_load(f)
         return metadata
 
     @staticmethod


### PR DESCRIPTION
## Description

Enable PytorchQuantizedModel, PytorchIPEXJITModel and PytorchIPEXJITBF16Model to receive memory files as input.

### 1. Why the change?

To avoid plain text saved on disk.

### 2. User API changes

None.

### 3. Summary of the change 

If path is a dict, get memory files directly.
