### PR TITLE
LLM: Adapt transformers models for `optimize model` SL

### DIFF
--- a/.github/workflows/llm_unit_tests.yml
+++ b/.github/workflows/llm_unit_tests.yml
@@ -27,7 +27,7 @@ on:
       - ".github/workflows/llm-binary-build.yml"
       - ".github/actions/llm/setup-llm-env/action.yml"
       - ".github/actions/llm/remove-llm-env/action.yml"
-      - ".github/actions/llm/convert-test/action.yml"
+      - ".github/actions/llm/cli-test-linux/action.yml"
       - ".github/actions/llm/cli-test-windows/action.yml"
       - ".github/actions/llm/download-llm-binary/action.yml"
   workflow_dispatch:

--- a/.github/workflows/llm_unit_tests.yml
+++ b/.github/workflows/llm_unit_tests.yml
@@ -28,6 +28,7 @@ on:
       - ".github/workflows/llm-binary-build.yml"
       - ".github/actions/llm/setup-llm-env/action.yml"
       - ".github/actions/llm/remove-llm-env/action.yml"
+      - ".github/actions/llm/convert-test/action.yml"
       - ".github/actions/llm/cli-test-linux/action.yml"
       - ".github/actions/llm/cli-test-windows/action.yml"
       - ".github/actions/llm/download-llm-binary/action.yml"

--- a/.github/workflows/llm_unit_tests.yml
+++ b/.github/workflows/llm_unit_tests.yml
@@ -45,9 +45,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: windows
-            instruction: avx2
-            python-version: "3.9"
           - os: ubuntu-20.04-lts
             instruction: avx512
             python-version: "3.9"

--- a/.github/workflows/llm_unit_tests.yml
+++ b/.github/workflows/llm_unit_tests.yml
@@ -59,7 +59,7 @@ jobs:
         shell: bash
         run: |
           echo "ORIGIN_DIR=$(pwd)/../llm/origin-models" >> "$GITHUB_ENV"
-          echo "INT4_CKPT_DIR=$(pwd)/../llm/nightly-converted-models" >> "$GITHUB_ENV"
+          echo "INT4_CKPT_DIR=$(pwd)/../llm/pr-converted-models" >> "$GITHUB_ENV"
       - name: Create model directories
         shell: bash
         run: |

--- a/.github/workflows/llm_unit_tests.yml
+++ b/.github/workflows/llm_unit_tests.yml
@@ -16,7 +16,6 @@ on:
       - ".github/workflows/llm-binary-build.yml"
       - ".github/actions/llm/setup-llm-env/action.yml"
       - ".github/actions/llm/remove-llm-env/action.yml"
-      - ".github/actions/llm/convert-test/action.yml"
       - ".github/actions/llm/cli-test-linux/action.yml"
       - ".github/actions/llm/cli-test-windows/action.yml"
       - ".github/actions/llm/download-llm-binary/action.yml"
@@ -29,7 +28,6 @@ on:
       - ".github/actions/llm/setup-llm-env/action.yml"
       - ".github/actions/llm/remove-llm-env/action.yml"
       - ".github/actions/llm/convert-test/action.yml"
-      - ".github/actions/llm/cli-test-linux/action.yml"
       - ".github/actions/llm/cli-test-windows/action.yml"
       - ".github/actions/llm/download-llm-binary/action.yml"
   workflow_dispatch:
@@ -39,81 +37,6 @@ on:
 jobs:
   llm-cpp-build:
     uses: ./.github/workflows/llm-binary-build.yml
