### PR TITLE
[nano] remove tensorflow dependency

### DIFF
--- a/.github/actions/nano/setup-tensorflow-env/action.yml
+++ b/.github/actions/nano/setup-tensorflow-env/action.yml
@@ -48,7 +48,7 @@ runs:
         if [ $OS = "centos" ]; then
           source $CONDA_HOME/bin/activate nano-tensorflow
         fi
-        pip install intel-tensorflow==2.10.0 tf2onnx==1.13.0
+        pip install intel-tensorflow==2.9.1 tf2onnx==1.13.0
         if [ $IS_PR = "false" ]; then
           pip install --pre --upgrade bigdl-nano[inference]
         else

--- a/.github/actions/nano/setup-tensorflow-env/action.yml
+++ b/.github/actions/nano/setup-tensorflow-env/action.yml
@@ -48,14 +48,15 @@ runs:
         if [ $OS = "centos" ]; then
           source $CONDA_HOME/bin/activate nano-tensorflow
         fi
+        pip install -y intel-tensorflow==2.10.0 tf2onnx==1.13.0
         if [ $IS_PR = "false" ]; then
-          pip install --pre --upgrade bigdl-nano[tensorflow,inference]
+          pip install --pre --upgrade bigdl-nano[inference]
         else
           pip install wheel
           if [ ! $OS = "windows" ]; then
-            bash python/nano/dev/build_and_install.sh linux default false tensorflow,inference
+            bash python/nano/dev/build_and_install.sh linux default false inference
           else
-            bash python/nano/dev/build_and_install.sh windows default false tensorflow,inference
+            bash python/nano/dev/build_and_install.sh windows default false inference
           fi
         fi
         if [ $OS = "centos" ]; then

--- a/.github/actions/nano/setup-tensorflow-env/action.yml
+++ b/.github/actions/nano/setup-tensorflow-env/action.yml
@@ -48,7 +48,7 @@ runs:
         if [ $OS = "centos" ]; then
           source $CONDA_HOME/bin/activate nano-tensorflow
         fi
-        pip install -y intel-tensorflow==2.10.0 tf2onnx==1.13.0
+        pip install intel-tensorflow==2.10.0 tf2onnx==1.13.0
         if [ $IS_PR = "false" ]; then
           pip install --pre --upgrade bigdl-nano[inference]
         else

--- a/.github/workflows/nano_howto_guides_tests.yml
+++ b/.github/workflows/nano_howto_guides_tests.yml
@@ -120,7 +120,7 @@ jobs:
           $CONDA/bin/conda create -n howto-guides-inference-tensorflow -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate howto-guides-inference-tensorflow
           $CONDA/bin/conda info
-          pip install intel-tensorflow==2.10.0 tf2onnx==1.13.0
+          pip install intel-tensorflow==2.9.1 tf2onnx==1.13.0
           bash python/nano/dev/build_and_install.sh linux default false inference
           source bigdl-nano-init
           pip install pytest nbmake
@@ -137,7 +137,7 @@ jobs:
           $CONDA/bin/conda create -n howto-guides-training-tensorflow -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate howto-guides-training-tensorflow
           $CONDA/bin/conda info
-          pip install intel-tensorflow==2.10.0 tf2onnx==1.13.0
+          pip install iintel-tensorflow==2.9.1 tf2onnx==1.13.0
           bash python/nano/dev/build_and_install.sh linux default false basic
           source bigdl-nano-init
           pip install pytest nbmake

--- a/.github/workflows/nano_howto_guides_tests.yml
+++ b/.github/workflows/nano_howto_guides_tests.yml
@@ -137,7 +137,7 @@ jobs:
           $CONDA/bin/conda create -n howto-guides-training-tensorflow -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate howto-guides-training-tensorflow
           $CONDA/bin/conda info
-          pip install iintel-tensorflow==2.9.1 tf2onnx==1.13.0
+          pip install intel-tensorflow==2.9.1 tf2onnx==1.13.0
           bash python/nano/dev/build_and_install.sh linux default false basic
           source bigdl-nano-init
           pip install pytest nbmake

--- a/.github/workflows/nano_howto_guides_tests.yml
+++ b/.github/workflows/nano_howto_guides_tests.yml
@@ -4,7 +4,7 @@ name: Nano Unit Tests for How-To Guides Notebooks
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
-  
+
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
@@ -120,7 +120,8 @@ jobs:
           $CONDA/bin/conda create -n howto-guides-inference-tensorflow -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate howto-guides-inference-tensorflow
           $CONDA/bin/conda info
