### PR TITLE
LLM: update setup to specify bigdl-core-xe version

### DIFF
--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -259,7 +259,7 @@ def setup_package():
     xpu_requires += ["torch==2.0.1a0",
                      "torchvision==0.15.2a0",
                      "intel_extension_for_pytorch==2.0.110+xpu;platform_system=='Linux'",
-                     "bigdl-core-xe;platform_system=='Linux'"]
+                     "bigdl-core-xe==" + VERSION + ";platform_system=='Linux'"]
 
     metadata = dict(
         name='bigdl-llm',


### PR DESCRIPTION
## Description

Keep bigdl-core-xe's version is the same with bigdl-llm.

### 1. Why the change?
https://github.com/intel-analytics/BigDL/issues/8909

### 2. User API changes

No change

### 3. Summary of the change 

Keep bigdl-core-xe's version is the same with bigdl-llm.

### 4. How to test?
- [x] Unit test
- [x] Local test
