### PR TITLE
Add arc fp8 support

### DIFF
--- a/python/llm/src/bigdl/llm/ggml/quantize.py
+++ b/python/llm/src/bigdl/llm/ggml/quantize.py
@@ -32,7 +32,8 @@ ggml_tensor_qtype = {"sym_int4": 2,   # q4_0 in ggml
                      "sym_int8": 8,   # q8_0 in ggml
                      "nf4": 10,
                      "nf3": 11,
-                     "fp16": 12}
+                     "fp16": 12,
+                     "fp8": 15}
 
 _llama_quantize_type = {"q4_0": 2,
                         "q4_1": 3,

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -146,6 +146,9 @@ def _optimize_pre(model):
 def ggml_convert_low_bit(model, qtype, optimize_model=True,
                          convert_shape_only=False, device="cpu",
                          modules_to_not_convert=None):
+    logger.info(f"Converting the current model to " \
+                f"{list(ggml_tensor_qtype.keys())[list(ggml_tensor_qtype.values()).index(qtype)]} " \
+                f"format......")
     modules_to_not_convert = [] if modules_to_not_convert is None else modules_to_not_convert
 
     if optimize_model:

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -146,8 +146,8 @@ def _optimize_pre(model):
 def ggml_convert_low_bit(model, qtype, optimize_model=True,
                          convert_shape_only=False, device="cpu",
                          modules_to_not_convert=None):
-    logger.info(f"Converting the current model to " \
-                f"{list(ggml_tensor_qtype.keys())[list(ggml_tensor_qtype.values()).index(qtype)]} " \
+    logger.info(f"Converting the current model to "
+                f"{list(ggml_tensor_qtype.keys())[list(ggml_tensor_qtype.values()).index(qtype)]} "
                 f"format......")
     modules_to_not_convert = [] if modules_to_not_convert is None else modules_to_not_convert
 


### PR DESCRIPTION
## Description

Add arc fp8 support.

### 1. Why the change?

Add arc fp8 support.

### 2. User API changes

Related pr: https://github.com/intel-analytics/llm.cpp/pull/123

`llama_model = AutoModelForCausalLM.from_pretrained(model_path, optimize_model=True, load_in_low_bit='fp8')`

### 3. Summary of the change 

Add arc fp8 support.

### 4. How to test?
- [x] Manual test