-          bash python/nano/dev/build_and_install.sh linux default false tensorflow,inference
+          pip install intel-tensorflow==2.10.0 tf2onnx==1.13.0
+          bash python/nano/dev/build_and_install.sh linux default false inference
           source bigdl-nano-init
           pip install pytest nbmake
           pip install ipykernel==5.5.6
@@ -136,7 +137,8 @@ jobs:
           $CONDA/bin/conda create -n howto-guides-training-tensorflow -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate howto-guides-training-tensorflow
           $CONDA/bin/conda info
-          bash python/nano/dev/build_and_install.sh linux default false tensorflow
+          pip install intel-tensorflow==2.10.0 tf2onnx==1.13.0
+          bash python/nano/dev/build_and_install.sh linux default false basic
           source bigdl-nano-init
           pip install pytest nbmake
           pip install ipykernel==5.5.6

--- a/.github/workflows/nano_notebooks_tests.yml
+++ b/.github/workflows/nano_notebooks_tests.yml
@@ -157,7 +157,7 @@ jobs:
         run: |
           $CONDA/bin/conda create -n example-tensorflow -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate example-tensorflow
-          pip install intel-tensorflow==2.10.0 tf2onnx==1.13.0
+          pip install intel-tensorflow==2.9.1 tf2onnx==1.13.0
           bash python/nano/dev/build_and_install.sh linux default false inference
           pip install tensorflow-datasets==4.4.0
           pip install protobuf==3.19.5
@@ -178,7 +178,7 @@ jobs:
             $CONDA/bin/conda create -n notebooks-tutorial-tensorflow -y python==3.8.16 setuptools=58.0.4
             source $CONDA/bin/activate notebooks-tutorial-tensorflow
             $CONDA/bin/conda info
-            pip install intel-tensorflow==2.10.0 tf2onnx==1.13.0
+            pip install intel-tensorflow==2.9.1 tf2onnx==1.13.0
             bash python/nano/dev/build_and_install.sh linux default false inference
             source bigdl-nano-init
             pip install pytest nbmake

--- a/.github/workflows/nano_notebooks_tests.yml
+++ b/.github/workflows/nano_notebooks_tests.yml
@@ -4,7 +4,7 @@ name: Nano Unit Tests for Notebooks
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: true
-  
+
 # Controls when the workflow will run
 on:
   # Triggers the workflow on push or pull request events but only for the main branch
@@ -128,7 +128,7 @@ jobs:
             source $CONDA/bin/deactivate
             $CONDA/bin/conda remove -n notebooks-tutorial-pytorch --all
         env:
-            ANALYTICS_ZOO_ROOT: ${{ github.workspace }}  
+            ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
 
   nano-notebooks-tensorflow-test:
     # The type of runner that the job will run on
@@ -157,7 +157,8 @@ jobs:
         run: |
           $CONDA/bin/conda create -n example-tensorflow -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate example-tensorflow
-          bash python/nano/dev/build_and_install.sh linux default false tensorflow,inference
+          pip install intel-tensorflow==2.10.0 tf2onnx==1.13.0
+          bash python/nano/dev/build_and_install.sh linux default false inference
           pip install tensorflow-datasets==4.4.0
           pip install protobuf==3.19.5
           pip install tensorflow-metadata==1.13.0
@@ -177,7 +178,8 @@ jobs:
             $CONDA/bin/conda create -n notebooks-tutorial-tensorflow -y python==3.8.16 setuptools=58.0.4
             source $CONDA/bin/activate notebooks-tutorial-tensorflow
             $CONDA/bin/conda info
-            bash python/nano/dev/build_and_install.sh linux default false tensorflow,inference
+            pip install intel-tensorflow==2.10.0 tf2onnx==1.13.0
+            bash python/nano/dev/build_and_install.sh linux default false inference
             source bigdl-nano-init
             pip install pytest nbmake
             pip install jupyter nbconvert
@@ -211,8 +213,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade setuptools==58.0.4
-          python -m pip install --upgrade wheel  
-    
+          python -m pip install --upgrade wheel
+
       - name: Run tutorial notebooks OpenVINO unit tests
         shell: bash
         run: |

