### PR TITLE
[LLM] Support the rest of AutoXXX classes in Transformers API

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/__init__.py
+++ b/python/llm/src/bigdl/llm/transformers/__init__.py
@@ -15,5 +15,9 @@
 #
 
 from .convert import ggml_convert_quant
-from .model import AutoModelForCausalLM, AutoModel, AutoModelForSeq2SeqLM, AutoModelForSpeechSeq2Seq
+from .model import AutoModelForCausalLM, AutoModel, AutoModelForSeq2SeqLM, \
+        AutoModelForSpeechSeq2Seq, AutoModelForQuestionAnswering, \
+        AutoModelForSequenceClassification, AutoModelForMaskedLM, \
+        AutoModelForNextSentencePrediction, AutoModelForMultipleChoice, \
+        AutoModelForTokenClassification
 from .modelling_bigdl import *

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -226,24 +226,24 @@ class AutoModelForSeq2SeqLM(_BaseAutoModelClass):
 
 
 class AutoModelForSequenceClassification(_BaseAutoModelClass):
-    HF_MODEL = transformers.AutoModelForSequenceClassification
+    HF_Model = transformers.AutoModelForSequenceClassification
 
 
 class AutoModelForMaskedLM(_BaseAutoModelClass):
-    HF_MODEL = transformers.AutoModelForMaskedLM
+    HF_Model = transformers.AutoModelForMaskedLM
 
 
 class AutoModelForQuestionAnswering(_BaseAutoModelClass):
-    HF_MODEL = transformers.AutoModelForQuestionAnswering
+    HF_Model = transformers.AutoModelForQuestionAnswering
 
 
 class AutoModelForNextSentencePrediction(_BaseAutoModelClass):
-    HF_MODEL = transformers.AutoModelForNextSentencePrediction
+    HF_Model = transformers.AutoModelForNextSentencePrediction
 
 
 class AutoModelForMultipleChoice(_BaseAutoModelClass):
-    HF_MODEL = transformers.AutoModelForMultipleChoice
+    HF_Model = transformers.AutoModelForMultipleChoice
 
 
 class AutoModelForTokenClassification(_BaseAutoModelClass):
-    HF_MODEL = transformers.AutoModelForTokenClassification
+    HF_Model = transformers.AutoModelForTokenClassification

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -223,3 +223,27 @@ class AutoModelForSpeechSeq2Seq(_BaseAutoModelClass):
 
 class AutoModelForSeq2SeqLM(_BaseAutoModelClass):
     HF_Model = transformers.AutoModelForSeq2SeqLM
+
+
+class AutoModelForSequenceClassification(_BaseAutoModelClass):
+    HF_MODEL = transformers.AutoModelForSequenceClassification
+
+
+class AutoModelForMaskedLM(_BaseAutoModelClass):
+    HF_MODEL = transformers.AutoModelForMaskedLM
+
+
+class AutoModelForQuestionAnswering(_BaseAutoModelClass):
+    HF_MODEL = transformers.AutoModelForQuestionAnswering
+
+
+class AutoModelForNextSentencePrediction(_BaseAutoModelClass):
+    HF_MODEL = transformers.AutoModelForNextSentencePrediction
+
+
+class AutoModelForMultipleChoice(_BaseAutoModelClass):
+    HF_MODEL = transformers.AutoModelForMultipleChoice
+
+
+class AutoModelForTokenClassification(_BaseAutoModelClass):
+    HF_MODEL = transformers.AutoModelForTokenClassification


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

#### AutoModelForQuestionAnswering
```python
model_path = "/path/to/the/finetuned/bloom-7b1-qa"  #should use the fine-tuned models
model = AutoModelForQuestionAnswering.from_pretrained(model_path,
                                                      load_in_4bit=True,
                                                      trust_remote_code=True)
tokenizer = AutoTokenizer.from_pretrained(model_path)

question = "How many programming languages does BLOOM support?"
context = "BLOOM has 176 billion parameters and can generate text in 46 languages natural languages and 13 programming languages."

inputs = tokenizer(question, context, return_tensors="pt")
with torch.no_grad():
    outputs = model(**inputs)

answer_start_index = outputs.start_logits.argmax()
answer_end_index = outputs.end_logits.argmax()

predict_answer_tokens = inputs.input_ids[0, answer_start_index : answer_end_index + 1]
answer = tokenizer.decode(predict_answer_tokens)
print(answer)
```

