### PR TITLE
LLM: fix wrong length in gptj kv_cache optimization

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/models/gptj.py
+++ b/python/llm/src/bigdl/llm/transformers/models/gptj.py
@@ -134,7 +134,7 @@ def gptj_attention_forward(
     device = hidden_states.device
 
     if layer_past is not None:
-        kv_seq_len += layer_past[0].size(-3)
+        kv_seq_len += layer_past[0].size(1)
 
     if layer_past is not None:
         cache_k = layer_past[0]

--- a/python/llm/src/bigdl/llm/transformers/models/gptj.py
+++ b/python/llm/src/bigdl/llm/transformers/models/gptj.py
@@ -134,7 +134,7 @@ def gptj_attention_forward(
     device = hidden_states.device
 
     if layer_past is not None:
-        kv_seq_len += layer_past[0].size(-2)
+        kv_seq_len += layer_past[0].size(-3)
 
     if layer_past is not None:
         cache_k = layer_past[0]


### PR DESCRIPTION
## Description

### 1. Why the change?

https://github.com/intel-analytics/BigDL/issues/9192

### 2. User API changes

No change.

### 3. Summary of the change 

- fix wrong length in gptj kv_cache optimization

### 4. How to test?
- [x] Unit test
- [x] Local test with dolly-v1-6B