--- a/.github/workflows/nano_unit_tests_tensorflow.yml
+++ b/.github/workflows/nano_unit_tests_tensorflow.yml
@@ -121,7 +121,7 @@ jobs:
           source $CONDA/bin/activate horovod-tf
           $CONDA/bin/conda info
           pip install ${{matrix.tf-version}} tf2onnx==1.13.0
-          bash python/nano/dev/build_and_install.sh linux default false
+          bash python/nano/dev/build_and_install.sh linux default false basic
           HOROVOD_WITH_MPI=1 HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITHOUT_PYTORCH=1 pip install --no-cache-dir horovod==0.25.0
           pip install pytest
           source bigdl-nano-init

--- a/.github/workflows/nano_unit_tests_tensorflow.yml
+++ b/.github/workflows/nano_unit_tests_tensorflow.yml
@@ -30,15 +30,15 @@ jobs:
         os: ["ubuntu-20.04"]
         python-version: ["3.8"]
         tf-version: [
-          "tensorflow_27",
-          "tensorflow_28",
-          "tensorflow_29",
-          "tensorflow_210",
-          "stock_tensorflow_27",
-          "stock_tensorflow_28",
-          "stock_tensorflow_29",
-          "stock_tensorflow_210"
-          ]
+          "intel-tensorflow==2.7.0",
+          "intel-tensorflow==2.8.0",
+          "intel-tensorflow==2.9.1",
+          "intel-tensorflow==2.10.0",
+          "tensorflow==2.7.4",
+          "tensorflow==2.8.4",
+          "tensorflow==2.9.3",
+          "tensorflow==2.10.1"
+        ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -61,9 +61,8 @@ jobs:
           $CONDA/bin/conda create -n nano-tensorflow -y python==3.8.16
           source $CONDA/bin/activate nano-tensorflow
           $CONDA/bin/conda info
-          if [ ! -z "${{matrix.tf-version}}" ]; then
-            bash python/nano/dev/build_and_install.sh linux default false ${{matrix.tf-version}}
-          fi
+          pip install ${{matrix.tf-version}} tf2onnx==1.13.0
+          bash python/nano/dev/build_and_install.sh linux default false basic
           pip install pytest
           source bigdl-nano-init
           bash python/nano/test/run-nano-tf-train-tests.sh
@@ -78,9 +77,8 @@ jobs:
           $CONDA/bin/conda create -n nano-tensorflow -y python==3.8.16
           source $CONDA/bin/activate nano-tensorflow
           $CONDA/bin/conda info
-          if [ ! -z "${{matrix.tf-version}}" ]; then
-            bash python/nano/dev/build_and_install.sh linux default false ${{matrix.tf-version}},inference
-          fi
+          pip install ${{matrix.tf-version}} tf2onnx==1.13.0
+          bash python/nano/dev/build_and_install.sh linux default false inference
           pip install pytest
           source bigdl-nano-init
           bash python/nano/test/run-nano-tf-inference-tests.sh
@@ -98,15 +96,15 @@ jobs:
         os: ["ubuntu-20.04"]
         python-version: ["3.7"]
         tf-version: [
-          "tensorflow_27",
-          "tensorflow_28",
-          "tensorflow_29",
-          "tensorflow_210",
-          "stock_tensorflow_27",
-          "stock_tensorflow_28",
-          "stock_tensorflow_29",
-          "stock_tensorflow_210"
-          ]
+          "intel-tensorflow==2.7.0",
+          "intel-tensorflow==2.8.0",
+          "intel-tensorflow==2.9.1",
+          "intel-tensorflow==2.10.0",
+          "tensorflow==2.7.4",
+          "tensorflow==2.8.4",
+          "tensorflow==2.9.3",
+          "tensorflow==2.10.1"
+        ]
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
@@ -122,9 +120,8 @@ jobs:
           $CONDA/bin/conda create -n horovod-tf -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate horovod-tf
           $CONDA/bin/conda info
-          if [ ! -z "${{matrix.tf-version}}" ]; then
-            bash python/nano/dev/build_and_install.sh linux default false ${{matrix.tf-version}}
-          fi
+          pip install ${{matrix.tf-version}} tf2onnx==1.13.0
+          bash python/nano/dev/build_and_install.sh linux default false
           HOROVOD_WITH_MPI=1 HOROVOD_WITH_TENSORFLOW=1 HOROVOD_WITHOUT_PYTORCH=1 pip install --no-cache-dir horovod==0.25.0
           pip install pytest
           source bigdl-nano-init
