### PR TITLE
LLM: add Mistral support for Portable-Zip

### DIFF
--- a/python/llm/portable-zip/README.md
+++ b/python/llm/portable-zip/README.md
@@ -17,6 +17,7 @@ This portable zip includes everything you need to run an LLM with BigDL-LLM opti
 - Baichuan2-7B-Chat
 - internlm-chat-7b-8k
 - Llama-2-7b-chat-hf
+- Mistral-7B-OpenOrca
 
 ## How to use
 

--- a/python/llm/portable-zip/chat.bat
+++ b/python/llm/portable-zip/chat.bat
@@ -1,10 +1,1 @@
-@echo off
-
-
-:: execute chat script
-set PYTHONUNBUFFERED=1
-
-set /p modelpath="Please enter the model path: "
-.\python-embed\python.exe .\chat.py --model-path="%modelpath%"
-
-pause
+powershell .\chat.ps1

--- a/python/llm/portable-zip/chat.ps1
+++ b/python/llm/portable-zip/chat.ps1
@@ -1,0 +1,37 @@
+Write-Host "Please enter the model path: "
+$modelpath = Read-Host
+$use_new_transformers = 0
+
+# execute chat script
+$env:PYTHONUNBUFFERED=1
+
+$json = Get-Content "$modelpath\config.json" | ConvertFrom-Json
+if ($json.model_type -eq 'mistral') {
+    $use_new_transformers = 1
+}
+
+if ($use_new_transformers -eq 1) {
+    Write-Host "Mistral model detected, installing transformers==4.34.0"
+    .\python-embed\python.exe -m pip install transformers==4.34.0 > $null
+    if ($?) {
+        Write-Host "Successfully installed transformers==4.34.0, now load model..."
+    } else {
+        Write-Host "Installed transformers==4.34.0 failed. exiting..."
+        exit 1
+    }
+}
+
+.\python-embed\python.exe .\chat.py --model-path=`"$modelpath`"
+
+if($use_new_transformers -eq 1) {
+    Write-Host "Rolling back to transformers==4.31.0"
+    .\python-embed\python.exe -m pip install transformers==4.31.0 > $null
+    if ($?) {
+        Write-Host "Successfully installed transformers==4.31.0, now exit..."
+    } else {
+        Write-Host "Installed transformers==4.31.0 failed. exiting..."
+        exit 1
+    }
+}
+
+Read-Host -Prompt "Press Enter to exit"

--- a/python/llm/portable-zip/setup.bat
+++ b/python/llm/portable-zip/setup.bat
@@ -20,4 +20,4 @@ cd ..
 %python-embed% -m pip install bigdl-llm[all] transformers_stream_generator tiktoken einops colorama
 
 :: compress the python and scripts
-powershell -Command "Compress-Archive -Path '.\python-embed', '.\chat.bat', '.\chat.py', '.\README.md' -DestinationPath .\bigdl-llm.zip"
+powershell -Command "Compress-Archive -Path '.\python-embed', '.\chat.bat', '.\chat.ps1', '.\chat.py', '.\README.md' -DestinationPath .\bigdl-llm.zip"


### PR DESCRIPTION
## Description

Add support for Mistral on Portable-Zip. 

- However, Mistral needs `transformers==4.34.0`, so we need to upgrade `transformers` to 4.34.0 before we run mistral.
- Also, most of our model run on `transformers==4.31.0`, so we need to downgrade `transformers` to 4.31.0 after we run mistral.

I wrote a powershell script `chat.ps1` to read `config.json` to check if the model is mistral. Most of the logic is moved into the `chat.ps1` and what `chat.bat` does is to simply run `chat.ps1`.

The usage still remains the same, which is double-click the `chat.bat`.

## Screenshot

![anime](https://github.com/intel-analytics/BigDL/assets/89779290/f158f269-7633-44eb-a9fc-d0adb282ebd1)
