### PR TITLE
[llm] transformer int4 windows add OMP_WAIT_POLICY

### DIFF
--- a/python/llm/src/bigdl/llm/ggml/model/llama/llama_cpp.py
+++ b/python/llm/src/bigdl/llm/ggml/model/llama/llama_cpp.py
@@ -80,6 +80,10 @@ def _load_shared_library(lib_base_name: str):
     cdll_args = dict()  # type: ignore
     # Add the library directory to the DLL search path on Windows (if needed)
     if sys.platform == "win32" and sys.version_info >= (3, 8):
+        # On windows, pytorch and our native library use different OMP, we should
+        # set OMP_WAIT_POLICY=PASSIVE to avoid OMP waiting.
+        os.environ["OMP_WAIT_POLICY"] = "PASSIVE"
+
         os.add_dll_directory(str(_base_path))
         os.environ["PATH"] = str(_base_path) + ";" + os.environ["PATH"]
         if "CUDA_PATH" in os.environ:


### PR DESCRIPTION
## Description

 transformer int4 windows add OMP_WAIT_POLICY = "PASSIVE"

### 1. Why the change?

On windows, pytorch and our native library use different OMP, we should set OMP_WAIT_POLICY=PASSIVE to avoid OMP waiting.

### 2. User API changes

None

### 3. Summary of the change 

This can get about 15-18% speed up for chatglm2 model on windows for rest tokens.

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

