### PR TITLE
Fix bigdl-llm-serving-cpu Dockerfile

### DIFF
--- a/docker/llm/serving/cpu/docker/Dockerfile
+++ b/docker/llm/serving/cpu/docker/Dockerfile
@@ -8,7 +8,7 @@ ARG TINI_VERSION=v0.18.0
 ARG PIP_NO_CACHE_DIR=false
 
 COPY ./entrypoint.sh /opt/entrypoint.sh
-COPY https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
+ADD  https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /sbin/tini
 # Install Serving Dependencies
 RUN mkdir /llm && \
     cd /llm && \


### PR DESCRIPTION
## Description

Fix bigdl-llm-serving-cpu Dockerfile by replacing `COPY` with `ADD`