### PR TITLE
LLM: add use_cache=True for all gpu examples

### DIFF
--- a/python/llm/example/gpu/hf-transformers-models/baichuan/generate.py
+++ b/python/llm/example/gpu/hf-transformers-models/baichuan/generate.py
@@ -43,7 +43,8 @@ if __name__ == '__main__':
     model = AutoModelForCausalLM.from_pretrained(model_path,
                                                  load_in_4bit=True,
                                                  optimize_model=False,
-                                                 trust_remote_code=True)
+                                                 trust_remote_code=True,
+                                                 use_cache=True)
     model = model.to('xpu')
 
     # Load tokenizer

--- a/python/llm/example/gpu/hf-transformers-models/chatglm2/generate.py
+++ b/python/llm/example/gpu/hf-transformers-models/chatglm2/generate.py
@@ -45,7 +45,8 @@ if __name__ == '__main__':
     model = AutoModel.from_pretrained(model_path,
                                       load_in_4bit=True,
                                       optimize_model=True,
-                                      trust_remote_code=True)
+                                      trust_remote_code=True,
+                                      use_cache=True)
     model = model.to('xpu')
 
     # Load tokenizer

--- a/python/llm/example/gpu/hf-transformers-models/falcon/generate.py
+++ b/python/llm/example/gpu/hf-transformers-models/falcon/generate.py
@@ -45,7 +45,8 @@ if __name__ == '__main__':
     model = AutoModelForCausalLM.from_pretrained(model_path,
                                                  load_in_4bit=True,
                                                  optimize_model=False,
-                                                 trust_remote_code=True)
+                                                 trust_remote_code=True,
+                                                 use_cache=True)
     model = model.to('xpu')
 
     # Load tokenizer

--- a/python/llm/example/gpu/hf-transformers-models/gpt-j/generate.py
+++ b/python/llm/example/gpu/hf-transformers-models/gpt-j/generate.py
@@ -43,7 +43,8 @@ if __name__ == '__main__':
     model = AutoModelForCausalLM.from_pretrained(model_path,
                                                  load_in_4bit=True,
                                                  optimize_model=False,
-                                                 trust_remote_code=True)
+                                                 trust_remote_code=True,
+                                                 use_cache=True)
     model = model.to('xpu')
     model = ipex.optimize(model.eval(), dtype="float16", inplace=True)
 

--- a/python/llm/example/gpu/hf-transformers-models/internlm/generate.py
+++ b/python/llm/example/gpu/hf-transformers-models/internlm/generate.py
@@ -44,7 +44,8 @@ if __name__ == '__main__':
     model = AutoModelForCausalLM.from_pretrained(model_path,
                                                  load_in_4bit=True,
                                                  optimize_model=False,
-                                                 trust_remote_code=True)
+                                                 trust_remote_code=True,
+                                                 use_cache=True)
     model = model.to('xpu')
 
     # Load tokenizer

--- a/python/llm/example/gpu/hf-transformers-models/llama2/generate.py
+++ b/python/llm/example/gpu/hf-transformers-models/llama2/generate.py
@@ -58,7 +58,8 @@ if __name__ == '__main__':
     model = AutoModelForCausalLM.from_pretrained(model_path,
                                                  load_in_4bit=True,
                                                  optimize_model=True,
-                                                 trust_remote_code=True)
+                                                 trust_remote_code=True,
+                                                 use_cache=True)
     model = model.to('xpu')
 
     # Load tokenizer

--- a/python/llm/example/gpu/hf-transformers-models/mpt/generate.py
+++ b/python/llm/example/gpu/hf-transformers-models/mpt/generate.py
@@ -45,7 +45,8 @@ if __name__ == '__main__':
     model = AutoModelForCausalLM.from_pretrained(model_path,
                                                  load_in_4bit=True,
                                                  optimize_model=False,
-                                                 trust_remote_code=True)
+                                                 trust_remote_code=True,
+                                                 use_cache=True)
     model = model.to('xpu')
 
     # Load tokenizer

