### PR TITLE
Align rope of chatglm with llama

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -197,6 +197,9 @@ def optimize(model):
         convert_forward(model,
                         module.ChatGLMModel,
                         chatglm2_model_forward)
+        convert_forward(model,
+                        module.RMSNorm,
+                        llama_rms_norm_forward)
     elif "chatglm" in model.config._name_or_path:
         # chatglm-6b
         modeling_module_name = model.__class__.__module__

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -186,7 +186,7 @@ def optimize(model):
         modeling_module_name = model.__class__.__module__
         module = importlib.import_module(modeling_module_name)
         from bigdl.llm.transformers.models.chatglm2 import chatglm2_attention_forward_8eb45c
-        from bigdl.llm.transformers.models.chatglm2 import core_attn_forward_8eb45c
+        from bigdl.llm.transformers.models.chatglm2 import core_attn_forward_8eb45c, chatglm2_model_forward
         convert_forward(model,
                         module.SelfAttention,
                         chatglm2_attention_forward_8eb45c
@@ -194,6 +194,9 @@ def optimize(model):
         convert_forward(model,
                         module.CoreAttention,
                         core_attn_forward_8eb45c)
+        convert_forward(model,
+                        module.ChatGLMModel,
+                        chatglm2_model_forward)
     elif "chatglm" in model.config._name_or_path:
         # chatglm-6b
         modeling_module_name = model.__class__.__module__

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -128,28 +128,6 @@ def chatglm2_attention_forward_8eb45c(
     # print("-----attention position ids:", position_ids)
 
     # apply relative positional encoding (rotary embedding)
-    # if rotary_pos_emb is not None:
-    #     query_layer = apply_rotary_pos_emb(query_layer, rotary_pos_emb)
-    #     key_layer = apply_rotary_pos_emb(key_layer, rotary_pos_emb)
-    #     rot_dim = rotary_pos_emb.shape[-2] * 2
-    #     cos, sin = torch.unbind(rotary_pos_emb, dim=-1)
-    #     cos = cos.permute(1, 0, 2).unsqueeze(0)
-    #     cos = torch.cat([cos, cos], dim=-1)
-    #     sin = sin.permute(1, 0, 2).unsqueeze(0)
-    #     sin = torch.cat([sin, sin], dim=-1)
-    #     query_layer = query_layer.permute(1, 2, 0, 3)
-    #     query_layer, query_layer_pass = query_layer[..., :rot_dim], query_layer[..., rot_dim:]
-    #     key_layer = key_layer.permute(1, 2, 0, 3)
-    #     key_layer, key_layer_pass = key_layer[..., :rot_dim], key_layer[..., rot_dim:]
-    #     query_layer, key_layer = apply_rotary_pos_emb(query_layer, key_layer, cos, sin, None, "llama")
-    #     if query_layer_pass.shape[-1] > 0:
-    #         query_layer = torch.cat((query_layer, query_layer_pass), dim=-1)
-    #     query_layer = query_layer.permute(2, 0, 1, 3)
-    #     if key_layer_pass.shape[-1] > 0:
-    #         key_layer = torch.cat((key_layer, key_layer_pass), dim=-1)
-    #     key_layer = key_layer.permute(2, 0, 1, 3)
-    # print("----query", query_layer.shape)
-    # print("----key", key_layer.shape)
     use_fuse_rope = query_layer.device.type == "xpu"
     use_fuse_rope = use_fuse_rope and not (self.training and query_layer.requires_grad)
     # use_fuse_rope = False

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -18,8 +18,9 @@
 #
 
 import torch
-from typing import Optional, Tuple, Union, List, Callable, Dict, Any
+from typing import Optional, Tuple, List
 import torch.nn.functional as F
+from transformers.modeling_outputs import BaseModelOutputWithPast
 from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, append_kv_cache, apply_rotary_pos_emb, apply_rotary_pos_emb_no_cache_xpu
 
 
@@ -74,6 +75,65 @@ def apply_rotary_pos_emb_chatglm(x: torch.Tensor, rope_cache: torch.Tensor) -> t
     return torch.cat((x_out2, x_pass), dim=-1)
 
 
+def chatglm2_model_forward(
+        self,
+        input_ids,
+        position_ids: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.BoolTensor] = None,
+        full_attention_mask: Optional[torch.BoolTensor] = None,
+        past_key_values: Optional[Tuple[Tuple[torch.Tensor, torch.Tensor], ...]] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+        use_cache: Optional[bool] = None,
+        output_hidden_states: Optional[bool] = None,
+        return_dict: Optional[bool] = None,
+):
+    output_hidden_states = (
+        output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+    )
+    use_cache = use_cache if use_cache is not None else self.config.use_cache
+    return_dict = return_dict if return_dict is not None else self.config.use_return_dict
+
+    batch_size, seq_length = input_ids.shape
+
+    if inputs_embeds is None:
+        inputs_embeds = self.embedding(input_ids)
+
+    if full_attention_mask is None:
+        if (attention_mask is not None and not attention_mask.all()) or (past_key_values and seq_length != 1):
+            full_attention_mask = self.get_masks(input_ids, past_key_values, padding_mask=attention_mask)
+
+    # use_fuse_rope = input_ids.device.type == "xpu"
+    # use_fuse_rope = use_fuse_rope and not self.training
+    use_fuse_rope = True
+
+    if use_fuse_rope:
+        rotary_pos_emb = position_ids
+    else:
+        # Rotary positional embeddings
+        rotary_pos_emb = self.rotary_pos_emb(self.seq_length)
+        if position_ids is not None:
+            rotary_pos_emb = rotary_pos_emb[position_ids]
+        else:
+            rotary_pos_emb = rotary_pos_emb[None, :seq_length]
+        rotary_pos_emb = rotary_pos_emb.transpose(0, 1).contiguous()
+
+    # Run encoder.
+    hidden_states, presents, all_hidden_states, all_self_attentions = self.encoder(
+        inputs_embeds, full_attention_mask, rotary_pos_emb=rotary_pos_emb,
+        kv_caches=past_key_values, use_cache=use_cache, output_hidden_states=output_hidden_states
+    )
+
+    if not return_dict:
+        return tuple(v for v in [hidden_states, presents, all_hidden_states, all_self_attentions] if v is not None)
+
+    return BaseModelOutputWithPast(
+        last_hidden_state=hidden_states,
+        past_key_values=presents,
+        hidden_states=all_hidden_states,
+        attentions=all_self_attentions,
+    )
+
+
 def chatglm2_attention_forward_8eb45c(
         self, hidden_states, attention_mask, rotary_pos_emb, kv_cache=None, use_cache=True
 ):
@@ -121,18 +181,9 @@ def chatglm2_attention_forward_8eb45c(
 
     cur_length, batch_size = query_layer.shape[0], query_layer.shape[1]
 
-    if kv_cache is not None:  # rest tokens
-        position_ids = torch.tensor([[kv_cache[0].shape[0]]], dtype=torch.long).to(query_layer.device)
-    else:
-        position_ids = torch.tensor([range(0, cur_length)], dtype=torch.long).to(query_layer.device)
-    # print("-----attention position ids:", position_ids)
-
     # apply relative positional encoding (rotary embedding)
-    use_fuse_rope = query_layer.device.type == "xpu"
-    use_fuse_rope = use_fuse_rope and not (self.training and query_layer.requires_grad)
-    # use_fuse_rope = False
     if rotary_pos_emb is not None:
-        if use_fuse_rope:
+        if len(rotary_pos_emb.shape) == 2:  # use_fuse_rope, actually it is position_ids
             rot_dim = rotary_pos_emb.shape[-2] * 2
             query_layer = query_layer.permute(1, 2, 0, 3)
             query_layer, query_layer_pass = query_layer[..., :rot_dim], query_layer[..., rot_dim:]
@@ -142,11 +193,11 @@ def chatglm2_attention_forward_8eb45c(
             dummy_k = torch.empty(key_layer.shape, dtype=key_layer.dtype, device=key_layer.device)
             _, query_layer = apply_rotary_pos_emb_no_cache_xpu(dummy_q,
                                                                query_layer,
-                                                               position_ids,
+                                                               rotary_pos_emb,
                                                                "llama")
             _, key_layer = apply_rotary_pos_emb_no_cache_xpu(dummy_k,
                                                              key_layer,
-                                                             position_ids,
+                                                             rotary_pos_emb,
                                                              "llama")
             if query_layer_pass.shape[-1] > 0:
                 query_layer = torch.cat((query_layer, query_layer_pass), dim=-1)

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -73,7 +73,7 @@ def rotate_every_two(x):
 def apply_rotary_pos_emb(q, k, cos, sin, position_ids, model_family):
     if model_family in ["llama", "baichuan", "internlm", "aquila", "gpt_neox"]:
         # The first two dimensions of cos and sin are always 1, so we can `squeeze` them.
-        if position_ids:
+        if position_ids is not None:
             cos = cos.squeeze(1).squeeze(0)  # [seq_len, dim]
             sin = sin.squeeze(1).squeeze(0)  # [seq_len, dim]
             cos = cos[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -73,10 +73,11 @@ def rotate_every_two(x):
 def apply_rotary_pos_emb(q, k, cos, sin, position_ids, model_family):
     if model_family in ["llama", "baichuan", "internlm", "aquila", "gpt_neox"]:
         # The first two dimensions of cos and sin are always 1, so we can `squeeze` them.
-        cos = cos.squeeze(1).squeeze(0)  # [seq_len, dim]
-        sin = sin.squeeze(1).squeeze(0)  # [seq_len, dim]
-        cos = cos[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
-        sin = sin[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
+        if position_ids:
+            cos = cos.squeeze(1).squeeze(0)  # [seq_len, dim]
+            sin = sin.squeeze(1).squeeze(0)  # [seq_len, dim]
+            cos = cos[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
+            sin = sin[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
         q_embed = (q * cos) + (rotate_half(q) * sin)
         k_embed = (k * cos) + (rotate_half(k) * sin)
         return q_embed, k_embed

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -73,11 +73,10 @@ def rotate_every_two(x):
 def apply_rotary_pos_emb(q, k, cos, sin, position_ids, model_family):
     if model_family in ["llama", "baichuan", "internlm", "aquila", "gpt_neox"]:
         # The first two dimensions of cos and sin are always 1, so we can `squeeze` them.
-        if position_ids is not None:
-            cos = cos.squeeze(1).squeeze(0)  # [seq_len, dim]
-            sin = sin.squeeze(1).squeeze(0)  # [seq_len, dim]
-            cos = cos[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
-            sin = sin[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
+        cos = cos.squeeze(1).squeeze(0)  # [seq_len, dim]
+        sin = sin.squeeze(1).squeeze(0)  # [seq_len, dim]
+        cos = cos[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
+        sin = sin[position_ids].unsqueeze(1)  # [bs, 1, seq_len, dim]
         q_embed = (q * cos) + (rotate_half(q) * sin)
         k_embed = (k * cos) + (rotate_half(k) * sin)
         return q_embed, k_embed


### PR DESCRIPTION
This PR tries to use the same logic of llama rope for chatglm, which is the first step for use fuse rope xpu.

Since rotary_pos_emb is already indexed by position_id (i.e. cos/sin) before passing to self-attention forward, more work needs to be done followed by this PR to align with llama (where cos/sin are calculated in the kernel and then indexed by position_id instead).

Any comments on this? Not sure after such modification there would still be performance benefits. @jason-dai @yangw1234 