### PR TITLE
[LLM]Fix save xpu models error

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -30,6 +30,7 @@ def save_low_bit(self, *args, **kwargs):
     invalidInputError(self.config.to_dict().get("bigdl_transformers_low_bit", False),
                       f"Detected this model is not a low-bit model, please use from_pretrained's"
                       f" load_in_4bit or load_in_low_bit parameter to load a 4-bit model first.")
+    self.to('cpu')
     self.save_pretrained(*args, **kwargs)
     import json
     import os


### PR DESCRIPTION
## Description

Since we converted the original q4_0 format into a new q4_0 format when using .to('xpu'), we need to call .to('cpu') before saving the model.

### 1. Why the change?

Related issue: https://github.com/intel-analytics/BigDL/issues/8942

Code:
```python
import intel_extension_for_pytorch as ipex
from bigdl.llm.transformers import AutoModelForSpeechSeq2Seq
from datasets import load_dataset, load_from_disk
from transformers import WhisperProcessor

dataset_path = "hf-internal-testing/librispeech_asr_dummy"
model_path = "/mnt/disk1/models/whisper-medium"

ds = load_dataset(dataset_path, "clean", split="validation")
processor = WhisperProcessor.from_pretrained(model_path)

sample = ds[0]["audio"]
# for transformer == 4.30.2
input_features = processor(sample["array"], sampling_rate=sample["sampling_rate"], return_tensors="pt").input_features
input_features = input_features.contiguous().to('xpu')

whisper =  AutoModelForSpeechSeq2Seq.from_pretrained(model_path, load_in_4bit=True, optimize_model=False)

whisper.save_low_bit("whisper-medium-int4-cpu")
whisper_loaded =  AutoModelForSpeechSeq2Seq.load_low_bit("whisper-medium-int4-cpu", optimize_model=False, trust_remote_code=True, tie_word_embeddings=False)
whisper_loaded.config.forced_decoder_ids = None
whisper_loaded.to('xpu')

predicted_ids = whisper_loaded.generate(input_features)
output_str = processor.batch_decode(predicted_ids, skip_special_tokens=True)
print(output_str)

whisper.to('xpu')
whisper.save_low_bit("whisper-medium-int4-xpu")
whisper_loaded =  AutoModelForSpeechSeq2Seq.load_low_bit("whisper-medium-int4-xpu", optimize_model=False, trust_remote_code=True, tie_word_embeddings=False)
whisper_loaded.config.forced_decoder_ids = None
whisper_loaded.to('xpu')

predicted_ids = whisper_loaded.generate(input_features)
output_str = processor.batch_decode(predicted_ids, skip_special_tokens=True)
print(output_str)

```
Before this PR:
<img width="1002" alt="image" src="https://github.com/intel-analytics/BigDL/assets/33650826/01f71c6d-ee54-43e5-a42b-4fcd44b0e311">
This PR:
<img width="432" alt="image" src="https://github.com/intel-analytics/BigDL/assets/33650826/217c606c-5554-4c86-a17f-984767e52549">