--- a/python/llm/example/gpu/hf-transformers-models/qwen/generate.py
+++ b/python/llm/example/gpu/hf-transformers-models/qwen/generate.py
@@ -43,7 +43,8 @@ if __name__ == '__main__':
     model = AutoModelForCausalLM.from_pretrained(model_path,
                                                  load_in_4bit=True,
                                                  optimize_model=False,
-                                                 trust_remote_code=True)
+                                                 trust_remote_code=True,
+                                                 use_cache=True)
     model = model.to('xpu')
 
     # Load tokenizer

--- a/python/llm/example/gpu/hf-transformers-models/starcoder/generate.py
+++ b/python/llm/example/gpu/hf-transformers-models/starcoder/generate.py
@@ -43,7 +43,8 @@ if __name__ == '__main__':
     model = AutoModelForCausalLM.from_pretrained(model_path,
                                                  load_in_4bit=True,
                                                  optimize_model=False,
-                                                 trust_remote_code=True)
+                                                 trust_remote_code=True,
+                                                 use_cache=True)
     model = model.to('xpu')
 
     # Load tokenizer

--- a/python/llm/example/gpu/hf-transformers-models/voiceassistant/generate.py
+++ b/python/llm/example/gpu/hf-transformers-models/voiceassistant/generate.py
@@ -89,11 +89,11 @@ if __name__ == '__main__':
     processor = WhisperProcessor.from_pretrained(whisper_model_path)
 
     # generate token ids
-    whisper =  AutoModelForSpeechSeq2Seq.from_pretrained(whisper_model_path, load_in_4bit=True, optimize_model=False)
+    whisper =  AutoModelForSpeechSeq2Seq.from_pretrained(whisper_model_path, load_in_4bit=True, optimize_model=False, use_cache=True)
     whisper.config.forced_decoder_ids = None
     whisper = whisper.to('xpu')
     
-    llama_model = AutoModelForCausalLM.from_pretrained(llama_model_path, load_in_4bit=True, trust_remote_code=True, optimize_model=False)
+    llama_model = AutoModelForCausalLM.from_pretrained(llama_model_path, load_in_4bit=True, trust_remote_code=True, optimize_model=False, use_cache=True)
     llama_model = llama_model.to('xpu')
     tokenizer = LlamaTokenizer.from_pretrained(llama_model_path)
 

--- a/python/llm/example/gpu/hf-transformers-models/whisper/recognize.py
+++ b/python/llm/example/gpu/hf-transformers-models/whisper/recognize.py
@@ -45,7 +45,8 @@ if __name__ == '__main__':
     # which convert the relevant layers in the model into INT4 format
     model = AutoModelForSpeechSeq2Seq.from_pretrained(model_path,
                                                       load_in_4bit=True,
-                                                      optimize_model=False)
+                                                      optimize_model=False,
+                                                      use_cache=True)
     model.to('xpu')
     model.config.forced_decoder_ids = None
 


### PR DESCRIPTION
## Description

Specify `use_cache=True` for all gpu example in llm.

Here's the results of No `use_cache` and `use_cache=True`

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

<html>
<body>
<!--StartFragment--><span><span class="ui-provider avq avr avs avt avu avv avw avx avy avz awa awb awc awd awe awf awg awh awi awj awk awl awm awn awo awp awq awr aws awt awu awv aww awx awy" dir="ltr"><span>

  | No `use_cache` (s) | `use_cache=True` (s) |  difference (%)
-- | -- | -- | --
Baichuan | 1.5989 | 1.5985 | 0.025017
chatglm2 | 0.8534 | 0.8524 | 0.117178
falcon | 1.4458 | 1.4456 | 0.013833
gpt-j | 0.8583 | 0.8563 | 0.233019
internlm | 1.0777 | 1.077 | 0.064953
llama2 | 0.9928 | 0.9926 | 0.020145
mpt | 1.0638 | 1.0548 | 0.846024
qwen | 1.4775 | 1.4994 | -1.48223
starcoder | 1.8921 | 1.8915 | 0.031711
whisper | 1.0365 | 1.0312 | 0.511336

</span></span></span><!--EndFragment-->
</body>
</html>
<!-- Provide the related github issue link if available -->

