### PR TITLE
[LLM] Fix langchain UT

### DIFF
--- a/.github/workflows/llm_unit_tests.yml
+++ b/.github/workflows/llm_unit_tests.yml
@@ -181,10 +181,8 @@ jobs:
       - name: Run LLM langchain test
         shell: bash
         run: |
-          # pip install -U langchain==0.0.184
-          # pip install -U chromadb==0.3.25
-          # pip install -U typing_extensions==4.5.0
-          pip install -U langchain==0.0.284
-          pip install -U chromadb==0.4.9
-          pip install -U pydantic==1.*
+          pip install -U langchain==0.0.184
+          pip install -U chromadb==0.3.25
+          pip install -U pandas==2.0.3
+          pip install -U typing_extensions==4.5.0
           bash python/llm/test/run-llm-langchain-tests.sh

--- a/.github/workflows/llm_unit_tests.yml
+++ b/.github/workflows/llm_unit_tests.yml
@@ -181,7 +181,10 @@ jobs:
       - name: Run LLM langchain test
         shell: bash
         run: |
-          pip install -U langchain==0.0.184
-          pip install -U chromadb==0.3.25
-          pip install -U typing_extensions==4.5.0
+          # pip install -U langchain==0.0.184
+          # pip install -U chromadb==0.3.25
+          # pip install -U typing_extensions==4.5.0
+          pip install -U langchain==0.0.284
+          pip install -U chromadb==0.4.9
+          pip install -U pydantic==1.*
           bash python/llm/test/run-llm-langchain-tests.sh

--- a/python/llm/example/langchain/README.md
+++ b/python/llm/example/langchain/README.md
@@ -10,6 +10,7 @@ Follow the instructions in [Install](https://github.com/intel-analytics/BigDL/tr
 ```bash
 pip install langchain==0.0.184
 pip install -U chromadb==0.3.25
+pip install -U pandas==2.0.3
 pip install -U typing_extensions==4.5.0
 ```
 


### PR DESCRIPTION
Langchain related ut failed: https://github.com/intel-analytics/BigDL/actions/runs/6110095180/job/16601916747#step:14:348
Reference issue: https://github.com/chroma-core/chroma/issues/1069#issuecomment-1707626341

It is due to a bug between duckdb and pandas 2.1.0. Pandas latest version is required by `chromadb 0.3.25`.

Latest `chromadb 0.4.*` dropped duckdb but [recommend Python 3.10](https://docs.trychroma.com/troubleshooting#sqlite), so I downgrade pandas to 2.0.3 for now (also in related example readme)