### PR TITLE
[LLM] Optimize kv_cache for gptj model family

### DIFF
--- a/python/llm/src/bigdl/llm/optimize.py
+++ b/python/llm/src/bigdl/llm/optimize.py
@@ -18,6 +18,10 @@ import torch
 import os
 import json
 from .transformers import ggml_convert_low_bit
+from torch.nn.modules import Module
+from torch.nn.modules.module import _IncompatibleKeys
+from accelerate import init_empty_weights
+from accelerate.utils import set_module_tensor_to_device
 from bigdl.llm.ggml.quantize import ggml_tensor_qtype
 from bigdl.llm.utils.common import invalidInputError
 
@@ -38,12 +42,27 @@ def _save_low_bit(self, save_dir, *args, **kwargs):
         json.dump(self._bigdl_config, json_file)
 
 
-def load_low_bit(model, model_path):
-    invalidInputError(isinstance(model, torch.nn.Module),
-                      "model should be a instance of `torch.nn.Module`.")
+# Under `init_empty_weights()`, we need to disable all actions
+# that may lead to any parameter allocation", otherwise may need to error:
+# NotImplementedError: Cannot copy out of meta tensor; no data!
+class DisableTorchAllocTensor():
+    def __init__(self) -> None:
+        self._old_torch_load_state_dict = Module.load_state_dict
+        self._old_torch_to_device = Module.to
+
+    def __enter__(self):
+        Module.load_state_dict = lambda *args, **kwargs: _IncompatibleKeys([], [])
+        Module.to = lambda self, *args, **kwargs: self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        Module.load_state_dict = self._old_torch_load_state_dict
+        Module.to = self._old_torch_to_device
+
+
+def low_bit_sanity_check(model_path):
     invalidInputError(os.path.isdir(model_path),
                       "model_path should be a valid directory path.")
-    invalidInputError(os.path.isdir(os.path.join(model_path, CONFIG_NAME)),
+    invalidInputError(os.path.isfile(os.path.join(model_path, CONFIG_NAME)),
                       "bigdl_config.json should be under your model directory,"
                       "please check your input path.")
     with open(os.path.join(model_path, CONFIG_NAME), 'r') as f:
@@ -54,13 +73,34 @@ def load_low_bit(model, model_path):
                       "Detect this model is not a low-bit model, Please use `optimize_model`"
                       " with low_bit to get a low-bit model , and "
                       " serialize the model using save_low_bit first.")
+    return low_bit
+
+
+def load_low_bit(model_or_creator, model_path, **kwargs):
+    is_creator = not isinstance(model_or_creator, torch.nn.Module) \
+        and callable(model_or_creator)
+    low_bit = low_bit_sanity_check(model_path)
 
     if low_bit:
+        # a creator
+        if is_creator:
+            with init_empty_weights(), DisableTorchAllocTensor():
+                model = model_or_creator(**kwargs)
+        else:
+            model = model_or_creator
+        invalidInputError(isinstance(model, torch.nn.Module),
+                          "model_or_creator should be a instance of "
+                          "`torch.nn.Module`or a method that returns "
+                          f"an instance of `torch.nn.Module`, but got {type(model)} at last.")
         qtype = ggml_tensor_qtype[low_bit]
         model = ggml_convert_low_bit(model, qtype=qtype, convert_shape_only=True)
 
     state_dict = torch.load(os.path.join(model_path, PYTORCH_MODEL_NAME))
-    model.load_state_dict(state_dict=state_dict)
+    if is_creator:
+        for param_name, param in state_dict.items():
+            set_module_tensor_to_device(model, param_name, "cpu", param)
+    else:
+        model.load_state_dict(state_dict=state_dict)
     return model
 
 

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -151,6 +151,8 @@ def optimize(model):
     else:
         # todo implement 4.28.0 ~ 4.30.2
         pass
+    
+    print(model.config._name_or_path)
 
     if "chatglm2" in model.config._name_or_path:
         modeling_module_name = model.__class__.__module__
@@ -171,6 +173,14 @@ def optimize(model):
         convert_forward(model,
                         module.SelfAttention,
                         chatglm_attention_forward
+                        )
+    elif "dolly" in model.config._name_or_path:
+        modeling_module_name = model.__class__.__module__
+        module = importlib.import_module(modeling_module_name)
+        from bigdl.llm.transformers.models.gptj import gptj_attention_forward 
+        convert_forward(model,
+                        module.GPTJAttention,
+                        gptj_attention_forward
                         )
 
     return model

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -178,10 +178,10 @@ def optimize(model):
         module = importlib.import_module(modeling_module_name)
         if "GPTJForCausalLM" in model.config.architectures:
             # dolly-v1-6b
