### PR TITLE
Re organize llm test

### DIFF
--- a/.github/workflows/llm-nightly-test.yml
+++ b/.github/workflows/llm-nightly-test.yml
@@ -79,3 +79,6 @@ jobs:
   llm-inference-test-on-windows:
     needs: llm-nightly-convert-test-avx512
     uses: ./.github/workflows/llm-nightly-test-windows.yml
+  llm-example-test:
+    needs: llm-nightly-convert-test-avx512
+    uses: ./.github/workflows/llm_example_tests.yml

--- a/.github/workflows/llm_example_tests.yml
+++ b/.github/workflows/llm_example_tests.yml
@@ -7,8 +7,8 @@ concurrency:
 
 # Controls when the action will run. 
 on:
-  schedule:
-    - cron: '00 13 * * *' # GMT time, 13:00 GMT == 21:00 China
+  # schedule:
+  #   - cron: '00 13 * * *' # GMT time, 13:00 GMT == 21:00 China
   pull_request:
     branches: [ main ]
     paths:


### PR DESCRIPTION
This submission adds llm-example-test into llm-nightly-test.yml so that we only need to monitor the status of llm-nightly-test.yml every workday.
