### PR TITLE
Use ipex fused rms norm for llama

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -135,6 +135,7 @@ def convert_forward(m, target_m, new_forward):
 def optimize(model):
     from packaging import version
     from bigdl.llm.transformers.models.llama import llama_attention_forward_4_31
+    from bigdl.llm.transformers.models.llama import llama_rms_norm_forward
     from transformers.modeling_utils import PreTrainedModel
 
     # All huggingface format models are inherited from `PreTrainedModel`
@@ -149,6 +150,10 @@ def optimize(model):
             model,
             transformers.models.llama.modeling_llama.LlamaAttention,
             llama_attention_forward_4_31,)
+        convert_forward(
+            model,
+            transformers.models.llama.modeling_llama.LlamaRMSNorm,
+            llama_rms_norm_forward,)
     else:
         # todo implement 4.28.0 ~ 4.30.2
         pass

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -57,6 +57,16 @@ def repeat_kv(hidden_states: torch.Tensor, n_rep: int) -> torch.Tensor:
 KV_CACHE_ALLOC_BLOCK_LENGTH = 256
 
 
+def llama_rms_norm_forward(self, hidden_states):
+    # input_dtype = hidden_states.dtype
+    # hidden_states = hidden_states.to(torch.float32)
+    # variance = hidden_states.pow(2).mean(-1, keepdim=True)
+    # hidden_states = hidden_states * torch.rsqrt(variance + self.variance_epsilon)
+    # return self.weight * hidden_states.to(input_dtype)
+    hidden_states, _ = torch.ops.torch_ipex.rms_norm(hidden_states, [self.weight.size(0)], self.weight)
+    return hidden_states
+
+
 def llama_attention_forward_4_31(
     self,
     hidden_states: torch.Tensor,


### PR DESCRIPTION
## Description

Use ipex fused rms norm for llama for xpu

### 4. How to test?

manually tested it end to end 
and the correctness of rms norm kernel is covered in https://github.com/intel/intel-extension-for-pytorch/blob/v2.0.110%2Bxpu/tests/gpu/examples/test_rms_norm.py#L45

The greedy output becomes different after a few tokens but I think it is due to numerical issues and is ok.

#### Main branch output XPU

> Once upon a time, there existed a little girl who liked to have adventures. She wanted to go to places and meet new people, and have fun. But her parents were always telling her to stay close to home, to be careful, and to always come back when the sun went down.
> 
> One

#### Main branch output CPU

> Once upon a time, there existed a little girl who liked to have adventures. She wanted to go to places and meet new people, and have fun. But her parents were always telling her to stay close to home, to be careful, and to not go anywhere alone.
> 
> One day, the little

#### This PR output XPU

> Once upon a time, there existed a little girl who liked to have adventures. She wanted to go to places and meet new people, and have fun. But her parents were always telling her to stay close to home, to be careful, and to always follow the rules.
> One day, the little girl

#### This PR output CPU

> Once upon a time, there existed a little girl who liked to have adventures. She wanted to go to places and meet new people, and have fun. But her parents were always telling her to stay close to home, to be careful, and to not go anywhere alone.
> 
> One day, the little