-            from bigdl.llm.transformers.models.gptj import gptj_attention_forward 
+            from bigdl.llm.transformers.models.gptj import gptj_attention_forward
             convert_forward(model,
                             module.GPTJAttention,
-                            gptj_attention_forward
+                            gptj_attention_forward)
     elif "falcon" in model.config._name_or_path:
         modeling_module_name = model.__class__.__module__
         module = importlib.import_module(modeling_module_name)

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -174,14 +174,13 @@ def optimize(model):
                         chatglm_attention_forward
                         )
     elif "gptj" in model.config.model_type:
+        # dolly-v1-6b
         modeling_module_name = model.__class__.__module__
         module = importlib.import_module(modeling_module_name)
-        if "GPTJForCausalLM" in model.config.architectures:
-            # dolly-v1-6b
-            from bigdl.llm.transformers.models.gptj import gptj_attention_forward
-            convert_forward(model,
-                            module.GPTJAttention,
-                            gptj_attention_forward)
+        from bigdl.llm.transformers.models.gptj import gptj_attention_forward
+        convert_forward(model,
+                        module.GPTJAttention,
+                        gptj_attention_forward)
     elif "falcon" in model.config._name_or_path:
         modeling_module_name = model.__class__.__module__
         module = importlib.import_module(modeling_module_name)

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -174,13 +174,15 @@ def optimize(model):
                         module.SelfAttention,
                         chatglm_attention_forward
                         )
-    elif "dolly" in model.config._name_or_path:
+    elif "gptj" in model.config.model_type:
         modeling_module_name = model.__class__.__module__
         module = importlib.import_module(modeling_module_name)
-        from bigdl.llm.transformers.models.gptj import gptj_attention_forward 
-        convert_forward(model,
-                        module.GPTJAttention,
-                        gptj_attention_forward
-                        )
+        if "GPTJForCausalLM" in model.config.architectures:
+            # dolly-v1-6b
+            from bigdl.llm.transformers.models.gptj import gptj_attention_forward 
+            convert_forward(model,
+                            module.GPTJAttention,
+                            gptj_attention_forward
+                            )
 
     return model

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -151,8 +151,6 @@ def optimize(model):
     else:
         # todo implement 4.28.0 ~ 4.30.2
         pass
-    
-    print(model.config._name_or_path)
 
     if "chatglm2" in model.config._name_or_path:
         modeling_module_name = model.__class__.__module__

