### PR TITLE
[LLM Doc] Add optimize_model doc in transformers api

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -62,8 +62,8 @@ class _BaseAutoModelClass:
                                 or sym_int8. sym_int4 means symmetric int 4, asym_int4 means
                                 asymmetric int 4, etc. Relevant low bit optimizations will
                                 be applied to the model.
-        :param optimize_model: boolean value, Whether to further optimize llm model.
-                               Default to True to optimize the model.
+        :param optimize_model: boolean value, Whether to further optimize the low_bit llm model.
+                               Default to be True.
 
         :return: a model instance
         """
@@ -137,8 +137,8 @@ class _BaseAutoModelClass:
         Load a low bit optimized model (including INT8, INT5 and INT4) from a saved ckpt.
 
         :param pretrained_model_name_or_path: str value, Path to load the optimized model ckpt.
-        :param optimize_model: boolean value, Whether to further optimize llm model.
-                               Default to True to optimize the model.
+        :param optimize_model: boolean value, Whether to further optimize the low_bit llm model.
+                               Default to be True.
 
         :return: a model instance
         """

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -54,7 +54,7 @@ class _BaseAutoModelClass:
         Load a model from a directory or the HF Hub. Use load_in_4bit or load_in_low_bit parameter
         the weight of model's linears can be loaded to low-bit format, like int4, int5 and int8.
 
-        Two new arguments are added to extend Hugging Face's from_pretrained method as follows:
+        Three new arguments are added to extend Hugging Face's from_pretrained method as follows:
 
         :param load_in_4bit: boolean value, True means load linear's weight to symmetric int 4.
         :param load_in_low_bit: str value, options are sym_int4, asym_int4, sym_int5, asym_int5
@@ -129,6 +129,13 @@ class _BaseAutoModelClass:
                      pretrained_model_name_or_path,
                      *model_args,
                      **kwargs):
+        """
+        Load a low bit optimized model (including INT8, INT5 and INT4) from a saved ckpt.
+
+        :param pretrained_model_name_or_path: str value, path to load the low bit optimized model
+                                              ckpt.
+        :param optimize_model: boolean value, Whether to further optimize llm model.
+        """
         from transformers.modeling_utils import no_init_weights, get_state_dict_dtype
         from transformers.dynamic_module_utils import resolve_trust_remote_code, \
             get_class_from_dynamic_module

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -57,7 +57,7 @@ class _BaseAutoModelClass:
         Three new arguments are added to extend Hugging Face's from_pretrained method as follows:
 
         :param load_in_4bit: boolean value, True means load linear's weight to symmetric int 4.
-                             Default to False.
+                             Default to be False.
         :param load_in_low_bit: str value, options are sym_int4, asym_int4, sym_int5, asym_int5
                                 or sym_int8. sym_int4 means symmetric int 4, asym_int4 means
                                 asymmetric int 4, etc. Relevant low bit optimizations will

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -134,7 +134,7 @@ class _BaseAutoModelClass:
                      *model_args,
                      **kwargs):
         """
-        Load a low bit optimized model (including INT8, INT5 and INT4) from a saved ckpt.
+        Load a low bit optimized model (including INT4, INT5 and INT8) from a saved ckpt.
 
         :param pretrained_model_name_or_path: str value, Path to load the optimized model ckpt.
         :param optimize_model: boolean value, Whether to further optimize the low_bit llm model.

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -57,11 +57,15 @@ class _BaseAutoModelClass:
         Three new arguments are added to extend Hugging Face's from_pretrained method as follows:
 
         :param load_in_4bit: boolean value, True means load linear's weight to symmetric int 4.
+                             Default to False.
         :param load_in_low_bit: str value, options are sym_int4, asym_int4, sym_int5, asym_int5
                                 or sym_int8. sym_int4 means symmetric int 4, asym_int4 means
                                 asymmetric int 4, etc. Relevant low bit optimizations will
                                 be applied to the model.
         :param optimize_model: boolean value, Whether to further optimize llm model.
+                               Default to True to optimize the model.
+
+        :return: a model instance
         """
         pretrained_model_name_or_path = kwargs.get("pretrained_model_name_or_path", None) \
             if len(args) == 0 else args[0]
@@ -132,9 +136,11 @@ class _BaseAutoModelClass:
         """
         Load a low bit optimized model (including INT8, INT5 and INT4) from a saved ckpt.
 
-        :param pretrained_model_name_or_path: str value, path to load the low bit optimized model
-                                              ckpt.
+        :param pretrained_model_name_or_path: str value, Path to load the optimized model ckpt.
         :param optimize_model: boolean value, Whether to further optimize llm model.
+                               Default to True to optimize the model.
+
+        :return: a model instance
         """
         from transformers.modeling_utils import no_init_weights, get_state_dict_dtype
         from transformers.dynamic_module_utils import resolve_trust_remote_code, \

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -61,6 +61,7 @@ class _BaseAutoModelClass:
                                 or sym_int8. sym_int4 means symmetric int 4, asym_int4 means
                                 asymmetric int 4, etc. Relevant low bit optimizations will
                                 be applied to the model.
+        :param optimize_model: boolean value, Whether to further optimize llm model.
         """
         pretrained_model_name_or_path = kwargs.get("pretrained_model_name_or_path", None) \
             if len(args) == 0 else args[0]


### PR DESCRIPTION
## Description
Added missing API documentation for the transformers-format API in this PR.

### 1. Why the change?
`from_pretrained` only has args and kwargs in the implementation, need to add it manually in the doc.

### 2. User API changes
N/A

### 3. Summary of the change 

Document missing args in `from_pretrained` and `load_low_bit`.

### 4. How to test?
- [x] Document test


https://optimize-model-doc.readthedocs.io/en/latest/doc/PythonAPI/LLM/transformers.html.
