### PR TITLE
LLM: fix model check before attention optimization

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -183,7 +183,7 @@ def optimize(model):
 
     if model.config.architectures[0] == "ChatGLMModel":
         if hasattr(model.config, "padded_vocab_size") and model.config.padded_vocab_size == 65024:
-            # chatglm-18b or chatglm2-6b
+            # chatglm2-6b
             modeling_module_name = model.__class__.__module__
             module = importlib.import_module(modeling_module_name)
             from bigdl.llm.transformers.models.chatglm2 import chatglm2_attention_forward_8eb45c

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -181,29 +181,30 @@ def optimize(model):
         # todo implement 4.28.0 ~ 4.30.2
         pass
 
-    if "chatglm-18b" in model.config._name_or_path or "chatglm2" in model.config._name_or_path:
-        # chatglm-18b or chatglm2-6b
-        modeling_module_name = model.__class__.__module__
-        module = importlib.import_module(modeling_module_name)
-        from bigdl.llm.transformers.models.chatglm2 import chatglm2_attention_forward_8eb45c
-        from bigdl.llm.transformers.models.chatglm2 import core_attn_forward_8eb45c
-        convert_forward(model,
-                        module.SelfAttention,
-                        chatglm2_attention_forward_8eb45c
-                        )
-        convert_forward(model,
-                        module.CoreAttention,
-                        core_attn_forward_8eb45c)
-    elif "chatglm" in model.config._name_or_path:
-        # chatglm-6b
-        modeling_module_name = model.__class__.__module__
-        module = importlib.import_module(modeling_module_name)
-        from bigdl.llm.transformers.models.chatglm import chatglm_attention_forward
-        convert_forward(model,
-                        module.SelfAttention,
-                        chatglm_attention_forward
-                        )
-    elif "mpt" in model.config._name_or_path:
+    if model.config.architectures[0] == "ChatGLMModel":
+        if hasattr(model.config, "padded_vocab_size") and model.config.padded_vocab_size == 65024:
+            # chatglm-18b or chatglm2-6b
+            modeling_module_name = model.__class__.__module__
+            module = importlib.import_module(modeling_module_name)
+            from bigdl.llm.transformers.models.chatglm2 import chatglm2_attention_forward_8eb45c
+            from bigdl.llm.transformers.models.chatglm2 import core_attn_forward_8eb45c
+            convert_forward(model,
+                            module.SelfAttention,
+                            chatglm2_attention_forward_8eb45c
+                            )
+            convert_forward(model,
+                            module.CoreAttention,
+                            core_attn_forward_8eb45c)
+        elif model.config.vocab_size == 130528:
+            # chatglm-6b
+            modeling_module_name = model.__class__.__module__
+            module = importlib.import_module(modeling_module_name)
+            from bigdl.llm.transformers.models.chatglm import chatglm_attention_forward
+            convert_forward(model,
+                            module.SelfAttention,
+                            chatglm_attention_forward
+                            )
+    elif "mpt" in model.config.model_type:
         modeling_module_name = model.__class__.__module__
         attention_module_name = '.'.join(modeling_module_name.split('.')[:-1]) + ".attention"
         module = importlib.import_module(attention_module_name)


### PR DESCRIPTION
## Description

Related to https://github.com/intel-analytics/BigDL/issues/9140

Use `architectures` and `vocab_size` instead of path to distinguish between chatglm and chatglm2.
And use `model_type` instead of path to check mpt.

### 2. User API changes

N/A

### 4. How to test?
- [ ] Unit test
- [x] Local test