### PR TITLE
[LLM] Fix arc qtype != q4_0 generate issue

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -114,7 +114,10 @@ def ggml_q_format_convet_xpu2cpu(tensor: torch.Tensor, num_elem: int, qtype: int
 
     src = ctypes.c_void_p(tensor.data.data_ptr())
 
-    dst_tensor = torch.empty_like(tensor)
+    if qtype == ggml_tensor_qtype["sym_int4"]:
+        dst_tensor = torch.empty_like(tensor)
+    else:
+        return tensor
     dst = ctypes.c_void_p(dst_tensor.data.data_ptr())
     ggml.ggml_q_format_convet_xpu2cpu(src, dst, num_elem, qtype)
     return dst_tensor


### PR DESCRIPTION
## Description

If the qtype != q4_0, the current implementation will generate nothing.

### 1. Why the change?

Fix arc qtype != q4_0 generate issue.
