### PR TITLE
llm: fix gptneox kv cache

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/models/gptneox.py
+++ b/python/llm/src/bigdl/llm/transformers/models/gptneox.py
@@ -34,7 +34,7 @@
 import torch
 from typing import Optional, Tuple
 from bigdl.llm.transformers.models.utils import apply_rotary_pos_emb
-from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache
+from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, append_kv_cache
 
 
 KV_CACHE_ALLOC_BLOCK_LENGTH = 256


### PR DESCRIPTION
## Description

fix missing `append_kv_cache` of gptneox.

### 1. Why the change?

https://github.com/intel-analytics/BigDL/pull/9030#discussion_r1335339385

### 4. How to test?
- [x] Unit test

