### PR TITLE
[PPML] Fix tdx attest vsock port setting

### DIFF
--- a/ppml/tdx/docker/trusted-bigdl-llm-fschat/entrypoint.sh
+++ b/ppml/tdx/docker/trusted-bigdl-llm-fschat/entrypoint.sh
@@ -176,6 +176,7 @@ else
 
   if [[ $ENABLE_ATTESTATION_API = "true" ]]; then
     attest_flag="--attest"
+    echo 'port=4050' | tee /etc/tdx-attest.conf
   fi
 
   controller_address="http://$controller_host:$controller_port"


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

Add `port=4050` when attestation api is needed for tdx coco.
