### PR TITLE
LLM: Enable jemalloc in benchmark scripts.

### DIFF
--- a/python/llm/dev/benchmark/all-in-one/README.md
+++ b/python/llm/dev/benchmark/all-in-one/README.md
@@ -37,8 +37,6 @@ run `python run.py`, this will output results to `results.csv`.
 For SPR performance, run `bash run-spr.sh`.
 > **Note**
 >
-> In `run-spr.sh`, we set optimal environment varaible by `source bigdl-nano-init -c`, `-c` stands for disabling jemalloc. Enabling jemalloc may lead to latency increasement after multiple trials.
->
 > The value of `OMP_NUM_THREADS` should be the same as the cpu cores specified by `numactl -C`.
 
 > **Note**

--- a/python/llm/dev/benchmark/all-in-one/run-spr.sh
+++ b/python/llm/dev/benchmark/all-in-one/run-spr.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
-source bigdl-nano-init -c
+source bigdl-nano-init
 export OMP_NUM_THREADS=48
-export TRANSFORMERS_OFFLINE=1
 
 # set following parameters according to the actual specs of the test machine
 numactl -C 0-47 -m 0 python $(dirname "$0")/run.py


### PR DESCRIPTION
## Description

This PR is to enable jemalloc in benchmark scripts. Because enabling jemalloc will decrease the 1st token latency and slightly decrease rest token latency as well.