### PR TITLE
LLM: basic api support for esimd fp16

### DIFF
--- a/python/llm/src/bigdl/llm/ggml/quantize.py
+++ b/python/llm/src/bigdl/llm/ggml/quantize.py
@@ -31,7 +31,8 @@ ggml_tensor_qtype = {"sym_int4": 2,   # q4_0 in ggml
                      "asym_int5": 7,  # q5_1 in ggml
                      "sym_int8": 8,   # q8_0 in ggml
                      "nf4": 10,
-                     "nf3": 11}
+                     "nf3": 11,
+                     "fp16": 12}
 
 _llama_quantize_type = {"q4_0": 2,
                         "q4_1": 3,
@@ -71,7 +72,7 @@ def quantize(input_path: str, output_path: str,
     :param dtype: Quantization method which differs in the resulting model disk size and
             inference speed. Defalut to `q4_0`. Difference model family may support
             different types, now the supported list is:
-            llama : "q4_0", "q4_1", "q4_2"
+            llama : "q4_0", "q4_1", "q5_0", "q5_1", "q8_0"
             bloom : "q4_0", "q4_1"
             gptneox : "q4_0", "q4_1", "q5_0", "q5_1", "q8_0"
             starcoder : "q4_0", "q4_1", "q5_0", "q5_1", "q8_0"

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -82,10 +82,15 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                             qtype,
                             module.bias is not None,
                         )
-                        # convert here
-                        m, n = module.weight.data.shape
-                        trans_weight = module.weight.data.reshape(m//16, 16, n).transpose(1, 2)
-                        new_linear._parameters['weight'] = nn.Parameter(trans_weight.contiguous())
+                        device_type = module.weight.data.device.type
+                        #  only support two size now
+                        #  may generalize to other sizes
+                        if module.in_features in [4096, 11008]:
+                            new_linear.convert = True
+                            # convert here
+                            m, n = module.weight.data.shape
+                            trans_weight = module.weight.data.reshape(m//16, 16, n).transpose(1, 2)
+                            new_linear._parameters['weight'] = nn.Parameter(trans_weight.contiguous())
 
                     if module.bias is not None:
                         new_linear._parameters['bias'] = nn.Parameter(module.bias.data)\

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -89,8 +89,9 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                             new_linear.convert = True
                             # convert here
                             m, n = module.weight.data.shape
-                            trans_weight = module.weight.data.reshape(m//16, 16, n).transpose(1, 2)
-                            new_linear._parameters['weight'] = nn.Parameter(trans_weight.contiguous())
+                            trans_weight = module.weight.data.reshape(m//16, 16, n)
+                            trans_weight = trans_weight.transpose(1, 2).contiguous()
+                            new_linear._parameters['weight'] = nn.Parameter(trans_weight)
                         else:
                             new_linear._parameters['weight'] = nn.Parameter(module.weight.data)
 

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -91,6 +91,8 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                             m, n = module.weight.data.shape
                             trans_weight = module.weight.data.reshape(m//16, 16, n).transpose(1, 2)
                             new_linear._parameters['weight'] = nn.Parameter(trans_weight.contiguous())
+                        else:
+                            new_linear._parameters['weight'] = nn.Parameter(module.weight.data)
 
                     if module.bias is not None:
                         new_linear._parameters['bias'] = nn.Parameter(module.bias.data)\

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -68,11 +68,11 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                         device_type = module.weight.data.device.type
                         # Copy the weights
                         paramsLowBit = FP4Params(data=module.weight.data,
-                                                requires_grad=False,
-                                                quantized=False,
-                                                _shape=None,
-                                                convert_shape_only=convert_shape_only,
-                                                qtype=qtype).to(device_type)
+                                                 requires_grad=False,
+                                                 quantized=False,
+                                                 _shape=None,
+                                                 convert_shape_only=convert_shape_only,
+                                                 qtype=qtype).to(device_type)
                         new_linear._parameters['weight'] = paramsLowBit
                     else:
                         # esimd fp16 path
@@ -84,8 +84,8 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                         )
                         # convert here
                         m, n = module.weight.data.shape
-                        trans_weight = module.weight.data.reshape(m//16, 16, n).transpose(1, 2).contiguous()
-                        new_linear._parameters['weight'] = nn.Parameter(trans_weight)
+                        trans_weight = module.weight.data.reshape(m//16, 16, n).transpose(1, 2)
+                        new_linear._parameters['weight'] = nn.Parameter(trans_weight.contiguous())
 
                     if module.bias is not None:
                         new_linear._parameters['bias'] = nn.Parameter(module.bias.data)\

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -413,7 +413,7 @@ class FP16Linear(nn.Linear):
             x_2d = x_2d.contiguous()
 
         if x_2d.shape[0] > 1:
-            # first token, re-convert weight
+            # first token or batch size > 1, re-convert weight
             original_weight = self.weight.data.transpose(1, 2)
             original_weight = original_weight.reshape(self.out_len, self.in_len)
             result = F.linear(x_2d, original_weight.contiguous())

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -382,7 +382,7 @@ class LowBitLinear(nn.Linear):
 
 class FP16Linear(nn.Linear):
     def __init__(self, input_features, output_features, qtype, bias=True,
-                 conver_to_half=True):
+                 conver_to_half=True, convert=False):
         super().__init__(input_features, output_features, bias)
         self.in_len = input_features
         self.out_len = output_features
@@ -390,6 +390,7 @@ class FP16Linear(nn.Linear):
         self.weight_length = self.out_len * self.in_len
         self.qtype = qtype
         self.conver_to_half = conver_to_half
+        self.convert = convert
 
     def forward(self, x: torch.Tensor):
         if self.bias is not None and self.bias.dtype != x.dtype:
@@ -411,17 +412,20 @@ class FP16Linear(nn.Linear):
 
         if x_2d.is_contiguous() is False:
             x_2d = x_2d.contiguous()
-        # current workaround to reduce first token latency of fp32 input
-        # sometimes fp16 cause nan and training instability
-        # disable the conversion when training
-        if x_2d.shape[0] > 1:
-            # first token, re-convert weight
-            original_weight = self.weight.data.transpose(1, 2).reshape(self.out_len, self.in_len)
-            result = F.linear(x_2d, original_weight.contiguous())
-            del original_weight
+        if self.convert:
+            # weight has been converted
+            if x_2d.shape[0] > 1:
+                # first token, re-convert weight
+                original_weight = self.weight.data.transpose(1, 2).reshape(self.out_len, self.in_len)
+                result = F.linear(x_2d, original_weight.contiguous())
+                del original_weight
+            else:
+                # rest token, use esimd optimization
+                result = linear_fp16_esimd.forward(x_2d, self.weight.data)
         else:
-            # rest token, use esimd optimization
-            result = linear_fp16_esimd.forward(x_2d, self.weight.data)
+            # weight is not converted
+            result = F.linear(x_2d, self.weight.data)
+
         new_shape = x_shape[:-1] + (self.out_len,)
         result = result.view(new_shape)
         if self.bias is not None:

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -416,7 +416,8 @@ class FP16Linear(nn.Linear):
             # weight has been converted
             if x_2d.shape[0] > 1:
                 # first token, re-convert weight
-                original_weight = self.weight.data.transpose(1, 2).reshape(self.out_len, self.in_len)
+                original_weight = self.weight.data.transpose(1, 2)
+                original_weight = original_weight.reshape(self.out_len, self.in_len)
                 result = F.linear(x_2d, original_weight.contiguous())
                 del original_weight
             else:

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -378,3 +378,52 @@ class LowBitLinear(nn.Linear):
                     result += self.bias
 
         return result.to(x.dtype)
+
+
+class FP16Linear(nn.Linear):
+    def __init__(self, input_features, output_features, qtype, bias=True,
+                 conver_to_half=True):
+        super().__init__(input_features, output_features, bias)
+        self.in_len = input_features
+        self.out_len = output_features
+        self.weight_shape = (self.out_len, self.in_len)
+        self.weight_length = self.out_len * self.in_len
+        self.qtype = qtype
+        self.conver_to_half = conver_to_half
+
+    def forward(self, x: torch.Tensor):
+        if self.bias is not None and self.bias.dtype != x.dtype:
+            self.bias.data = self.bias.data.to(x.dtype)
+
+        x_shape = x.shape
+        x_2d = x.view(-1, x_shape[-1])
+
+        x0 = self.weight.data
+        # only work for GPU
+        assert x0.device.type == "xpu"
+        try:
+            import intel_extension_for_pytorch
+            import linear_fp16_esimd
+        except ModuleNotFoundError:
+            invalidInputError(False,
+                                "Please `pip install bigdl_core_xe` first.")
+
+        if x_2d.is_contiguous() is False:
+            x_2d = x_2d.contiguous()
+        # current workaround to reduce first token latency of fp32 input
+        # sometimes fp16 cause nan and training instability
+        # disable the conversion when training
+        if x_2d.shape[0] > 1:
+            # first token, re-convert weight
+            original_weight = self.weight.data.transpose(1, 2).reshape(self.out_len, self.in_len).contiguous()
+            result = F.linear(x_2d, original_weight)
+            del original_weight
+        else:
+            # rest token, use esimd optimization
+            result = linear_fp16_esimd.forward(x_2d, self.weight.data)
+        new_shape = x_shape[:-1] + (self.out_len,)
+        result = result.view(new_shape)
+        if self.bias is not None:
+            result += self.bias
+
+        return result.to(x.dtype)

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -400,13 +400,14 @@ class FP16Linear(nn.Linear):
 
         x0 = self.weight.data
         # only work for GPU
-        assert x0.device.type == "xpu"
+        invalidInputError(x0.device.type == "xpu",
+                          "FP16 only works for GPU")
         try:
             import intel_extension_for_pytorch
             import linear_fp16_esimd
         except ModuleNotFoundError:
             invalidInputError(False,
-                                "Please `pip install bigdl_core_xe` first.")
+                              "Please `pip install bigdl_core_xe` first.")
 
         if x_2d.is_contiguous() is False:
             x_2d = x_2d.contiguous()
@@ -415,8 +416,8 @@ class FP16Linear(nn.Linear):
         # disable the conversion when training
         if x_2d.shape[0] > 1:
             # first token, re-convert weight
-            original_weight = self.weight.data.transpose(1, 2).reshape(self.out_len, self.in_len).contiguous()
-            result = F.linear(x_2d, original_weight)
+            original_weight = self.weight.data.transpose(1, 2).reshape(self.out_len, self.in_len)
+            result = F.linear(x_2d, original_weight.contiguous())
             del original_weight
         else:
             # rest token, use esimd optimization

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -63,6 +63,8 @@ class _BaseAutoModelClass:
                                 or sym_int8. sym_int4 means symmetric int 4, asym_int4 means
                                 asymmetric int 4, etc. Relevant low bit optimizations will
                                 be applied to the model.
+        :param load_in_fp16: boolean value, True means load linear's weight to transposed format to
+                             take advantage of esimd optimizations of float16. Default to be False.
         :param optimize_model: boolean value, Whether to further optimize the low_bit llm model.
                                Default to be True.
 
@@ -81,9 +83,10 @@ class _BaseAutoModelClass:
         # we can convert the model to quantized later.
         load_in_4bit = kwargs.pop("load_in_4bit", False)
         load_in_low_bit = kwargs.pop("load_in_low_bit", None)
+        load_in_fp16 = kwargs.pop("load_in_fp16", False)
         optimize_model = kwargs.pop("optimize_model", True)
 
-        if load_in_4bit or load_in_low_bit:
+        if load_in_4bit or load_in_low_bit or load_in_fp16:
             # load int x-bit
             kwargs["low_cpu_mem_usage"] = True
             # set default torch_dtype='auto'
@@ -91,7 +94,14 @@ class _BaseAutoModelClass:
             # Avoid tensor parallel F.Linear Operations
             if "pretraining_tp" in config_dict:
                 kwargs["pretraining_tp"] = 1
-            q_k = load_in_low_bit if load_in_low_bit else "sym_int4"
+            if not load_in_fp16:
+                q_k = load_in_low_bit if load_in_low_bit else "sym_int4"
+            else:
+                invalidInputError(not load_in_4bit,
+                                  "can't set load_in_4bit and load_in_fp16 at the same time")
+                invalidInputError(load_in_low_bit is None,
+                                  "can't set load_in_low_bit and load_in_fp16 at the same time")
+                q_k = "fp16"
             model = cls.load_convert(q_k, optimize_model, *args, **kwargs)
         else:
             # load default
@@ -102,10 +112,13 @@ class _BaseAutoModelClass:
     @classmethod
     def load_convert(cls, q_k, optimize_model, *args, **kwargs):
         from .convert import ggml_convert_low_bit
-        invalidInputError(q_k in ggml_tensor_qtype,
+        invalidInputError(q_k in ggml_tensor_qtype or q_k == "fp16",
                           f"Unknown load_in_low_bit value: {q_k}, expected:"
-                          f" sym_int4, asym_int4, sym_int5, asym_int5 or sym_int8.")
-        qtype = ggml_tensor_qtype[q_k]
+                          f" sym_int4, asym_int4, sym_int5, asym_int5, sym_int8 or fp16.")
+        if q_k != "fp16":
+            qtype = ggml_tensor_qtype[q_k]
+        else:
+            qtype = "fp16"
         # In case it needs a second try,
         # `from_pretrained`` may pop items out in dict
         # and lead to args missing.

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -102,13 +102,11 @@ class _BaseAutoModelClass:
     @classmethod
     def load_convert(cls, q_k, optimize_model, *args, **kwargs):
         from .convert import ggml_convert_low_bit
-        invalidInputError(q_k in ggml_tensor_qtype or q_k == "fp16",
+        invalidInputError(q_k in ggml_tensor_qtype,
                           f"Unknown load_in_low_bit value: {q_k}, expected:"
                           f" sym_int4, asym_int4, sym_int5, asym_int5, sym_int8 or fp16.")
-        if q_k != "fp16":
-            qtype = ggml_tensor_qtype[q_k]
-        else:
-            qtype = "fp16"
+        qtype = ggml_tensor_qtype[q_k]
+
         # In case it needs a second try,
         # `from_pretrained`` may pop items out in dict
         # and lead to args missing.


### PR DESCRIPTION
## Description

Provide optimized fp16 in BigDL-LLM (**GPU only**).
Note, **this PR is just a starting point, and only suitable for specific models**, more optimizations may be added later.
This PR should be merged with https://github.com/intel-analytics/llm.cpp/pull/99.

### 1. Why the change?
To provide optimized fp16 in BigDL-LLM (**GPU only**).

### 2. User API changes
new value `fp16` is added to `load_in_low_bit` .
```python
from bigdl.llm.transformers import AutoModelForCausalLM
model = AutoModelForCausalLM.from_pretrained(model_path, load_in_low_bit='fp16', use_cache=True, optimize_model=True)
model = model.half().to('xpu')

# save / load
model.to("cpu")
model.save_low_bit(model_dir)

load_model = AutoModelForCausalLM.load_low_bit(model_dir)
load_model = load_model.half().to('xpu')
```

### 3. Summary of the change 

- provide optimized fp16 in BigDL-LLM (**GPU only**)
- verify save & load behavior

### 4. How to test?
- [x] Unit test
- [x] Local test for llama2-7b
- [x] Local test for chatglm2-6b

### Future work
- [ ] generalization to various common models