### PR TITLE
LLM: improve transformers style API doc

### DIFF
--- a/docs/readthedocs/source/doc/PythonAPI/LLM/optimize.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/LLM/optimize.rst
@@ -1,7 +1,7 @@
 BigDL-LLM PyTorch API
 =====================
 
-llm.optimize
+optimize model
 ----------------------------------------
 
 .. automodule:: bigdl.llm.optimize

--- a/docs/readthedocs/source/doc/PythonAPI/LLM/transformers.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/LLM/transformers.rst
@@ -1,7 +1,7 @@
 BigDL-LLM ``transformers``-style API
 ====================================
 
-Hugging Face ``transformers`` Format
+Hugging Face ``transformers`` AutoModel
 ------------------------------------
 
 You can apply BigDL-LLM optimizations on any Hugging Face Transformers models by using the standard AutoModel APIs.
@@ -10,7 +10,7 @@ You can apply BigDL-LLM optimizations on any Hugging Face Transformers models by
 AutoModelForCausalLM
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: bigdl.llm.transformers.model.AutoModelForCausalLM
+.. autoclass:: bigdl.llm.transformers.AutoModelForCausalLM
     :members:
     :undoc-members:
     :show-inheritance:
@@ -22,7 +22,7 @@ AutoModelForCausalLM
 AutoModel
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: bigdl.llm.transformers.model.AutoModel
+.. autoclass:: bigdl.llm.transformers.AutoModel
     :members:
     :undoc-members:
     :show-inheritance:
@@ -34,7 +34,7 @@ AutoModel
 AutoModelForSpeechSeq2Seq
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: bigdl.llm.transformers.model.AutoModelForSpeechSeq2Seq
+.. autoclass:: bigdl.llm.transformers.AutoModelForSpeechSeq2Seq
     :members:
     :undoc-members:
     :show-inheritance:
@@ -46,7 +46,7 @@ AutoModelForSpeechSeq2Seq
 AutoModelForSeq2SeqLM
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. autoclass:: bigdl.llm.transformers.model.AutoModelForSeq2SeqLM
+.. autoclass:: bigdl.llm.transformers.AutoModelForSeq2SeqLM
     :members:
     :undoc-members:
     :show-inheritance:
@@ -57,7 +57,7 @@ AutoModelForSeq2SeqLM
 
 
 
-Native Format
+Native Model
 ----------------------------------------
 
 For ``llama``/``chatglm``/``bloom``/``gptneox``/``starcoder`` model families, you may also convert and run LLM using the native (cpp) implementation for maximum performance.
@@ -67,7 +67,7 @@ For ``llama``/``chatglm``/``bloom``/``gptneox``/``starcoder`` model families, yo
 
     .. tab:: Llama
 
-        .. autoclass:: bigdl.llm.transformers.modelling_bigdl.LlamaForCausalLM
+        .. autoclass:: bigdl.llm.transformers.LlamaForCausalLM
             :members:
             :undoc-members:
             :show-inheritance:
@@ -77,7 +77,7 @@ For ``llama``/``chatglm``/``bloom``/``gptneox``/``starcoder`` model families, yo
 
     .. tab:: ChatGLM
 
-        .. autoclass:: bigdl.llm.transformers.modelling_bigdl.ChatGLMForCausalLM
+        .. autoclass:: bigdl.llm.transformers.ChatGLMForCausalLM
             :members:
             :undoc-members:
             :show-inheritance:
@@ -87,7 +87,7 @@ For ``llama``/``chatglm``/``bloom``/``gptneox``/``starcoder`` model families, yo
 
     .. tab:: Gptneox
 
-        .. autoclass:: bigdl.llm.transformers.modelling_bigdl.GptneoxForCausalLM
+        .. autoclass:: bigdl.llm.transformers.GptneoxForCausalLM
             :members:
             :undoc-members:
             :show-inheritance:
@@ -96,7 +96,7 @@ For ``llama``/``chatglm``/``bloom``/``gptneox``/``starcoder`` model families, yo
             .. automethod:: from_pretrained
 
     .. tab:: Bloom
-        .. autoclass:: bigdl.llm.transformers.modelling_bigdl.BloomForCausalLM
+        .. autoclass:: bigdl.llm.transformers.BloomForCausalLM
             :members:
             :undoc-members:
             :show-inheritance:
@@ -106,7 +106,7 @@ For ``llama``/``chatglm``/``bloom``/``gptneox``/``starcoder`` model families, yo
 
     .. tab:: Starcoder
 
-        .. autoclass:: bigdl.llm.transformers.modelling_bigdl.StarcoderForCausalLM
+        .. autoclass:: bigdl.llm.transformers.StarcoderForCausalLM
             :members:
             :undoc-members:
             :show-inheritance:

--- a/docs/readthedocs/source/doc/PythonAPI/LLM/transformers.rst
+++ b/docs/readthedocs/source/doc/PythonAPI/LLM/transformers.rst
@@ -1,8 +1,14 @@
-BigDL-LLM `transformers`-style API
-=====================
+BigDL-LLM ``transformers``-style API
+====================================
 
-llm.transformers.model
----------------------------
+Hugging Face ``transformers`` Format
+------------------------------------
+
+You can apply BigDL-LLM optimizations on any Hugging Face Transformers models by using the standard AutoModel APIs.
+
+
+AutoModelForCausalLM
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: bigdl.llm.transformers.model.AutoModelForCausalLM
     :members:
