### PR TITLE
[ORCA] Hot-fix pytorch ray beckend error on databricks cluster

### DIFF
--- a/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
+++ b/python/orca/src/bigdl/orca/ray/ray_on_spark_context.py
@@ -212,7 +212,7 @@ class RayServiceFuncGenerator(object):
     @staticmethod
     def start_ray_daemon(python_loc, pid_to_watch, pgid_to_kill):
         daemon_path = os.path.join(os.path.dirname(__file__), "ray_daemon.py")
-        invalidInputError(os.path.isdir(python_loc),
+        invalidInputError(os.path.exists(python_loc),
                           "python_loc should be a valid directory path.")
         invalidInputError(os.path.isdir(daemon_path),
                           "daemon_path should be a valid directory path.")


### PR DESCRIPTION
## Description
Fix https://github.com/intel-analytics/BigDL/issues/8870.

### 1. Why the change?
`python_loc` is a file but not a directory in databricks, that's the reason of this issue.

### 2. User API changes
N/A

### 3. Summary of the change 
`os.path.isdir` -> `os.path.exists`.

### 4. How to test?
- [ ] Unit test
- [ ] Application test


