### PR TITLE
[ORCA] Hot-fix ray_tune_search issue on k8s cluster

### DIFF
--- a/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
+++ b/python/orca/src/bigdl/orca/automl/search/ray_tune/ray_tune_search_engine.py
@@ -61,10 +61,13 @@ class RayTuneSearchEngine(SearchEngine):
         if ray_ctx.is_local:
             return None
         else:
-            default_remote_dir = f"hdfs:///tmp/{name}"
-            process(command=f"hadoop fs -mkdir -p {default_remote_dir}; "
-                            f"hadoop fs -chmod 777 {default_remote_dir}")
-            return default_remote_dir
+            try:
+                default_remote_dir = f"hdfs:///tmp/{name}"
+                process(command=f"hadoop fs -mkdir -p {default_remote_dir}; "
+                                f"hadoop fs -chmod 777 {default_remote_dir}")
+                return default_remote_dir
+            except Exception:
+                return None
 
     def compile(self,
                 data,


### PR DESCRIPTION
## Description
Fix issue https://github.com/intel-analytics/BigDL/issues/8895 as a temp solution, we will add support for k8s later.

### 1. Why the change?

Ray_tune_search requires to create hdfs directories on cluster, which caused error on k8s.

### 2. User API changes
N/A

### 3. Summary of the change 
When the cluster does not support `hadoop` cmd, setup `remote_directory` to None (same as local).

### 4. How to test?
- [x] Unit test
- [x] Application test