-  llm-nightly-convert-test:
-    needs: llm-cpp-build
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-20.04-lts
-            instruction: avx512
-            python-version: "3.9"
-    runs-on: [self-hosted, llm, "${{matrix.instruction}}", "${{matrix.os}}"]
-    env:
-      ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
-    steps:
-      - name: Set model directories
-        shell: bash
-        run: |
-          echo "ORIGIN_DIR=$(pwd)/../llm/origin-models" >> "$GITHUB_ENV"
-          echo "INT4_CKPT_DIR=$(pwd)/../llm/pr-converted-models" >> "$GITHUB_ENV"
-      - name: Create model directories
-        shell: bash
-        run: |
-          if [ ! -d $ORIGIN_DIR ]; then
-            mkdir -p $ORIGIN_DIR
-          fi
-          if [ ! -d $INT4_CKPT_DIR ]; then
-            mkdir -p $INT4_CKPT_DIR
-          fi
-      - name: Set environment variables
-        shell: bash
-        run: |
-          echo "LLAMA_ORIGIN_PATH=${ORIGIN_DIR}/llama-7b-hf" >> "$GITHUB_ENV"
-          echo "GPTNEOX_ORIGIN_PATH=${ORIGIN_DIR}/gptneox-7b-redpajama-bf16" >> "$GITHUB_ENV"
-          echo "BLOOM_ORIGIN_PATH=${ORIGIN_DIR}/bloomz-7b1" >> "$GITHUB_ENV"
-          echo "STARCODER_ORIGIN_PATH=${ORIGIN_DIR}/gpt_bigcode-santacoder" >> "$GITHUB_ENV"
-
-          echo "LLAMA_INT4_CKPT_PATH=${INT4_CKPT_DIR}/bigdl_llm_llama_q4_0.bin" >> "$GITHUB_ENV"
-          echo "GPTNEOX_INT4_CKPT_PATH=${INT4_CKPT_DIR}/bigdl_llm_gptneox_q4_0.bin" >> "$GITHUB_ENV"
-          echo "BLOOM_INT4_CKPT_PATH=${INT4_CKPT_DIR}/bigdl_llm_bloom_q4_0.bin" >> "$GITHUB_ENV"
-          echo "STARCODER_INT4_CKPT_PATH=${INT4_CKPT_DIR}/bigdl_llm_starcoder_q4_0.bin" >> "$GITHUB_ENV"
-      - uses: actions/checkout@v3
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        shell: bash
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install --upgrade setuptools==58.0.4
-          python -m pip install --upgrade wheel
-
-      - name: Download llm binary
-        uses: ./.github/actions/llm/download-llm-binary
-
-      - name: Install BigDL-LLM
-        uses: ./.github/actions/llm/setup-llm-env
-
-      - name: Download original models & convert
-        uses: ./.github/actions/llm/convert-test
-
-      - name: Upload ckpt to ftp
-        shell: bash
-        if: runner.os == 'Linux' && github.event_name == 'schedule'
-        run: |
-          curl -T $LLAMA_INT4_CKPT_PATH ${LLM_FTP_URL}/llm/ggml-actions/nightly/bigdl_llm_llama_7b_q4_0.bin
-          curl -T $GPTNEOX_INT4_CKPT_PATH ${LLM_FTP_URL}/llm/ggml-actions/nightly/bigdl_llm_redpajama_7b_q4_0.bin
-          curl -T $BLOOM_INT4_CKPT_PATH ${LLM_FTP_URL}/llm/ggml-actions/nightly/bigdl_llm_bloom_7b_q4_0.bin
-          curl -T $STARCODER_INT4_CKPT_PATH ${LLM_FTP_URL}/llm/ggml-actions/nightly/bigdl_llm_santacoder_1b_q4_0.bin
-      - name: Delete ckpt
-        shell: bash
-        run: |
-          rm -rf $LLAMA_INT4_CKPT_PATH
-          rm -rf $GPTNEOX_INT4_CKPT_PATH
-          rm -rf $BLOOM_INT4_CKPT_PATH
-          rm -rf $STARCODER_INT4_CKPT_PATH
   llm-unit-test:
     needs: llm-cpp-build
     strategy:

--- a/.github/workflows/llm_unit_tests.yml
+++ b/.github/workflows/llm_unit_tests.yml
@@ -16,6 +16,7 @@ on:
       - ".github/workflows/llm-binary-build.yml"
       - ".github/actions/llm/setup-llm-env/action.yml"
       - ".github/actions/llm/remove-llm-env/action.yml"
+      - ".github/actions/llm/convert-test/action.yml"
       - ".github/actions/llm/cli-test-linux/action.yml"
       - ".github/actions/llm/cli-test-windows/action.yml"
       - ".github/actions/llm/download-llm-binary/action.yml"
@@ -37,6 +38,84 @@ on:
 jobs:
   llm-cpp-build:
     uses: ./.github/workflows/llm-binary-build.yml
