### PR TITLE
Add Inference CPU Dockerfile

### DIFF
--- a/docker/llm/inference/cpu/docker/Dockerfile
+++ b/docker/llm/inference/cpu/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:20.04
+
+ARG http_proxy
+ARG https_proxy
+
+# Install PYTHON 3.9
+RUN env DEBIAN_FRONTEND=noninteractive apt-get update && \
+    apt install software-properties-common libunwind8-dev vim less -y && \
+    add-apt-repository ppa:deadsnakes/ppa -y && \
+    apt-get install -y python3.9 git curl wget && \
+    rm /usr/bin/python3 && \
+    ln -s /usr/bin/python3.9 /usr/bin/python3 && \
+    ln -s /usr/bin/python3 /usr/bin/python && \
+    apt-get install -y python3-pip python3.9-dev python3-wheel python3.9-distutils && \
+    pip3 install --no-cache --upgrade requests argparse urllib3 && \
+    pip3 install --pre --upgrade bigdl-llm[all] 
+
+ENTRYPOINT ["/bin/bash"]


### PR DESCRIPTION
## Description

Add an initial Inference CPU Dockerfile so that others can work on it.

## Possible next steps

- [ ] Add `build-docker-image.sh` script
- [ ] (Optional) Add entrypoint
- [ ] Add documentation, README
- [ ] Add best config environment for using the container
