### PR TITLE
[LLM] change chatglm int4 checkpoint name

### DIFF
--- a/python/llm/src/bigdl/llm/utils/convert_chatglm.py
+++ b/python/llm/src/bigdl/llm/utils/convert_chatglm.py
@@ -413,8 +413,8 @@ def main():
         help="Model name or path used in AutoModel.from_pretrained",
     )
     parser.add_argument(
-        "-o", "--save_path", default="chatglm-ggml.bin",
-        type=Path, help="Path to save the generated GGML model"
+        "-o", "--save_path", default="",
+        type=str, help="Path to save the generated GGML model"
     )
     parser.add_argument(
         "-t",
@@ -426,6 +426,8 @@ def main():
     )
     args = parser.parse_args()
 
+    if args.save_path == "":
+        args.save_path = f"bigdl_llm_chatglm_{args.type.lower()}.bin"
     ggml_type = GGMLType[args.type.upper()]
     tokenizer = AutoTokenizer.from_pretrained(args.model_name_or_path, trust_remote_code=True)
     model = AutoModel.from_pretrained(args.model_name_or_path, trust_remote_code=True)

--- a/python/llm/src/bigdl/llm/utils/convert_util.py
+++ b/python/llm/src/bigdl/llm/utils/convert_util.py
@@ -1778,7 +1778,7 @@ def _convert_starcoder_hf_to_ggml(model_path, outfile_dir, outtype):
 
 def _convert_chatglm_hf_to_ggml(model_path, outfile_dir, outtype):
     filestem = Path(model_path).stem
-    outfile = os.path.join(outfile_dir, f"ggml-{filestem}-{outtype}.bin")
+    outfile = os.path.join(outfile_dir, f"bigdl_llm_chatglm_{outtype}.bin")
     invalidInputError(outtype in ["q4_0", "q4_1"],
                       "For now we only support quantization type 'q4_0' and 'q4_1' "
                       "in chatglm family.")


### PR DESCRIPTION
## Description

change chatglm checkpoint name, now its default name is `bigdl_llm_chatglm_<qtype>.bin`, e.g. `bigdl_llm_chatglm_q4_0.bin`