+  llm-nightly-convert-test:
+    needs: llm-cpp-build
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: windows
+            instruction: avx2
+            python-version: "3.9"
+          - os: ubuntu-20.04-lts
+            instruction: avx512
+            python-version: "3.9"
+    runs-on: [self-hosted, llm, "${{matrix.instruction}}", "${{matrix.os}}"]
+    env:
+      ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
+    steps:
+      - name: Set model directories
+        shell: bash
+        run: |
+          echo "ORIGIN_DIR=$(pwd)/../llm/origin-models" >> "$GITHUB_ENV"
+          echo "INT4_CKPT_DIR=$(pwd)/../llm/nightly-converted-models" >> "$GITHUB_ENV"
+      - name: Create model directories
+        shell: bash
+        run: |
+          if [ ! -d $ORIGIN_DIR ]; then
+            mkdir -p $ORIGIN_DIR
+          fi
+          if [ ! -d $INT4_CKPT_DIR ]; then
+            mkdir -p $INT4_CKPT_DIR
+          fi
+      - name: Set environment variables
+        shell: bash
+        run: |
+          echo "LLAMA_ORIGIN_PATH=${ORIGIN_DIR}/llama-7b-hf" >> "$GITHUB_ENV"
+          echo "GPTNEOX_ORIGIN_PATH=${ORIGIN_DIR}/gptneox-7b-redpajama-bf16" >> "$GITHUB_ENV"
+          echo "BLOOM_ORIGIN_PATH=${ORIGIN_DIR}/bloomz-7b1" >> "$GITHUB_ENV"
+          echo "STARCODER_ORIGIN_PATH=${ORIGIN_DIR}/gpt_bigcode-santacoder" >> "$GITHUB_ENV"
+
+          echo "LLAMA_INT4_CKPT_PATH=${INT4_CKPT_DIR}/bigdl_llm_llama_q4_0.bin" >> "$GITHUB_ENV"
+          echo "GPTNEOX_INT4_CKPT_PATH=${INT4_CKPT_DIR}/bigdl_llm_gptneox_q4_0.bin" >> "$GITHUB_ENV"
+          echo "BLOOM_INT4_CKPT_PATH=${INT4_CKPT_DIR}/bigdl_llm_bloom_q4_0.bin" >> "$GITHUB_ENV"
+          echo "STARCODER_INT4_CKPT_PATH=${INT4_CKPT_DIR}/bigdl_llm_starcoder_q4_0.bin" >> "$GITHUB_ENV"
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade setuptools==58.0.4
+          python -m pip install --upgrade wheel
+
+      - name: Download llm binary
+        uses: ./.github/actions/llm/download-llm-binary
+
+      - name: Install BigDL-LLM
+        uses: ./.github/actions/llm/setup-llm-env
+
+      - name: Download original models & convert
+        uses: ./.github/actions/llm/convert-test
+
+      - name: Upload ckpt to ftp
+        shell: bash
+        if: runner.os == 'Linux' && github.event_name == 'schedule'
+        run: |
+          curl -T $LLAMA_INT4_CKPT_PATH ${LLM_FTP_URL}/llm/ggml-actions/nightly/bigdl_llm_llama_7b_q4_0.bin
+          curl -T $GPTNEOX_INT4_CKPT_PATH ${LLM_FTP_URL}/llm/ggml-actions/nightly/bigdl_llm_redpajama_7b_q4_0.bin
+          curl -T $BLOOM_INT4_CKPT_PATH ${LLM_FTP_URL}/llm/ggml-actions/nightly/bigdl_llm_bloom_7b_q4_0.bin
+          curl -T $STARCODER_INT4_CKPT_PATH ${LLM_FTP_URL}/llm/ggml-actions/nightly/bigdl_llm_santacoder_1b_q4_0.bin
+      - name: Delete ckpt
+        shell: bash
+        run: |
+          rm -rf $LLAMA_INT4_CKPT_PATH
+          rm -rf $GPTNEOX_INT4_CKPT_PATH
+          rm -rf $BLOOM_INT4_CKPT_PATH
+          rm -rf $STARCODER_INT4_CKPT_PATH
   llm-unit-test:
     needs: llm-cpp-build
     strategy:

--- a/python/llm/src/bigdl/llm/optimize.py
+++ b/python/llm/src/bigdl/llm/optimize.py
@@ -141,7 +141,6 @@ def load_low_bit(model_or_creator, model_path, **kwargs):
         qtype = ggml_tensor_qtype[low_bit]
         model = ggml_convert_low_bit(model, qtype=qtype, convert_shape_only=True)
 
-    # TODO: Support transformer shards models
     resolved_archive_file, is_sharded = extract_local_archive_file(model_path, subfolder="")
     if is_sharded:
         # For now only shards transformers models

--- a/python/llm/src/bigdl/llm/transformers/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/utils.py
@@ -55,7 +55,7 @@ WEIGHTS_NAME = "pytorch_model.bin"
 WEIGHTS_INDEX_NAME = "pytorch_model.bin.index.json"
 
 
