### PR TITLE
LLM: Save transformer models with `tie_word_embeddings=False` option

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -121,6 +121,7 @@ class _BaseAutoModelClass:
         model = model.to("cpu")
         model = ggml_convert_low_bit(model, qtype, optimize_model)
         model.config.update({"bigdl_transformers_low_bit": q_k})
+        model.config.update({"tie_word_embeddings": False})
 
         # add save_low_bit to pretrained model dynamically
         import types


### PR DESCRIPTION
## Description

For symmetrical embedding architecture, they will duplicate the input embedding matrix to output embedding, on the purpose of saving only one shard of embedding weights on disk. Since we have already resize the shape of output embedding, this 'tie_word_embeddings' operation is ineffective, and because the two embeddings' weights have already been aligned during 'from_pretrained', there is no need to perform this operation during the second load.

llama2 is not involved on this PR.:
```
-------------------- Prompt --------------------
### HUMAN:
What is AI?

### RESPONSE:

-------------------- Output --------------------
### HUMAN:
What is AI?

### RESPONSE:

AI, or artificial intelligence, refers to the ability of machines to perform tasks that would typically require human intelligence, such as learning, problem-solving,
```

related issue:
https://github.com/intel-analytics/BigDL/issues/8942
https://github.com/analytics-zoo/nano/issues/581