### PR TITLE
Update bigdl logo url to the one hosted on readthedocs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <div align="center">
 
-<p align="center"> <img src="docs/readthedocs/image/bigdl_logo.jpg" height="140px"><br></p>
+<p align="center"> <img src="https://llm-assets.readthedocs.io/en/latest/_images/bigdl_logo.jpg" height="140px"><br></p>
 
 </div>
 


### PR DESCRIPTION
Preview: https://github.com/Oscilloscope98/BigDL/blob/bigdl-update-logo-hosted-readthedocs/README.md