-def extract_local_archive_file(pretrained_model_name_or_path, subfolder, variant):
+def extract_local_archive_file(pretrained_model_name_or_path, subfolder, variant=None):
     pretrained_model_name_or_path = str(pretrained_model_name_or_path)
     if os.path.isfile(
         os.path.join(pretrained_model_name_or_path, subfolder, _add_variant(WEIGHTS_NAME, variant))

--- a/python/llm/src/bigdl/llm/utils/lazy_load_torch.py
+++ b/python/llm/src/bigdl/llm/utils/lazy_load_torch.py
@@ -1,0 +1,187 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# ===========================================================================
+#
+# This file is adapted from
+# https://github.com/ggerganov/llama.cpp/blob/master/convert.py#L516
+#
+# MIT License
+#
+# Copyright (c) 2023 Georgi Gerganov
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+import torch
+from torch.serialization import StorageType
+import pickle
+import zipfile
+import io
+from typing import Dict, IO, Any, Callable
+from dataclasses import dataclass
+
+
+item_size = {torch.bfloat16: 2,
+             torch.float16: 2,
+             torch.int: 4,
+             torch.float: 4,
+             torch.float32: 4,
+             torch.int8: 1}
+
+@dataclass
+class LazyStorage:
+    load: Callable[[int, int], torch.Tensor]
+    kind: StorageType
+    description: str
+
+@dataclass
+class LazyTensor:
+    _load: Callable[[], torch.Tensor]
+    shape: list[int]
+    data_type: torch.dtype
+    description: str
+
+    def load(self) -> torch.Tensor:
+        ret = self._load()
+        return ret
+
+    def to(self, data_type):
+        # self.validate_conversion_to(data_type)
+
+        def load() -> torch.Tensor:
+            print(f"to {data_type}")
+            return self.load().to(data_type)
+        return LazyTensor(load, self.shape, data_type, f'convert({data_type}) {self.description}')
+
+def _load(pickle_fp, map_location, picklemoudle, pickle_file='data.pkl', zip_file=None):
+
+    load_module_mapping: Dict[str, str] = {
+        'torch.tensor': 'torch._tensor'
+    }
+
+    class LazyUnpickler(picklemoudle.Unpickler):
+        def __init__(self, fp: IO[bytes], data_base_path: str, zip_file: zipfile.ZipFile):
+            super().__init__(fp)
+            self.data_base_path = data_base_path
+            self.zip_file = zip_file
+
+
+        def persistent_load(self, pid):
+            assert pid[0] == 'storage'
+            assert isinstance(pid[1], StorageType)
+            data_type = pid[1].dtype
+            filename_stem = pid[2]
+            filename = f'{self.data_base_path}/{filename_stem}'
+            info = self.zip_file.getinfo(filename)
+
+            def load(offset: int, elm_count: int):
+                dtype = data_type
+                fp = self.zip_file.open(info)
+                fp.seek(offset * item_size[dtype])
+                size = elm_count * item_size[dtype]
+                data = fp.read(size)
+                assert len(data) == size
+                return torch.frombuffer(bytearray(data), dtype=dtype)
+            description = f'storage data_type={data_type} path-in-zip={filename} path={self.zip_file.filename}'
+            return LazyStorage(load=load, kind=pid[1], description=description)
+
+
+        @staticmethod
+        def lazy_rebuild_tensor_v2(storage: Any, storage_offset: Any, size: Any, stride: Any,
+                                requires_grad: Any, backward_hooks: Any, metadata: Any = None) -> LazyTensor:
+            assert isinstance(storage, LazyStorage)
+
+            def load() -> torch.Tensor:
+                elm_count = stride[0] * size[0]
+                return storage.load(storage_offset, elm_count).reshape(size)
+            description = f'pickled storage_offset={storage_offset} in {storage.description}'
+            return LazyTensor(load, list(size), storage.kind.dtype, description)
+
+
+        @staticmethod
+        def rebuild_from_type_v2(func, new_type, args, state):
+            return func(*args)
+
+
+        CLASSES: dict[tuple[str, str], Any] = {
+            ('torch._tensor', '_rebuild_from_type_v2'): getattr(rebuild_from_type_v2, '__func__'),
+            ('torch._utils', '_rebuild_tensor_v2'): getattr(lazy_rebuild_tensor_v2, '__func__'),
+            ('torch', 'Tensor'): LazyTensor,
+        }
+
+
+        def find_class(self, mod_name, name):
+            if (mod_name, name) in self.CLASSES:
+                return self.CLASSES[(mod_name, name)]
+            if type(name) is str and 'Storage' in name:
+                try:
+                    return StorageType(name)
+                except KeyError:
+                    pass
+            mod_name = load_module_mapping.get(mod_name, mod_name)
+            return super().find_class(mod_name, name)
+
+    unpickler = LazyUnpickler(pickle_fp,
+                              data_base_path=pickle_file,
+                              zip_file=zip_file)
+    result = unpickler.load()
+
+    return result
+
+
+# This can only be used on huggingface transformers loaded from a zip file.
+def lazyload(
+    f,
+    *args,
+    **kwargs
+):
+    if isinstance(f, io.BufferedIOBase):
+        fp = f
+    else:
+        fp = open(f, 'rb')
+    zf = zipfile.ZipFile(fp)
+    pickle_paths = [name for name in zf.namelist() if name.endswith('.pkl')]
+    assert len(pickle_paths) == 1, pickle_paths
+    pickle_fp = zf.open(pickle_paths[0], 'r')
+    state_dict= _load(pickle_fp, None, pickle, pickle_file=pickle_paths[0][:-4], zip_file=zf)
+    return state_dict
+
+
+class LazyLoadTensors:
+    def __init__(self):
+        self.torch_load = torch.load
+
+    def __enter__(self):
+        torch.load = lazyload
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        torch.load = self.torch_load

--- a/python/llm/test/convert/test_convert_model.py
+++ b/python/llm/test/convert/test_convert_model.py
@@ -32,6 +32,7 @@ starcoder_model_path = os.environ.get('STARCODER_ORIGIN_PATH')
 output_dir = os.environ.get('INT4_CKPT_DIR')
 
 def optimize_transformers_llm_test_pipeline(output_dir, model_path):
+
     with tempfile.TemporaryDirectory(dir=output_dir) as tempdir:
         model = AutoModelForCausalLM.from_pretrained(model_path,
                                         torch_dtype="auto",

--- a/python/llm/test/convert/test_convert_model.py
+++ b/python/llm/test/convert/test_convert_model.py
@@ -31,23 +31,6 @@ bloom_model_path = os.environ.get('BLOOM_ORIGIN_PATH')
 starcoder_model_path = os.environ.get('STARCODER_ORIGIN_PATH')
 output_dir = os.environ.get('INT4_CKPT_DIR')
 
-def optimize_transformers_llm_test_pipeline(output_dir, model_path):
-    from transformers import AutoModelForCausalLM as AutoCLM
-    with tempfile.TemporaryDirectory(dir=output_dir) as tempdir:
-        model = AutoCLM.from_pretrained(model_path,
-                                        torch_dtype="auto",
-                                        low_cpu_mem_usage=True,
-                                        trust_remote_code=True)
-        model = optimize_model(model)
-        model.save_low_bit(tempdir)
-        with low_memory_init():
-            new_model = AutoCLM.from_pretrained(tempdir,
-                                            torch_dtype="auto",
-                                            trust_remote_code=True)
-        new_model = load_low_bit(new_model,
-                            model_path=tempdir)
-        assert new_model is not None
-
 class TestConvertModel(TestCase):
     
     def test_convert_llama(self):

--- a/python/llm/test/convert/test_convert_model.py
+++ b/python/llm/test/convert/test_convert_model.py
@@ -105,10 +105,10 @@ class TestConvertModel(TestCase):
             assert newModel is not None
 
     def test_optimize_transformers_llama(self):
-        optimize_transformers_llm_test_pipeline(llama_model_path)
+        optimize_transformers_llm_test_pipeline(output_dir, llama_model_path)
 
     def test_optimize_transformers_bloom(self):
-        optimize_transformers_llm_test_pipeline(bloom_model_path)
+        optimize_transformers_llm_test_pipeline(output_dir, bloom_model_path)
 
 if __name__ == '__main__':
     pytest.main([__file__])

--- a/python/llm/test/convert/test_convert_model.py
+++ b/python/llm/test/convert/test_convert_model.py
@@ -51,7 +51,7 @@ def optimize_transformers_llm_test_pipeline(output_dir, model_path):
         assert new_model is not None
     finally:
         if os.path.exists(tempdir):
-            os.rmdir(tempdir)
+            shutil.rmtree(tempdir)
 
 class TestConvertModel(TestCase):
     

--- a/python/llm/test/convert/test_convert_model.py
+++ b/python/llm/test/convert/test_convert_model.py
@@ -51,6 +51,7 @@ def optimize_transformers_llm_test_pipeline(output_dir, model_path):
         assert new_model is not None
     finally:
         if os.path.exists(tempdir):
+            print(os.getcwd())
             shutil.rmtree(tempdir)
 
 class TestConvertModel(TestCase):

--- a/python/llm/test/convert/test_convert_model.py
+++ b/python/llm/test/convert/test_convert_model.py
@@ -33,20 +33,25 @@ output_dir = os.environ.get('INT4_CKPT_DIR')
 
 def optimize_transformers_llm_test_pipeline(output_dir, model_path):
 
-    with tempfile.TemporaryDirectory(dir=output_dir) as tempdir:
-        model = AutoModelForCausalLM.from_pretrained(model_path,
+    tempdir = tempfile.mkdtemp(dir=output_dir)
+    try:
+        from transformers import AutoModelForCausalLM as AutoCLM
+        model = AutoCLM.from_pretrained(model_path,
                                         torch_dtype="auto",
                                         low_cpu_mem_usage=True,
                                         trust_remote_code=True)
         model = optimize_model(model)
         model.save_low_bit(tempdir)
         with low_memory_init():
-            new_model = AutoModelForCausalLM.from_pretrained(tempdir,
+            new_model = AutoCLM.from_pretrained(tempdir,
                                             torch_dtype="auto",
                                             trust_remote_code=True)
         new_model = load_low_bit(new_model,
                             model_path=tempdir)
         assert new_model is not None
+    finally:
+        if os.path.exists(tempdir):
+            os.rmdir(tempdir)
 
 class TestConvertModel(TestCase):
     

--- a/python/llm/test/convert/test_convert_model.py
+++ b/python/llm/test/convert/test_convert_model.py
@@ -50,6 +50,8 @@ def optimize_transformers_llm_test_pipeline(output_dir, model_path):
                             model_path=tempdir)
         assert new_model is not None
     finally:
+        import time
+        time.sleep(1)
         if os.path.exists(tempdir):
             print(os.getcwd())
             shutil.rmtree(tempdir)


### PR DESCRIPTION
## Description

In order to adapt the from_pretrained and save/load API for different Transformer models, adapt more torch load involved methods `_load_from_state_dict `

## Usage Example
```python
#####First load using `from_pretrained` and call `optimize_model`
from transformers import AutoModelForCausalLM
from bigdl.llm import optimize_model

path = '/disk1/changmin/moss-moon-003-sft'
saved_dir = '/disk1/changmin/moss-moon-003-sft-INT4'

model = AutoModelForCausalLM.from_pretrained(path,
                                  torch_dtype="auto",
                                  low_cpu_mem_usage=True,
                                  trust_remote_code=True)

model = optimize_model(model)

model.save_low_bit(saved_dir) # For transformer models we directly call `save_pretrained`

#####Use `load_low_bit` to load with torch model on cpu
from bigdl.llm.optimize import load_low_bit

model = AutoModelForCausalLM.from_pretrained(path,
                                  torch_dtype="auto",
                                  low_cpu_mem_usage=True,
                                  trust_remote_code=True)

model = load_low_bit(model, saved_dir)

#####Use `load_low_bit` to load with torch model on meta device
from bigdl.llm.optimize import low_memory_init, load_low_bit

with low_memory_init():
     model = AutoModelForCausalLM.from_pretrained(path, torch_dtype="auto", trust_remote_code=True)

model = load_low_bit(model, saved_dir)
```

## Further Test
1. chatglm2-6b(4G of int4 model)
![image](https://github.com/intel-analytics/BigDL/assets/26900100/9edd33be-6e5a-4a1b-906a-fec2f9f29ce5)

2. llama2-7b(3.8G ...)
![image](https://github.com/intel-analytics/BigDL/assets/26900100/f0782674-05bc-467b-a99c-f5ae3e7a38ec)

3. bloom-7b(7.4G ...)
![image](https://github.com/intel-analytics/BigDL/assets/26900100/4cc50775-6e5b-47e2-8b7b-32a6c515dce3)

4. Baichuan 13B(7.7G ...)
```log
--------------------before model init--------------------

Used: 10027.57 MB
--------------------after model init--------------------

Used: 10032.98 MB
--------------------after model load--------------------

Used: 10031.48 MB
--------------------after model load--------------------

Used: 17858.24 MB
```

5. (Shards model) moss(9.4G+1.2G)
![image](https://github.com/intel-analytics/BigDL/assets/26900100/a49563e7-69e7-48a5-a9b6-171394ce36df)