@@ -140,9 +137,8 @@ jobs:
           $CONDA/bin/conda create -n ray-tf -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate ray-tf
           $CONDA/bin/conda info
-          if [ ! -z "${{matrix.tf-version}}" ]; then
-            bash python/nano/dev/build_and_install.sh linux default false ${{matrix.tf-version}}
-          fi
+          pip install ${{matrix.tf-version}} tf2onnx==1.13.0
+          bash python/nano/dev/build_and_install.sh linux default false basic
           pip install pytest
           # fix issue, see https://github.com/intel-analytics/BigDL/blob/main/docs/readthedocs/source/doc/Nano/Overview/known_issues.md#ray-issues
           pip install google-api-core==2.8.2
@@ -160,9 +156,8 @@ jobs:
           $CONDA/bin/conda create -n nano-automl-tf -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate nano-automl-tf
           $CONDA/bin/conda info
-          if [ ! -z "${{matrix.tf-version}}" ]; then
-            bash python/nano/dev/build_and_install.sh linux default false ${{matrix.tf-version}}
-          fi
+          pip install ${{matrix.tf-version}} tf2onnx==1.13.0
+          bash python/nano/dev/build_and_install.sh linux default false basic
           pip install pytest
           pip install ConfigSpace
           pip install 'optuna<=3.1.1'
@@ -180,9 +175,8 @@ jobs:
           $CONDA/bin/conda create -n inc-tf -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate inc-tf
           $CONDA/bin/conda info
-          if [ ! -z "${{matrix.tf-version}}" ]; then
-            bash python/nano/dev/build_and_install.sh linux default false ${{matrix.tf-version}},inference
-          fi
+          pip install ${{matrix.tf-version}} tf2onnx==1.13.0
+          bash python/nano/dev/build_and_install.sh linux default false inference
           pip install pytest
           source bigdl-nano-init
           bash python/nano/test/run-nano-tf-inc-tests.sh
@@ -197,9 +191,8 @@ jobs:
           $CONDA/bin/conda create -n openvino-tensorflow -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate openvino-tensorflow
           $CONDA/bin/conda info
-          if [ ! -z "${{matrix.tf-version}}" ]; then
-            bash python/nano/dev/build_and_install.sh linux default false ${{matrix.tf-version}},inference
-          fi
+          pip install ${{matrix.tf-version}} tf2onnx==1.13.0
+          bash python/nano/dev/build_and_install.sh linux default false inference
           pip install pytest
           source bigdl-nano-init
           bash python/nano/test/run-nano-tf-openvino-tests.sh
@@ -214,9 +207,8 @@ jobs:
           $CONDA/bin/conda create -n onnx-tensorflow -y python==3.8.16 setuptools=58.0.4
           source $CONDA/bin/activate onnx-tensorflow
           $CONDA/bin/conda info
-          if [ ! -z "${{matrix.tf-version}}" ]; then
-            bash python/nano/dev/build_and_install.sh linux default false ${{matrix.tf-version}},inference
-          fi
+          pip install ${{matrix.tf-version}} tf2onnx==1.13.0
+          bash python/nano/dev/build_and_install.sh linux default false inference
           pip install pytest
           source bigdl-nano-init
           bash python/nano/test/run-nano-tf-onnx-tests.sh

--- a/python/nano/benchmark/keras_inference_optimizer/run.sh
+++ b/python/nano/benchmark/keras_inference_optimizer/run.sh
@@ -23,7 +23,8 @@ export WORKLOAD_DIR=${NANO_BENCHMARK_DIR}/keras_inference_optimizer
 set -e
 
 # install dependencies
-bash $ANALYTICS_ZOO_ROOT/python/nano/dev/build_and_install.sh linux default false tensorflow,inference --force-reinstall
+pip install intel-tensorflow==2.10.0 tf2onnx==1.13.0
+bash $ANALYTICS_ZOO_ROOT/python/nano/dev/build_and_install.sh linux default false inference --force-reinstall
 pip install tensorboard==2.9
 
 # set nano's environment variables

--- a/python/nano/setup.py
+++ b/python/nano/setup.py
@@ -73,50 +73,6 @@ def download_libs(url: str):
 
 
 def setup_package():
