### PR TITLE
Chronos: update tensorflow installation option

### DIFF
--- a/.github/workflows/chronos-example-python-spark31.yml
+++ b/.github/workflows/chronos-example-python-spark31.yml
@@ -59,7 +59,8 @@ jobs:
           bash python/dev/release_default_linux_spark3.sh default false false
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`
-          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[tensorflow_27,pytorch,inference]
+          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[pytorch,inference]
+          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0
           pip install -i https://pypi.python.org/simple python/dllib/src/dist/bigdl_dllib_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/orca/src/dist/bigdl_orca_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/chronos/src/dist/bigdl_chronos_*-py3-none-manylinux1_x86_64.whl

--- a/.github/workflows/chronos-example-python-spark31.yml
+++ b/.github/workflows/chronos-example-python-spark31.yml
@@ -60,7 +60,7 @@ jobs:
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`
           pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[pytorch,inference]
-          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0
+          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0 tensorflow==2.7.0
           pip install -i https://pypi.python.org/simple python/dllib/src/dist/bigdl_dllib_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/orca/src/dist/bigdl_orca_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/chronos/src/dist/bigdl_chronos_*-py3-none-manylinux1_x86_64.whl

--- a/.github/workflows/chronos-howto-guides-python-spark31.yml
+++ b/.github/workflows/chronos-howto-guides-python-spark31.yml
@@ -55,7 +55,7 @@ jobs:
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`
           pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[pytorch,inference]
-          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0
+          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0 tensorflow==2.7.0
           pip install -i https://pypi.python.org/simple python/dllib/src/dist/bigdl_dllib_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/orca/src/dist/bigdl_orca_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/chronos/src/dist/bigdl_chronos_*-py3-none-manylinux1_x86_64.whl
@@ -106,7 +106,8 @@ jobs:
           bash python/dev/release_default_linux_spark3.sh default false false
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`
-          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[tensorflow,pytorch,inference]
+          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[pytorch,inference]
+          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0 tensorflow==2.7.0
           pip install -i https://pypi.python.org/simple python/dllib/src/dist/bigdl_dllib_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/orca/src/dist/bigdl_orca_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/chronos/src/dist/bigdl_chronos_*-py3-none-manylinux1_x86_64.whl

--- a/.github/workflows/chronos-howto-guides-python-spark31.yml
+++ b/.github/workflows/chronos-howto-guides-python-spark31.yml
@@ -54,7 +54,8 @@ jobs:
           bash python/dev/release_default_linux_spark3.sh default false false
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`
-          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[tensorflow_27,pytorch,inference]
+          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[pytorch,inference]
+          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0
           pip install -i https://pypi.python.org/simple python/dllib/src/dist/bigdl_dllib_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/orca/src/dist/bigdl_orca_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/chronos/src/dist/bigdl_chronos_*-py3-none-manylinux1_x86_64.whl

--- a/.github/workflows/chronos-prvn-python-spark31.yml
+++ b/.github/workflows/chronos-prvn-python-spark31.yml
@@ -61,7 +61,8 @@ jobs:
           bash python/dev/release_default_linux_spark3.sh default false false
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`
-          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[tensorflow_27,pytorch,inference]
+          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[pytorch,inference]
+          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0
           pip install -i https://pypi.python.org/simple python/dllib/src/dist/bigdl_dllib_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/orca/src/dist/bigdl_orca_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/chronos/src/dist/bigdl_chronos_*-py3-none-manylinux1_x86_64.whl
@@ -114,7 +115,8 @@ jobs:
           bash python/dev/release_default_linux_spark3.sh default false false
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`
-          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[tensorflow_27,pytorch,inference]
+          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[pytorch,inference]
+          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0
           pip install -i https://pypi.python.org/simple python/dllib/src/dist/bigdl_dllib_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/orca/src/dist/bigdl_orca_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/chronos/src/dist/bigdl_chronos_*-py3-none-manylinux1_x86_64.whl
@@ -167,7 +169,8 @@ jobs:
           bash python/dev/release_default_linux_spark3.sh default false false
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`
-          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[tensorflow_27,pytorch,inference]
+          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[pytorch,inference]
+          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0
           pip install -i https://pypi.python.org/simple python/dllib/src/dist/bigdl_dllib_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/orca/src/dist/bigdl_orca_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/chronos/src/dist/bigdl_chronos_*-py3-none-manylinux1_x86_64.whl
@@ -220,7 +223,8 @@ jobs:
           bash python/dev/release_default_linux_spark3.sh default false false
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`
-          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[tensorflow_27,pytorch,inference]
+          pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[pytorch,inference]
+          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0
           pip install -i https://pypi.python.org/simple python/dllib/src/dist/bigdl_dllib_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/orca/src/dist/bigdl_orca_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/chronos/src/dist/bigdl_chronos_*-py3-none-manylinux1_x86_64.whl

--- a/.github/workflows/chronos-prvn-python-spark31.yml
+++ b/.github/workflows/chronos-prvn-python-spark31.yml
@@ -62,7 +62,7 @@ jobs:
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`
           pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[pytorch,inference]
-          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0
+          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0 tensorflow==2.7.0
           pip install -i https://pypi.python.org/simple python/dllib/src/dist/bigdl_dllib_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/orca/src/dist/bigdl_orca_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/chronos/src/dist/bigdl_chronos_*-py3-none-manylinux1_x86_64.whl
