### PR TITLE
LLM: Fix accelerate version

### DIFF
--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -51,7 +51,8 @@ github_artifact_dir = os.path.join(llm_home, '../llm-binary')
 libs_dir = os.path.join(llm_home, "bigdl", "llm", "libs")
 CONVERT_DEP = ['numpy >= 1.22', 'torch',
                'transformers == 4.31.0', 'sentencepiece',
-               'accelerate', 'tabulate']
+               # TODO: Support accelerate 0.22.0
+               'accelerate == 0.21.0', 'tabulate']
 windows_binarys = [
     "llama.dll",
     "gptneox.dll",


### PR DESCRIPTION
## Description

https://github.com/intel-analytics/BigDL/issues/8940
We fix accelerate==0.21.0 for now and see what's going on in 0.22.