### PR TITLE
Nano: update setup version of xpu

### DIFF
--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -126,11 +126,14 @@ def setup_package():
                             "torchvision==0.14.1",
                             "intel_extension_for_pytorch==1.13.100;platform_system=='Linux'"]
 
-    # This is for xpu support (currently we only support 1.13)
-    # should be installed with -f https://developer.intel.com/ipex-whl-stable-xpu
-    pytorch_113_xpu_requires = ["torch==1.13.0a0",
+    # xpu should be installed with -f https://developer.intel.com/ipex-whl-stable-xpu
+    pytorch_113_xpu_requires = ["torch==1.13.0a0+git6c9b55e",
                                 "torchvision==0.14.1a0",
-                                "intel_extension_for_pytorch==1.13.10+xpu;platform_system=='Linux'"]
+                                "intel_extension_for_pytorch==1.13.120+xpu;platform_system=='Linux'"]
+
+    pytorch_20_xpu_requires = ["torch==2.0.1a0",
+                               "torchvision==0.15.2a0",
+                               "intel_extension_for_pytorch==2.0.110+xpu;platform_system=='Linux'"]
 
     pytorch_112_requires = ["torch==1.12.1",
                             "torchvision==0.13.1",
@@ -226,6 +229,7 @@ def setup_package():
                         "pytorch_111": pytorch_111_requires,
                         "pytorch_110": pytorch_110_requires,
                         "pytorch_113_xpu": pytorch_113_xpu_requires,
+                        "pytorch_20_xpu": pytorch_20_xpu_requires,
                         "pytorch_nightly": pytorch_nightly_requires,
                         "inference": inference_requires},
         package_data={"bigdl.nano": package_data},

--- a/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_gpu.ipynb
+++ b/python/nano/tutorial/notebook/inference/pytorch/accelerate_pytorch_inference_gpu.ipynb
@@ -66,7 +66,7 @@
    },
    "outputs": [],
    "source": [
-    "pip install --pre bigdl-nano[pytorch_113_xpu] -f https://developer.intel.com/ipex-whl-stable-xpu # prepare proper nano environment and its dependencies\n",
+    "pip install --pre bigdl-nano[pytorch_20_xpu] -f https://developer.intel.com/ipex-whl-stable-xpu # prepare proper nano environment and its dependencies\n",
     "\n",
     "source bigdl-nano-init --gpu # enable nano environment"
    ]


### PR DESCRIPTION
## Description

Fix out-of-date ipex version of Nano setup.

### 1. Why the change?
https://github.com/intel-analytics/BigDL/issues/8675

### 2. User API changes

1. installation of ipex 1.13
```bash
pip install --pre bigdl-nano[pytorch_113_xpu] -f https://developer.intel.com/ipex-whl-stable-xpu
source bigdl-nano-init --gpu
```
2. installation of ipex 2.0
```bash
pip install --pre bigdl-nano[pytorch_20_xpu] -f https://developer.intel.com/ipex-whl-stable-xpu
source bigdl-nano-init --gpu
```

### 3. Summary of the change 

- Fix out-of-date ipex version of Nano setup
- Support xpu 2.0 in Nano installation

### 4. How to test?
- [x] Unit test

