### PR TITLE
[LLM]Support q5_0 on arc

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -98,7 +98,6 @@ def ggml_q_format_convet_cpu2xpu(tensor: torch.Tensor, num_elem: int, qtype: int
 
     src = ctypes.c_void_p(tensor.data.data_ptr())
 
-
     if qtype == ggml_tensor_qtype["sym_int4"]:
         dst_tensor = torch.empty_like(tensor)
     elif qtype == ggml_tensor_qtype["sym_int5"]:
@@ -107,7 +106,7 @@ def ggml_q_format_convet_cpu2xpu(tensor: torch.Tensor, num_elem: int, qtype: int
         dst_size = (num_elem // QK) * block_size_in_bytes
         dst_tensor = torch.empty(dst_size, dtype=torch.uint8,
                                  device=torch.device('cpu'))
-    else: 
+    else:
         return tensor
     dst = ctypes.c_void_p(dst_tensor.data.data_ptr())
     ggml.ggml_q_format_convet_cpu2xpu(src, dst, num_elem, qtype)

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -316,7 +316,6 @@ class LowBitLinear(nn.Linear):
                 x_2d = x_2d.half()
             # input format of linear_q4.forward is 1: input, 2: weight
             result = linear_q4_0.forward_new(x_2d, x0, self.qtype)
-            # result = linear_q4_0.forward(x_2d, x0, self.qtype)
             new_shape = x_shape[:-1] + (self.out_len,)
             result = result.view(new_shape)
             if self.bias is not None:


### PR DESCRIPTION
## Description

Support q5_0 on arc.

### 1. Why the change?

Convert the q5_0 block -> q5_1 block on the CPU side for better performance.


### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