@@ -13,6 +19,8 @@ llm.transformers.model
     .. automethod:: load_convert
     .. automethod:: load_low_bit
 
+AutoModel
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: bigdl.llm.transformers.model.AutoModel
     :members:
@@ -23,6 +31,8 @@ llm.transformers.model
     .. automethod:: load_convert
     .. automethod:: load_low_bit
 
+AutoModelForSpeechSeq2Seq
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: bigdl.llm.transformers.model.AutoModelForSpeechSeq2Seq
     :members:
@@ -33,6 +43,8 @@ llm.transformers.model
     .. automethod:: load_convert
     .. automethod:: load_low_bit
 
+AutoModelForSeq2SeqLM
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 .. autoclass:: bigdl.llm.transformers.model.AutoModelForSeq2SeqLM
     :members:
@@ -45,48 +57,59 @@ llm.transformers.model
 
 
 
-llm.transformers.modelling_bigdl
+Native Format
 ----------------------------------------
 
-.. autoclass:: bigdl.llm.transformers.modelling_bigdl.LlamaForCausalLM
-    :members:
-    :undoc-members:
-    :show-inheritance:
-    :exclude-members: GGML_Model, GGML_Module, HF_Class
-
-    .. automethod:: from_pretrained
+For ``llama``/``chatglm``/``bloom``/``gptneox``/``starcoder`` model families, you may also convert and run LLM using the native (cpp) implementation for maximum performance.
 
 
-.. autoclass:: bigdl.llm.transformers.modelling_bigdl.ChatGLMForCausalLM
-    :members:
-    :undoc-members:
-    :show-inheritance:
-    :exclude-members: GGML_Model, GGML_Module, HF_Class
+.. tabs::
 
-    .. automethod:: from_pretrained
+    .. tab:: Llama
 
+        .. autoclass:: bigdl.llm.transformers.modelling_bigdl.LlamaForCausalLM
+            :members:
+            :undoc-members:
+            :show-inheritance:
+            :exclude-members: GGML_Model, GGML_Module, HF_Class
 
-.. autoclass:: bigdl.llm.transformers.modelling_bigdl.GptneoxForCausalLM
-    :members:
-    :undoc-members:
-    :show-inheritance:
-    :exclude-members: GGML_Model, GGML_Module, HF_Class
+            .. automethod:: from_pretrained
 
-    .. automethod:: from_pretrained
+    .. tab:: ChatGLM
 
+        .. autoclass:: bigdl.llm.transformers.modelling_bigdl.ChatGLMForCausalLM
+            :members:
+            :undoc-members:
+            :show-inheritance:
+            :exclude-members: GGML_Model, GGML_Module, HF_Class
 
-.. autoclass:: bigdl.llm.transformers.modelling_bigdl.BloomForCausalLM
-    :members:
-    :undoc-members:
-    :show-inheritance:
-    :exclude-members: GGML_Model, GGML_Module, HF_Class    
+            .. automethod:: from_pretrained
 
-    .. automethod:: from_pretrained
+    .. tab:: Gptneox
 
-.. autoclass:: bigdl.llm.transformers.modelling_bigdl.StarcoderForCausalLM
-    :members:
-    :undoc-members:
-    :show-inheritance:
-    :exclude-members: GGML_Model, GGML_Module, HF_Class
+        .. autoclass:: bigdl.llm.transformers.modelling_bigdl.GptneoxForCausalLM
+            :members:
+            :undoc-members:
+            :show-inheritance:
+            :exclude-members: GGML_Model, GGML_Module, HF_Class
 
-    .. automethod:: from_pretrained
+            .. automethod:: from_pretrained
+
+    .. tab:: Bloom
+        .. autoclass:: bigdl.llm.transformers.modelling_bigdl.BloomForCausalLM
+            :members:
+            :undoc-members:
+            :show-inheritance:
+            :exclude-members: GGML_Model, GGML_Module, HF_Class    
+
+            .. automethod:: from_pretrained
+
+    .. tab:: Starcoder
+
+        .. autoclass:: bigdl.llm.transformers.modelling_bigdl.StarcoderForCausalLM
+            :members:
+            :undoc-members:
+            :show-inheritance:
+            :exclude-members: GGML_Model, GGML_Module, HF_Class
+
+            .. automethod:: from_pretrained

--- a/python/llm/src/bigdl/llm/utils/lazy_load_torch.py
+++ b/python/llm/src/bigdl/llm/utils/lazy_load_torch.py
@@ -46,7 +46,7 @@ from torch.serialization import StorageType
 import pickle
 import zipfile
 import io
-from typing import Dict, IO, Any, Callable
+from typing import Dict, IO, Any, Callable, List
 from dataclasses import dataclass
 from .common import invalidInputError
 
@@ -69,7 +69,7 @@ class LazyStorage:
 @dataclass
 class LazyTensor:
     _load: Callable[[], torch.Tensor]
-    shape: list[int]
+    shape: List[int]
     data_type: torch.dtype
     description: str
 


### PR DESCRIPTION
## Description

Improvements on BigDL-LLM transformers-style API document page:
- change `llm.transformers.model` and `llm.transformers.modelling_bigdl` to `Hugging Face transformers AutoModel` and 
`Native Model`
- make classes more clear
- add some descriptions
- update autoclass path

Besides, fix the missing PyTorch API and LangChain API doc page.


### 4. How to test?
- [x] Document test (https://binbin-doc.readthedocs.io/en/improve-doc-v1/doc/PythonAPI/LLM/transformers.html)
