### PR TITLE
fix decryptStream API in BigDLEncrypt

### DIFF
--- a/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/BigDLEncrypt.scala
+++ b/scala/ppml/src/main/scala/com/intel/analytics/bigdl/ppml/crypto/BigDLEncrypt.scala
@@ -279,8 +279,8 @@ class BigDLEncrypt extends Crypto {
   protected def decryptStream(
         inputStream: DataInputStream,
         outputStream: DataOutputStream): Unit = {
-    val header = read(inputStream, 400)
-    verifyHeader(header)
+    val (_, initializationVector) = getHeader(inputStream)
+    verifyHeader(initializationVector)
     while (inputStream.available() != 0) {
       val decrypted = decryptPart(inputStream, byteBuffer)
       outputStream.write(decrypted)


### PR DESCRIPTION
## Description

as above

### 1. Why the change?

#8694 

### 2. User API changes

no

### 3. Summary of the change 

fix wrong usage of BigDLEncyrpt in decryptStream API

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...
