### PR TITLE
LLM: Fix Qwen kv_cache optimization

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/models/qwen.py
+++ b/python/llm/src/bigdl/llm/transformers/models/qwen.py
@@ -37,6 +37,7 @@ except ImportError:
     rearrange = None
 
 from bigdl.llm.transformers.models.utils import extend_kv_cache, init_kv_cache, append_kv_cache
+from bigdl.llm.transformers.models.utils import rotate_half
 from bigdl.llm.utils.common import invalidInputError
 
 apply_rotary_emb_func = None
@@ -48,30 +49,15 @@ logger = logging.get_logger(__name__)
 KV_CACHE_ALLOC_BLOCK_LENGTH = 256
 
 
-def _rotate_half(x):
-    from einops import rearrange
-
-    x = rearrange(x, "... (j d) -> ... j d", j=2)
-    x1, x2 = x.unbind(dim=-2)
-    return torch.cat((-x2, x1), dim=-1)
-
-
 def apply_rotary_pos_emb(t, freqs):
     cos, sin = freqs
-    if apply_rotary_emb_func is not None and t.is_cuda:
-        t_ = t.float()
-        cos = cos.squeeze(0).squeeze(1)[:, : cos.shape[-1] // 2]
-        sin = sin.squeeze(0).squeeze(1)[:, : sin.shape[-1] // 2]
-        output = apply_rotary_emb_func(t_, cos, sin).type_as(t)
-        return output
-    else:
-        rot_dim = freqs[0].shape[-1]
-        cos, sin = freqs
-        t_, t_pass_ = t[..., :rot_dim], t[..., rot_dim:]
-        t_ = t_.float()
-        t_pass_ = t_pass_.float()
-        t_ = (t_ * cos) + (_rotate_half(t_) * sin)
-        return torch.cat((t_, t_pass_), dim=-1).type_as(t)
+    rot_dim = freqs[0].shape[-1]
+    cos, sin = freqs
+    t_, t_pass_ = t[..., :rot_dim], t[..., rot_dim:]
+    t_ = t_.float()
+    t_pass_ = t_pass_.float()
+    t_ = (t_ * cos) + (rotate_half(t_) * sin)
+    return torch.cat((t_, t_pass_), dim=-1).type_as(t)
 
 
 def qwen_attention_forward(

--- a/python/llm/src/bigdl/llm/transformers/models/qwen.py
+++ b/python/llm/src/bigdl/llm/transformers/models/qwen.py
@@ -79,7 +79,7 @@ def qwen_attention_forward(
     query = self._split_heads(query, self.num_heads, self.head_dim)
     key = self._split_heads(key, self.num_heads, self.head_dim)
     value = self._split_heads(value, self.num_heads, self.head_dim)
-    
+
     kv_seq_len = hidden_states.size()[1]
 
     if rotary_pos_emb_list is not None:
@@ -171,7 +171,7 @@ def qwen_attention_forward(
         context_layer = self.core_attention_flash(q, k, v, attention_mask=attention_mask)
 
         # b s h d -> b s (h d)
-        context_layer = context_layer.flatten(2,3).contiguous()
+        context_layer = context_layer.flatten(2, 3).contiguous()
 
     else:
         query = query.permute(0, 2, 1, 3)
@@ -185,7 +185,7 @@ def qwen_attention_forward(
             and not self.is_fp32
             and not query.is_cuda
         ):
-            raise Exception(_ERROR_INPUT_CPU_QUERY_WITH_FLASH_ATTN_ACTIVATED)
+            invalidInputError(False, _ERROR_INPUT_CPU_QUERY_WITH_FLASH_ATTN_ACTIVATED)
         attn_output, attn_weight = self._attn(
             query, key, value, registered_causal_mask, attention_mask, head_mask
         )
@@ -202,7 +202,7 @@ def qwen_attention_forward(
             and flash_attn_unpadded_func is not None
             and not self.is_fp32
         ):
-            raise ValueError("Cannot output attentions while using flash-attn")
+            invalidInputError(False, "Cannot output attentions while using flash-attn")
         else:
             outputs += (attn_weight,)
 


### PR DESCRIPTION
## Description

Qwen update their modeling file in 9/25, so our current kv_cache optimization is out-of-date. Update this part with latest code and accelerate rotate_half by using common util function.

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/9146
https://github.com/intel-analytics/BigDL/issues/9075#issuecomment-1757798360

### 2. User API changes

No change.

### 3. Summary of the change 

- Update Qwen kv_cache with latest modeling code
- accelerate rotate_half of Qwen by using common util function

### 4. How to test?
- [x] Unit test
- [x] Local test with latest Qwen-7B-Chat