--- a/python/llm/src/bigdl/llm/transformers/models/gptj.py
+++ b/python/llm/src/bigdl/llm/transformers/models/gptj.py
@@ -1,0 +1,192 @@
+import torch
+from typing import Optional, Tuple, Union
+from bigdl.llm.transformers.models.utils import create_kv_cache, append_kv_cache
+from transformers.utils.import_utils import is_torch_fx_proxy
+
+
+KV_CACHE_ALLOC_BLOCK_LENGTH = 256
+KV_CACHE_ALLOC_MIN_LENGTH = 512
+
+def apply_rotary_pos_emb(tensor: torch.Tensor, sin: torch.Tensor, cos: torch.Tensor) -> torch.Tensor:
+    sin = torch.repeat_interleave(sin[:, :, None, :], 2, 3)
+    cos = torch.repeat_interleave(cos[:, :, None, :], 2, 3)
+    return (tensor * cos) + (rotate_every_two(tensor) * sin)
+
+
+def rotate_every_two(x: torch.Tensor) -> torch.Tensor:
+    x1 = x[:, :, :, ::2]
+    x2 = x[:, :, :, 1::2]
+    x = torch.stack((-x2, x1), dim=-1)
+    return x.flatten(-2)  # in einsum notation: rearrange(x, '... d j -> ... (d j)')
+
+def _get_embed_positions(self, position_ids):
+    embed_positions = self.embed_positions
+    if embed_positions.device != position_ids.device:
+        embed_positions = embed_positions.to(position_ids.device)
+        self.embed_positions = embed_positions
+    return embed_positions.repeat(position_ids.shape[0], 1, 1)
+
+
+def _attn(
+        self,
+        query,
+        key,
+        value,
+        attention_mask=None,
+        head_mask=None,
+    ):
+    # compute causal mask from causal mask buffer
+    query_length, key_length = query.size(-2), key.size(-2)
+    causal_mask = self.bias[:, :, key_length - query_length : key_length, :key_length]
+
+    # Keep the attention weights computation in fp32 to avoid overflow issues
+    query = query.to(torch.float32)
+    key = key.to(torch.float32)
+
+    attn_weights = torch.matmul(query, key.transpose(-1, -2))
+
+    mask_value = torch.finfo(attn_weights.dtype).min
+    # Need to be a tensor, otherwise we get error: `RuntimeError: expected scalar type float but found double`.
+    # Need to be on the same device, otherwise `RuntimeError: ..., x and y to be on the same device`
+    mask_value = torch.tensor(mask_value, dtype=attn_weights.dtype).to(attn_weights.device)
+    attn_weights = torch.where(causal_mask, attn_weights, mask_value)
+
+    attn_weights = attn_weights / self.scale_attn
+
+    if attention_mask is not None:
+        # Apply the attention mask
+        attn_weights = attn_weights + attention_mask
+
+    attn_weights = nn.functional.softmax(attn_weights, dim=-1)
+    attn_weights = attn_weights.to(value.dtype)
+    attn_weights = self.attn_dropout(attn_weights)
+
+    # Mask heads if we want to
+    if head_mask is not None:
+        attn_weights = attn_weights * head_mask
+
+    attn_output = torch.matmul(attn_weights, value)
+
+    return attn_output, attn_weights
+
+
+def gptj_attention_forward(
+    self,
+    hidden_states: torch.FloatTensor,
+    layer_past: Optional[Tuple[torch.Tensor]] = None,
+    attention_mask: Optional[torch.FloatTensor] = None,
+    position_ids: Optional[torch.LongTensor] = None,
+    head_mask: Optional[torch.FloatTensor] = None,
+    use_cache: Optional[bool] = False,
+    output_attentions: Optional[bool] = False,
+) -> Union[
+    Tuple[torch.Tensor, Tuple[torch.Tensor]],
+    Optional[Tuple[torch.Tensor, Tuple[torch.Tensor], Tuple[torch.Tensor, ...]]],
+]:
+    query = self.q_proj(hidden_states)
+    key = self.k_proj(hidden_states)
+    value = self.v_proj(hidden_states)
+
+    query = self._split_heads(query, self.num_attention_heads, self.head_dim, True)
+    key = self._split_heads(key, self.num_attention_heads, self.head_dim, True)
+    value = self._split_heads(value, self.num_attention_heads, self.head_dim, False)
+
+    if is_torch_fx_proxy(position_ids) or torch.jit.is_tracing():
+        # The logic to conditionally copy to GPU could not be traced, so we do this
+        # every time in the torch.fx case
+        embed_positions = get_embed_positions(self.embed_positions, position_ids)
+    else:
+        embed_positions = self._get_embed_positions(position_ids)
+
+    repeated_position_ids = position_ids.unsqueeze(-1).repeat(1, 1, embed_positions.shape[-1])
+    sincos = torch.gather(embed_positions, 1, repeated_position_ids)
+    sin, cos = torch.split(sincos, sincos.shape[-1] // 2, dim=-1)
+
+    if self.rotary_dim is not None:
+        k_rot = key[:, :, :, : self.rotary_dim]
+        k_pass = key[:, :, :, self.rotary_dim :]
+
+        q_rot = query[:, :, :, : self.rotary_dim]
+        q_pass = query[:, :, :, self.rotary_dim :]
+
+        k_rot = apply_rotary_pos_emb(k_rot, sin, cos)
+        q_rot = apply_rotary_pos_emb(q_rot, sin, cos)
+
+        key = torch.cat([k_rot, k_pass], dim=-1)
+        query = torch.cat([q_rot, q_pass], dim=-1)
+    else:
+        key = apply_rotary_pos_emb(key, sin, cos)
+        query = apply_rotary_pos_emb(query, sin, cos)
+    
+    batch_size, cur_length = query.shape[0], query.shape[1]
+
+    key = key.permute(0, 2, 1, 3).contiguous()
+    query = query.permute(0, 2, 1, 3).contiguous()
+
+    device = query.device
+
+    if layer_past is not None:
+        cache_k = layer_past[0]
+        cache_v = layer_past[1]
+
+        cache_k = cache_k.permute(0, 2, 1, 3)
+        cache_v = cache_v.permute(0, 2, 1, 3)
+        past_length = cache_k.size(2)
+
+        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+            # allocate new
+            if device.type == 'xpu':
+                torch.xpu.empty_cache()
+
+            max_cache_length = past_length + cur_length + KV_CACHE_ALLOC_BLOCK_LENGTH
+
+            new_cache_k, new_cache_v = create_kv_cache(batch_size,
+                                                        self.num_attention_heads,
+                                                        self.head_dim,
+                                                        cur_length,
+                                                        max_cache_length,
+                                                        dtype=query.dtype,
+                                                        device=device)
+            new_cache_k[:] = cache_k
+            new_cache_v[:] = cache_v
+            cache_k = new_cache_k
+            cache_v = new_cache_v
+        key, value = append_kv_cache(cache_k, cache_v, key, value)
+
+
+    elif use_cache:
+        max_cache_length = max(KV_CACHE_ALLOC_MIN_LENGTH, cur_length) \
+            + KV_CACHE_ALLOC_BLOCK_LENGTH
+        
+        key_cache, value_cache = create_kv_cache(batch_size,
+                                                    self.num_attention_heads,
+                                                    self.head_dim,
+                                                    cur_length,
+                                                    max_cache_length,
+                                                    dtype=query.dtype,
+                                                    device=device)
+
+
+        key_cache[:] = key
+        value_cache[:] = value
+        key = key_cache
+        value = value_cache
+
+
+    if use_cache is True:
+        present = (key.permute(0, 2, 1, 3), value.permute(0, 2, 1, 3))
+    else:
+        present = None
+
+    # compute self-attention: V x Softmax(QK^T)
+    attn_output, attn_weights = self._attn(query, key, value, attention_mask, head_mask)
+
+    attn_output = self._merge_heads(attn_output, self.num_attention_heads, self.head_dim)
+    attn_output = self.out_proj(attn_output)
+    attn_output = self.resid_dropout(attn_output)
+
+    outputs = (attn_output, present)
+    if output_attentions:
+        outputs += (attn_weights,)
+
+    return outputs  # a, present, (attentions)

--- a/python/llm/src/bigdl/llm/transformers/models/gptj.py
+++ b/python/llm/src/bigdl/llm/transformers/models/gptj.py
@@ -155,9 +155,6 @@ def gptj_attention_forward(
         past_length = cache_k.size(2)
 
         if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
-            # allocate new
-            if device.type == 'xpu':
-                torch.xpu.empty_cache()
 
             max_cache_length = past_length + cur_length + KV_CACHE_ALLOC_BLOCK_LENGTH
 

--- a/python/llm/src/bigdl/llm/transformers/models/gptj.py
+++ b/python/llm/src/bigdl/llm/transformers/models/gptj.py
@@ -49,13 +49,13 @@ def _get_embed_positions(self, position_ids):
 
 
 def _attn(
-        self,
-        query,
-        key,
-        value,
-        attention_mask=None,
-        head_mask=None,
-    ):
+    self,
+    query,
+    key,
+    value,
+    attention_mask=None,
+    head_mask=None,
+):
     # compute causal mask from causal mask buffer
     query_length, key_length = query.size(-2), key.size(-2)
     causal_mask = self.bias[:, :, key_length - query_length : key_length, :key_length]

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -58,6 +58,13 @@ def rotate_half(x):
     return torch.cat((-x2, x1), dim=-1)
 
 
+def rotate_every_two(x):
+    x1 = x[:, :, :, ::2]
+    x2 = x[:, :, :, 1::2]
+    x = torch.stack((-x2, x1), dim=-1)
+    return x.flatten(-2)  # in einsum notation: rearrange(x, '... d j -> ... (d j)')
+
+
 def apply_rotary_pos_emb(q, k, cos, sin, position_ids, model_family):
     if model_family in ["llama", "baichuan"]:
         # The first two dimensions of cos and sin are always 1, so we can `squeeze` them.
@@ -67,6 +74,12 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids, model_family):
         sin = sin[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
         q_embed = (q * cos) + (rotate_half(q) * sin)
         k_embed = (k * cos) + (rotate_half(k) * sin)
+        return q_embed, k_embed
+    elif model_family == "gptj":
+        cos = torch.repeat_interleave(cos[:, :, None, :], 2, 3)
+        sin = torch.repeat_interleave(sin[:, :, None, :], 2, 3)
+        q_embed = (q * cos) + (rotate_every_two(q) * sin)
+        k_embed = (k * cos) + (rotate_every_two(k) * sin)
         return q_embed, k_embed
     else:
         invalidInputError(False,


### PR DESCRIPTION
## Description
In this PR, we refactored the code for `key` and `value` inside the GPTJAttention forward function to optimize the model generation of reset tokens' latency.

### 1. Why the change?
The rest tokens latency need to be optimized.

### 2. User API changes
N/A

### 3. Summary of the change 
- add `create_kv_cache` and `append_kv_cache` to instead of `torch.cat`.
- refactor new functionality of `gptj_attention_forward`.

### 4. How to test?
- [x] Unit test


