### PR TITLE
LLM: reduce 1st token latency and update example

### DIFF
--- a/python/llm/dev/benchmark/README.md
+++ b/python/llm/dev/benchmark/README.md
@@ -54,9 +54,16 @@ tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
 prompt = "今天睡不着怎么办"
  
 with torch.inference_mode():
-    input_ids = tokenizer.encode(prompt, return_tensors="pt").to('xpu')
-    output = model.generate(input_ids, do_sample=False, max_new_tokens=32)
-    output_str = tokenizer.decode(output[0], skip_special_tokens=True)
+    # wamup two times as use ipex
+    for i in range(2):
+        input_ids = tokenizer.encode(prompt, return_tensors="pt").to('xpu')
+        output = model.generate(input_ids, do_sample=False, max_new_tokens=32)
+        output_str = tokenizer.decode(output[0], skip_special_tokens=True)
+    # collect performance data now
+    for i in range(5):
+        input_ids = tokenizer.encode(prompt, return_tensors="pt").to('xpu')
+        output = model.generate(input_ids, do_sample=False, max_new_tokens=32)
+        output_str = tokenizer.decode(output[0], skip_special_tokens=True)
 ```
 Output will be like:
 ```bash

--- a/python/llm/example/transformers/transformers_int4/GPU/chatglm2/generate.py
+++ b/python/llm/example/transformers/transformers_int4/GPU/chatglm2/generate.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
                                       load_in_4bit=True,
                                       optimize_model=False,
                                       trust_remote_code=True)
-    model = model.half().to('xpu')
+    model = model.to('xpu')
 
     # Load tokenizer
     tokenizer = AutoTokenizer.from_pretrained(model_path,

--- a/python/llm/example/transformers/transformers_int4/GPU/llama2/generate.py
+++ b/python/llm/example/transformers/transformers_int4/GPU/llama2/generate.py
@@ -49,7 +49,7 @@ if __name__ == '__main__':
                                                  load_in_4bit=True,
                                                  optimize_model=False,
                                                  trust_remote_code=True)
-    model = model.half().to('xpu')
+    model = model.to('xpu')
 
     # Load tokenizer
     tokenizer = LlamaTokenizer.from_pretrained(model_path, trust_remote_code=True)

--- a/python/llm/src/bigdl/llm/transformers/linear_quant.py
+++ b/python/llm/src/bigdl/llm/transformers/linear_quant.py
@@ -244,7 +244,7 @@ class LinearQuant(nn.Linear):
             if x_2d.is_contiguous() is False:
                 x_2d = x_2d.contiguous()
             # current workaround to reduce first token latency of fp32 input
-            if x_2d.shape[0] > 1 and  x_2d.dtype == torch.float32:
+            if x_2d.shape[0] > 1 and x_2d.dtype == torch.float32:
                 x_2d = x_2d.half()
             # input format of linear_q4.forward is 1: input, 2: weight
             result = linear_q4_0.forward(x_2d, x0)

--- a/python/llm/src/bigdl/llm/transformers/linear_quant.py
+++ b/python/llm/src/bigdl/llm/transformers/linear_quant.py
@@ -161,8 +161,6 @@ class ParamsQuant(torch.nn.Parameter):
                                     _shape=self._shape,
                                     qtype=self.qtype)
             return new_param
-        # elif (device is not None and device.type == "xpu" and self.data.device.type == "xpu"):
-        #     return self.quantize(device)
         else:
             new_param = ParamsQuant(super().to(device=device,
                                                dtype=dtype,


### PR DESCRIPTION
## Description

I discovered that removing `half()` can further improve 2+ token's performance, but will hurt 1st token latency.
So here force first token use torch.float16 and update related examples.

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/411#issuecomment-1679938137

### 2. User API changes
```python
from bigdl.llm.transformers import AutoModel
model = AutoModel.from_pretrained(args.model_dir, load_in_4bit=True, optimize_model=False, trust_remote_code=True)
model = model.to('xpu')
with torch.inference_mode():
     inputs = tokenizer([prompt], return_tensors="pt").to('xpu')
     output = model.generate(**inputs, do_sample=False, max_new_tokens=32)
```

### 3. Summary of the change 

- update example about new usage
- force first token always use torch.float16
- update readme of GPU benchmark script

### 4. How to test?
- [x] Unit test
