### PR TITLE
[ppml] update langchain version to 0.0.246 for trusted-bigdl-llm image

### DIFF
--- a/ppml/tdx/docker/trusted-bigdl-llm/requirements.txt
+++ b/ppml/tdx/docker/trusted-bigdl-llm/requirements.txt
@@ -14,7 +14,7 @@ fastapi==0.95.2
 pydantic==1.10.8
 
 ### document qa
-langchain==0.0.240
+langchain==0.0.246
 pypdf
 chromadb==0.3.25
 


### PR DESCRIPTION
## Description
This submission is to fix CVE issue: https://github.com/intel-analytics/BigDL/issues/8885

 