### PR TITLE
LLM: support stop for starcoder native int4 stream

### DIFF
--- a/python/llm/src/bigdl/llm/ggml/model/starcoder/starcoder.py
+++ b/python/llm/src/bigdl/llm/ggml/model/starcoder/starcoder.py
@@ -295,6 +295,10 @@ class Starcoder(GenerationMixin):
                 text = self.detokenize([token]).decode("utf-8", errors="ignore")
                 if text.endswith("<|endoftext|>"):
                     print('\n')
+                    return
+                elif text is not None and text in stop:
+                    print('\n')
+                    return
                 else:
                     yield {
                         "id": completion_id,


### PR DESCRIPTION
## Description

Support stop words for starcoder native int4 stream

### 1. Why the change?

Fix https://github.com/intel-analytics/BigDL/issues/8730

### 2. User API changes

No change.

### 3. Summary of the change 

Support stop words for starcoder native int4 stream

### 4. How to test?
- [x] Unit test

### sample output
## some sample output
```python
response = ""
prompt = "Write a Python function to generate the nth Fibonacci number"

for chunk in model(prompt, stream=True, max_tokens=512, stop=['<fim_prefix>', '<fim_middle>']):
    response += chunk['choices'][0]['text']

print(response)
```

```bash
.

# The Fibonacci numbers are the numbers in the following integer sequence.
# 0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, ……..

# In mathematical terms, the sequence Fn of Fibonacci numbers is defined by the recurrence relation
# Fn = Fn-1 + Fn-2 where F1 = 0 and F2 = 1.

# Example:
# Input: 4
# Output: 3
# Explanation:
# Fibonacci numbers are:
# 0, 1, 1, 2, 3, 5, 8, 13, 21, 34
# Hence, the 4th Fibonacci number is 3.

# Solution:
# 1. Recursive
# 2. Iterative
# 3. Dynamic Programming

# Recursive
class Solution:
    def fib(self, n: int) -> int:
        if n == 0:
            return 0
        if n == 1:
            return 1
        return self.fib(n-1) + self.fib(n-2)

# Iterative
class Solution:
    def fib(self, n: int) -> int:
        if n == 0:
            return 0
        if n == 1:
            return 1
        a, b = 0, 1
        for _ in range(n-1):
            a, b = b, a+b
        return b

# Dynamic Programming
class Solution:
    def fib(self, n: int) -> int:
        if n == 0:
            return 0
        if n == 1:
            return 1
        dp = [0, 1]
        for _ in range(2, n+1):
            dp.append(dp[-1] + dp[-2])
        return dp[-1]
```