#### AutoModelForSequenceClassification
```python
import torch
from transformers import AutoTokenizer
from bigdl.llm.transformers import AutoModelForSequenceClassification

checkpoint = "distilbert-base-uncased-finetuned-sst-2-english"
model = AutoModelForSequenceClassification.from_pretrained(checkpoint, load_in_4bit=True)
tokenizer = AutoTokenizer.from_pretrained(checkpoint)

raw_inputs = [
    "I've been waiting for a HuggingFace course my whole life.",
    "I hate this so much!",
]
inputs = tokenizer(raw_inputs, padding=True, truncation=True, return_tensors="pt")
print(inputs)

outputs = model(**inputs)
print(outputs.logits.shape)
print(outputs.logits)

predictions = torch.nn.functional.softmax(outputs.logits, dim=-1)
print(predictions)
```

#### AutoModelForMaskedLM
```python
from transformers import AutoTokenizer
import torch
from bigdl.llm.transformers import AutoModelForMaskedLM

model_path = "distilbert-base-uncased"
tokenizer = AutoTokenizer.from_pretrained(model_path)

model = AutoModelForMaskedLM.from_pretrained(model_path, load_in_4bit=True) 

inputs = tokenizer("The internet [MASK] amazing.", return_tensors="pt")


with torch.no_grad():
    logits = model(**inputs).logits

# retrieve index of [MASK]
mask_token_index = (inputs.input_ids == tokenizer.mask_token_id)[0].nonzero(as_tuple=True)[0]

predicted_token_id = logits[0, mask_token_index].argmax(axis=-1)
output = tokenizer.decode(predicted_token_id)
print(output) 
```

#### AutoModelForNextSentencePrediction
```python
from transformers import AutoTokenizer
import torch
from bigdl.llm.transformers import AutoModelForNextSentencePrediction

model_path = "bert-base-uncased"
tokenizer = AutoTokenizer.from_pretrained(model_path)
model = AutoModelForNextSentencePrediction.from_pretrained(model_path, load_in_4bit=True)

prompt = "In Italy, pizza served in formal settings, such as at a restaurant, is presented unsliced."
next_sentence = "The sky is blue due to the shorter wavelength of blue light."
encoding = tokenizer(prompt, next_sentence, return_tensors="pt")

outputs = model(**encoding, labels=torch.LongTensor([1]))
logits = outputs.logits
assert logits[0, 0] < logits[0, 1]  # next sentence was random
```

#### AutoModelForMultipleChoice
```python
from transformers import AutoTokenizer
from bigdl.llm.transformers import AutoModelForMultipleChoice
import torch

model_path = "bert-base-uncased"
tokenizer = AutoTokenizer.from_pretrained(model_path)
model = AutoModelForMultipleChoice.from_pretrained(model_path, load_in_4bit=True)

prompt = "In Italy, pizza served in formal settings, such as at a restaurant, is presented unsliced."
choice0 = "It is eaten with a fork and a knife."
choice1 = "It is eaten while held in the hand."
labels = torch.tensor(0).unsqueeze(0)  # choice0 is correct (according to Wikipedia ;)), batch size 1

encoding = tokenizer([prompt, choice0], [prompt, choice1], return_tensors="pt", padding=True)
outputs = model(**{k: v.unsqueeze(0) for k, v in encoding.items()}, labels=labels)  # batch size is 1

# the linear classifier still needs to be trained
loss = outputs.loss
logits = outputs.logits
predicted_class = logits.argmax().item()
print(predicted_class)
```

#### AutoModelForTokenClassification
```python
from transformers import AutoTokenizer
from bigdl.llm.transformers import AutoModelForTokenClassification
import torch

model_path = "bigscience/bloom-560m"

tokenizer = AutoTokenizer.from_pretrained(model_path)
model = AutoModelForTokenClassification.from_pretrained(model_path, load_in_4bit=True)

inputs = tokenizer(
    "HuggingFace is a company based in Paris and New York", add_special_tokens=False, return_tensors="pt"
)

with torch.no_grad():
    logits = model(**inputs).logits

predicted_token_class_ids = logits.argmax(-1)

# Note that tokens are classified rather then input words which means that
# there might be more predicted token classes than words.
# Multiple token classes might account for the same word
predicted_tokens_classes = [model.config.id2label[t.item()] for t in predicted_token_class_ids[0]]
predicted_tokens_classes

labels = predicted_token_class_ids
loss = model(**inputs, labels=labels).loss
print(round(loss.item(), 2))
```

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
