### PR TITLE
[LLM] Support Arc q8_0

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/linear_quant.py
+++ b/python/llm/src/bigdl/llm/transformers/linear_quant.py
@@ -245,7 +245,7 @@ class LinearQuant(nn.Linear):
             if x_2d.is_contiguous() is False:
                 x_2d = x_2d.contiguous()
             # input format of linear_q4.forward is 1: input, 2: weight
-            result = linear_q4_0.forward(x_2d, x0)
+            result = linear_q4_0.forward(x_2d, x0, self.qtype)
             new_shape = x_shape[:-1] + (self.out_len,)
             result = result.view(new_shape)
             if self.bias is not None:


### PR DESCRIPTION
## Description

Support Arc q8_0.

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

```python
model_path = "/mnt/disk1/models/Llama-2-7b-chat-hf"
llama_model = AutoModelForCausalLM.from_pretrained(model_path, optimize_model=False, load_in_low_bit="sym_int8")
llama_model = llama_model.to('xpu')
```


### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...