### PR TITLE
LLM: fix installation on windows

### DIFF
--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -50,7 +50,7 @@ llm_home = os.path.join(os.path.dirname(os.path.abspath(__file__)), "src")
 github_artifact_dir = os.path.join(llm_home, '../llm-binary')
 libs_dir = os.path.join(llm_home, "bigdl", "llm", "libs")
 CONVERT_DEP = ['numpy >= 1.22', 'torch',
-               'transformers == 4.31.0', 'sentencepiece',
+               'transformers == 4.31.0', 'sentencepiece', 'tokenizers == 0.13.3',
                # TODO: Support accelerate 0.22.0
                'accelerate == 0.21.0', 'tabulate']
 SERVING_DEP = ['fschat[model_worker, webui] == 0.2.28', 'protobuf']


### PR DESCRIPTION
## Description

related to https://github.com/intel-analytics/BigDL/issues/8962.
According to local test, we fail to install pre-released tokenizers. To fix it, specify `tokenizers==0.13.3`.

### 2. User API changes

N/A

### 4. How to test?
- [x] Unit test
- [x] Local installation test
