### PR TITLE
[LLM] Fix GPU performance tests

### DIFF
--- a/.github/actions/llm/setup-llm-env/action.yml
+++ b/.github/actions/llm/setup-llm-env/action.yml
@@ -11,6 +11,10 @@ runs:
     - name: Create conda env for llm tests and conduct install tests
       shell: bash
       run: |
+        # make sure we install the latest version for bigdl-core-xe
+        pip uninstall bigdl-core-xe || true
+        sed -i 's/"bigdl-core-xe==" + VERSION + "/"bigdl-core-xe/g' python/llm/setup.py
+
         pip install requests
         if [[ ${{ runner.os }} == 'Linux' ]]; then
           bash python/llm/dev/release_default_linux.sh default false


### PR DESCRIPTION
Fix LLM performance tests for GPU.
Currently, `bigdl-core-xe` cannot be successfully installed with default version `2.4.0.dev0`. We find a way to make sure latest `bigdl-core-xe`  is always installed for GPU related actions.

https://github.com/intel-analytics/BigDL/actions/runs/6222941880/job/16888205721