### PR TITLE
[LLM] fix bloom and starcoder memory release

### DIFF
--- a/python/llm/src/bigdl/llm/ggml/model/bloom/bloom.py
+++ b/python/llm/src/bigdl/llm/ggml/model/bloom/bloom.py
@@ -313,9 +313,6 @@ class Bloom(GenerationMixin):
                     }
                 }
 
-    def free(self):
-        bloom_free(self.ctx)
-
     def _tokenize(self, text: bytes, add_bos: bool = False) -> List[int]:
         """Tokenize a string.
 
@@ -427,3 +424,8 @@ class Bloom(GenerationMixin):
                            seed=self.seed,
                            n_threads=self.n_threads,
                            n_batch=self.n_batch)
+
+    def __del__(self):
+        if self.ctx is not None:
+            bloom_free(self.ctx)
+            self.ctx = None

--- a/python/llm/src/bigdl/llm/ggml/model/starcoder/starcoder.py
+++ b/python/llm/src/bigdl/llm/ggml/model/starcoder/starcoder.py
@@ -315,9 +315,6 @@ class Starcoder(GenerationMixin):
                         }
                     }
 
-    def free(self):
-        starcoder_free(self.ctx)
-
     def _tokenize(self, text: bytes, add_bos: bool = False) -> List[int]:
         """Tokenize a string.
 
@@ -433,3 +430,8 @@ class Starcoder(GenerationMixin):
                                seed=self.seed,
                                n_threads=self.n_threads,
                                n_batch=self.n_batch)
+
+    def __del__(self):
+        if self.ctx is not None:
+            starcoder_free(self.ctx)
+            self.ctx = None


### PR DESCRIPTION
fix this issue (https://github.com/intel-analytics/BigDL/issues/8701) in this PR and this PR (https://github.com/intel-analytics/llm.cpp/pull/49)

I have tried the code in that issue, and starcoder does release all memory, though bloom only release mostly of the memory (about 1G remains), but it is not easy to fix quickly