-
-    # all intel-tensorflow is only avaliable for linux and windows now
-    tensorflow_27_requires = ["intel-tensorflow==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
-                              platform_system!='Darwin'",
-                              "tensorflow==2.7.0; platform_machine=='x86_64' and \
-                              platform_system=='Darwin'"]
-
-    tensorflow_28_requires = ["intel-tensorflow==2.8.0; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
-                              platform_system!='Darwin'",
-                              "tensorflow==2.8.0; platform_machine=='x86_64' and \
-                              platform_system=='Darwin'"]
-
-    tensorflow_29_requires = ["intel-tensorflow==2.9.1; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
-                              platform_system!='Darwin'",
-                              "tensorflow==2.9.0; platform_machine=='x86_64' and \
-                              platform_system=='Darwin'"]
-
-    tensorflow_210_requires = ["intel-tensorflow==2.10.0; (platform_machine=='x86_64' or platform_machine == 'AMD64') and \
-                               platform_system!='Darwin'",
-                               "tensorflow==2.10.0; platform_machine=='x86_64' and \
-                               platform_system=='Darwin'"]
-
-    # options for stock tensorflow
-    stock_tensorflow_27_requires = ["tensorflow==2.7.4; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
-
-    stock_tensorflow_28_requires = ["tensorflow==2.8.4; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
-
-    stock_tensorflow_29_requires = ["tensorflow==2.9.3; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
-
-    stock_tensorflow_210_requires = ["tensorflow==2.10.1; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
-
-    tensorflow_common_requires = ["tf2onnx==1.13.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
-
-    # default tensorflow_dep
-    tensorflow_requires = tensorflow_29_requires + tensorflow_common_requires
-    tensorflow_210_requires += tensorflow_common_requires
-    tensorflow_29_requires += tensorflow_common_requires
-    tensorflow_28_requires += tensorflow_common_requires
-    tensorflow_27_requires += tensorflow_common_requires
-    stock_tensorflow_27_requires += tensorflow_common_requires
-    stock_tensorflow_28_requires += tensorflow_common_requires
-    stock_tensorflow_29_requires += tensorflow_common_requires
-    stock_tensorflow_210_requires += tensorflow_common_requires
-
     # ipex is only avaliable for linux now
     pytorch_20_requires = ["torch==2.0.0",
                            "torchvision==0.15.1",
@@ -213,16 +169,7 @@ def setup_package():
         author_email='bigdl-user-group@googlegroups.com',
         url='https://github.com/intel-analytics/BigDL',
         install_requires=install_requires,
-        extras_require={"tensorflow": tensorflow_requires,
-                        "tensorflow_27": tensorflow_27_requires,
-                        "tensorflow_28": tensorflow_28_requires,
-                        "tensorflow_29": tensorflow_29_requires,
-                        "tensorflow_210": tensorflow_210_requires,
-                        "stock_tensorflow_27": stock_tensorflow_27_requires,
-                        "stock_tensorflow_28": stock_tensorflow_28_requires,
-                        "stock_tensorflow_29": stock_tensorflow_29_requires,
-                        "stock_tensorflow_210": stock_tensorflow_210_requires,
-                        "pytorch": pytorch_requires,
+        extras_require={"pytorch": pytorch_requires,
                         "pytorch_20": pytorch_20_requires,
                         "pytorch_113": pytorch_113_requires,
                         "pytorch_112": pytorch_112_requires,

--- a/python/requirements/nano/requirements_tensorflow.txt
+++ b/python/requirements/nano/requirements_tensorflow.txt
@@ -1,8 +1,0 @@
-# These are mirrored in python/nano/setup.py, 
-# which is what the users of the bigdl-nano[tensorflow] package will install.
-#
-# In short, if you change it here, PLEASE also change it in setup.py
-# Actrual installation logic will follow setup.py
-
-intel-tensorflow==2.9.1
-tf2onnx==1.13.0


### PR DESCRIPTION
## Description

It's hard work to support intel-tensorflow 2.12, so we remove it from our dependency, and require user to install it manually if they want to use tensorflow.

fix #8886

### 2. User API changes

`pip install bigdl-nano[tensorflow]` or command like `pip install bigdl-nano[tensorflow_27/tensorflow_28/stock_tensorflow_27/stock_tensorflow_28]` are no longer supported

### 4. How to test?
- [x] Unit test