@@ -116,7 +116,7 @@ jobs:
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`
           pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[pytorch,inference]
-          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0
+          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0 tensorflow==2.7.0
           pip install -i https://pypi.python.org/simple python/dllib/src/dist/bigdl_dllib_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/orca/src/dist/bigdl_orca_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/chronos/src/dist/bigdl_chronos_*-py3-none-manylinux1_x86_64.whl
@@ -170,7 +170,7 @@ jobs:
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`
           pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[pytorch,inference]
-          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0
+          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0 tensorflow==2.7.0
           pip install -i https://pypi.python.org/simple python/dllib/src/dist/bigdl_dllib_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/orca/src/dist/bigdl_orca_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/chronos/src/dist/bigdl_chronos_*-py3-none-manylinux1_x86_64.whl
@@ -224,7 +224,7 @@ jobs:
           bash python/nano/dev/build_and_install.sh linux default false pytorch --force-reinstall --no-deps -U
           whl_name=`ls python/nano/dist/`
           pip install -i https://pypi.python.org/simple python/nano/dist/${whl_name}[pytorch,inference]
-          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0
+          pip install -i https://pypi.python.org/simple intel-tensorflow==2.7.0 tf2onnx==1.13.0 tensorflow==2.7.0
           pip install -i https://pypi.python.org/simple python/dllib/src/dist/bigdl_dllib_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/orca/src/dist/bigdl_orca_*-py3-none-manylinux1_x86_64.whl
           pip install -i https://pypi.python.org/simple python/chronos/src/dist/bigdl_chronos_*-py3-none-manylinux1_x86_64.whl

--- a/python/chronos/src/setup.py
+++ b/python/chronos/src/setup.py
@@ -31,13 +31,18 @@ See [here](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.h
 bigdl_home = os.path.abspath(__file__ + "/../../../..")
 exclude_patterns = ["*__pycache__*", "*ipynb_checkpoints*"]
 
-VERSION = open(os.path.join(bigdl_home, 'python/version.txt'), 'r').read().strip()
+# VERSION = open(os.path.join(bigdl_home, 'python/version.txt'), 'r').read().strip()
+VERSION = '2.4.0b20230910'
 
 # Temporarily workaround to conflict on protobuf version of nano and orca
 ORCA_AUTOML_DEP = ['ray[default]==1.9.2', 'aiohttp==3.8.1', 'async-timeout==4.0.1',
                    'aioredis==1.3.1', 'hiredis==2.0.0', 'setproctitle', 'psutil',
                    'prometheus-client==0.11.0', 'protobuf==3.19.5', 'ray[tune]==1.9.2',
                    'scikit-learn', 'tensorboard']
+TF_DEP = ["intel-tensorflow==2.7.0; (platform_machine=='x86_64' or platform_machine == 'AMD64') \
+          and platform_system!='Darwin'",
+          "tensorflow==2.7.0; platform_machine=='x86_64' and platform_system=='Darwin'",
+          "tf2onnx==1.13.0; (platform_machine=='x86_64' or platform_machine == 'AMD64')"]
 
 
 def get_bigdl_packages():
@@ -70,14 +75,14 @@ def setup_package():
         install_requires=['pandas>=1.0.5, <=1.3.5', 'scikit-learn>=0.22.0, <=1.0.2',
                           'bigdl-nano==' + VERSION],
         extras_require={'pytorch': ['bigdl-nano[pytorch]==' + VERSION],
-                        'tensorflow': ['bigdl-nano[tensorflow_27]=='+VERSION],
+                        'tensorflow': ['bigdl-nano=='+VERSION] + TF_DEP,
                         'automl': ['optuna<=2.10.1', 'configspace<=0.5.0', 'SQLAlchemy<=1.4.27'],
                         'distributed:platform_system!="Windows"': ['bigdl-orca-spark3==' + VERSION,
                                                                    'grpcio==1.53.0', 'pyarrow'] +
                         ORCA_AUTOML_DEP,
                         'inference': ['bigdl-nano[inference]==' + VERSION],
                         'all': ['bigdl-nano[pytorch]==' + VERSION,
-                                'bigdl-nano[tensorflow_27]=='+VERSION,
+                                TF_DEP,
                                 'optuna<=2.10.1', 'configspace<=0.5.0', 'SQLAlchemy<=1.4.27',
                                 'bigdl-orca-spark3==' + VERSION +
                                 ';platform_system!="Windows"',

--- a/python/chronos/src/setup.py
+++ b/python/chronos/src/setup.py
@@ -31,8 +31,7 @@ See [here](https://bigdl.readthedocs.io/en/latest/doc/Chronos/Overview/chronos.h
 bigdl_home = os.path.abspath(__file__ + "/../../../..")
 exclude_patterns = ["*__pycache__*", "*ipynb_checkpoints*"]
 
-# VERSION = open(os.path.join(bigdl_home, 'python/version.txt'), 'r').read().strip()
-VERSION = '2.4.0b20230910'
+VERSION = open(os.path.join(bigdl_home, 'python/version.txt'), 'r').read().strip()
 
 # Temporarily workaround to conflict on protobuf version of nano and orca
 ORCA_AUTOML_DEP = ['ray[default]==1.9.2', 'aiohttp==3.8.1', 'async-timeout==4.0.1',


### PR DESCRIPTION
## Description

`pip install bigdl-nano[tensorflow_27]` is no longer supported after https://github.com/intel-analytics/BigDL/pull/8917
Update tensorflow installation option of Chronos

### 2. User API changes

N/A

### 4. How to test?
- [x] Unit test
