### PR TITLE
LLM: Enable attempting loading method automatically

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -85,12 +85,13 @@ def _replace_with_quant_linear(model, qtype, modules_to_not_convert=None,
 
         # Remove the last key for recursion
         if len(list(module.children())) > 0:
-            _, has_been_replaced = _replace_with_quant_linear(
+            _, _flag = _replace_with_quant_linear(
                 module,
                 qtype,
                 modules_to_not_convert,
                 current_key_name,
             )
+            has_been_replaced = _flag or has_been_replaced
     return model, has_been_replaced
 
 

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -22,6 +22,10 @@ from .utils import extract_local_archive_file, \
 from bigdl.llm.ggml.quantize import ggml_tensor_qtype
 from bigdl.llm.utils.common import invalidInputError
 import torch
+import copy
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 def save_low_bit(self, *args, **kwargs):
@@ -98,7 +102,19 @@ class _BaseAutoModelClass:
                           f"Unknown load_in_low_bit value: {q_k}, expected:"
                           f" sym_int4, asym_int4, sym_int5, asym_int5 or sym_int8.")
         qtype = ggml_tensor_qtype[q_k]
-        model = cls.HF_Model.from_pretrained(*args, **kwargs)
+        # In case it needs a second try,
+        # `from_pretrained`` may pop items out in dict
+        # and lead to args missing.
+        _args = copy.deepcopy(args)
+        _kwargs = copy.deepcopy(kwargs)
+        try:
+            model = cls.HF_Model.from_pretrained(*args, **kwargs)
+        except NotImplementedError:
+            logger.warning("Failed to load models with `low_cpu_mem_usage` specified, "
+                           "will fall to traditional load method with higher memory consumption.")
+            _kwargs["low_cpu_mem_usage"] = False
+            model = cls.HF_Model.from_pretrained(*_args, **_kwargs)
+            model.config.update({"bigdl_lcmu_enabled": False})
         model = model.to("cpu")
         model = ggml_convert_quant(model, qtype, optimize_model)
         model.config.update({"bigdl_transformers_low_bit": q_k})
@@ -151,6 +167,7 @@ class _BaseAutoModelClass:
 
         config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
         bigdl_transformers_low_bit = config_dict.pop("bigdl_transformers_low_bit", False)
+        bigdl_lcmu_enabled = config_dict.pop("bigdl_lcmu_enabled", True)
 
         invalidInputError(bigdl_transformers_low_bit,
                           "Detect this model is not a low-bit model, Please use from_pretrained"
@@ -226,10 +243,15 @@ class _BaseAutoModelClass:
         init_contexts = [no_init_weights(_enable=_fast_init)]
         init_contexts.append(init_empty_weights())
 
-        with ContextManagers(init_contexts):
+        if bigdl_lcmu_enabled:
+            with ContextManagers(init_contexts):
+                model = model_class(config, *model_args, **kwargs)
+        else:
             model = model_class(config, *model_args, **kwargs)
 
-        model = ggml_convert_quant(model, qtype, optimize_model, device="meta")
+        # Loading args may differ based on their usage
+        quant_device = "meta" if bigdl_lcmu_enabled else "cpu"
+        model = ggml_convert_quant(model, qtype, optimize_model, device=quant_device)
 
         if is_sharded:
             loaded_state_dict_keys = sharded_metadata["all_checkpoint_keys"]
@@ -260,7 +282,7 @@ class _BaseAutoModelClass:
             pretrained_model_name_or_path,
             sharded_metadata=sharded_metadata,
             _fast_init=_fast_init,
-            low_cpu_mem_usage=True,
+            low_cpu_mem_usage=bigdl_lcmu_enabled,
             offload_folder=offload_folder,
             offload_state_dict=offload_state_dict,
             dtype=torch_dtype,

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -25,6 +25,7 @@ import torch
 import copy
 import logging
 
+logging.basicConfig(format='%(asctime)s - %(levelname)s - %(message)s', level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 
@@ -110,8 +111,8 @@ class _BaseAutoModelClass:
         try:
             model = cls.HF_Model.from_pretrained(*args, **kwargs)
         except NotImplementedError:
-            logger.warning("Failed to load models with `low_cpu_mem_usage` specified, "
-                           "will fall to traditional load method with higher memory consumption.")
+            logger.info("Failed to load models with `low_cpu_mem_usage` specified, "
+                        "will fall to traditional load method with higher memory consumption.")
             _kwargs["low_cpu_mem_usage"] = False
             model = cls.HF_Model.from_pretrained(*_args, **_kwargs)
             model.config.update({"bigdl_lcmu_enabled": False})


### PR DESCRIPTION
## Description

https://github.com/intel-analytics/BigDL/issues/8837#issuecomment-1696883932

We are enforcing the experimental feature "low_cpu_mem_usage" to alleviate memory pressure when loading large models. This feature avoids initializing the parameters when initializing empty model itself (by put everything on a meta device). However,  some models like the bark contains a operation named "weights_norm" , which normalizes the weights during initialization, necessitating non-empty weights. This conflicts with the design of the meta device, and this is why "low_cpu_mem_usage" doesn't work on bark.

So in this PR,  we first load model with "low_mem_cpu_usage=True", if an exception is caught, then throw a warning and proceed to handle it using the original loading method.
```log
(changmim-llm) cpx@cpx-2:/disk1/changmin/BigDL/python/llm$ python test_bark.py 
Failed to load models with `low_cpu_mem_usage` specified, will fall to traditional load method with higher memory consumption.

/disk1/changmin/BigDL/python/llm/src/bigdl/llm/transformers/convert.py:103: UserWarning: No linear modules were found in your model. This can happen for some architectures such as gpt2 that uses Conv1D instead of Linear layers. Please double check your model architecture, or submit an issue on github if you think this is a bug.
  warnings.warn(
Cost time--1:  0.009249687194824219
The attention mask and the pad token id were not set. As a consequence, you may observe unexpected behavior. Please pass your input's `attention_mask` to obtain reliable results.
Setting `pad_token_id` to `eos_token_id`:10000 for open-end generation.
Cost time--2:  36.95219945907593
Cost time:  36.9615421295166
save audio to bark_out.wav---
```