### PR TITLE
[LLM] Replace Embedding layer to fix it on CPU

### DIFF
--- a/python/llm/src/bigdl/llm/optimize.py
+++ b/python/llm/src/bigdl/llm/optimize.py
@@ -192,7 +192,8 @@ def load_low_bit(model, model_path):
     return model
 
 
-def optimize_model(model, low_bit='sym_int4', optimize_llm=True, modules_to_not_convert=None):
+def optimize_model(model, low_bit='sym_int4', optimize_llm=True, modules_to_not_convert=None,
+                   replace_embedding=False):
     """
     A method to optimize any pytorch model.
 
@@ -202,6 +203,8 @@ def optimize_model(model, low_bit='sym_int4', optimize_llm=True, modules_to_not_
     :param optimize_llm: Whether to further optimize llm model.
     :param modules_to_not_convert: list of str value, modules (nn.Module) that are skipped
         when conducting model optimizations. Default to be None.
+    :param replace_embedding: Whether to replace the Embedding layer, may need to set it
+        to `True` when running BigDL-LLM on GPU on Windows. Default to be `False`.
 
     :return: The optimized model.
 
@@ -227,7 +230,8 @@ def optimize_model(model, low_bit='sym_int4', optimize_llm=True, modules_to_not_
     model = ggml_convert_low_bit(model,
                                  qtype=qtype,
                                  optimize_model=optimize_llm,
-                                 modules_to_not_convert=modules_to_not_convert)
+                                 modules_to_not_convert=modules_to_not_convert,
+                                 replace_embedding=replace_embedding)
     # add save_low_bit to pretrained model dynamically
     import types
     model._bigdl_config = dict()

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -109,7 +109,8 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                         model._modules[name].requires_grad_(False)
 
                         module.weight = None
-        elif isinstance(module, nn.Embedding) and name not in modules_to_not_convert:
+        elif type(module) == nn.Embedding and name not in modules_to_not_convert:
+            # skip user-defined Embedding layer
             if platform.system().lower() == 'windows':
                 model._modules[name] = CPUEmbedding(
                     num_embeddings=module.num_embeddings,

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -50,7 +50,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                                  current_key_name=None, convert_shape_only=False,
                                  replace_embedding=False):
     from bigdl.llm.transformers.low_bit_linear import LowBitLinear, FP4Params, FP16Linear
-    from bigdl.llm.transformers.embedding import CPUEmbedding
+    from bigdl.llm.transformers.embedding import LLMEmbedding
     has_been_replaced = False
 
     for name, module in model.named_children():
@@ -113,7 +113,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
         elif replace_embedding and type(module) == nn.Embedding:
             # skip user-defined Embedding layer
             if platform.system().lower() == 'windows':
-                model._modules[name] = CPUEmbedding(
+                model._modules[name] = LLMEmbedding(
                     num_embeddings=module.num_embeddings,
                     embedding_dim=module.embedding_dim,
                     padding_idx=module.padding_idx,

--- a/python/llm/src/bigdl/llm/transformers/embedding.py
+++ b/python/llm/src/bigdl/llm/transformers/embedding.py
@@ -20,7 +20,7 @@ from torch import Tensor
 
 
 class CPUEmbedding(torch.nn.Embedding):
-    def forward(self, x: Tensor, **kwargs):
+    def forward(self, x: Tensor):
         if self.weight.device != 'cpu':
             self.to('cpu')
-        return super().forward(x.to('cpu'), **kwargs).to(x.device)
+        return super().forward(x.to('cpu')).to(x.device)

--- a/python/llm/src/bigdl/llm/transformers/embedding.py
+++ b/python/llm/src/bigdl/llm/transformers/embedding.py
@@ -20,7 +20,7 @@ from torch import Tensor
 
 
 class CPUEmbedding(torch.nn.Embedding):
-    def forward(self, x: Tensor):
+    def forward(self, x: Tensor, **kwargs):
         if self.weight.device != 'cpu':
             self.to('cpu')
-        return super().forward(x.to('cpu')).to(x.device)
+        return super().forward(x.to('cpu'), **kwargs).to(x.device)

--- a/python/llm/src/bigdl/llm/transformers/embedding.py
+++ b/python/llm/src/bigdl/llm/transformers/embedding.py
@@ -1,0 +1,26 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import torch
+from torch import Tensor
+
+
+class CPUEmbedding(torch.nn.Embedding):
+    def forward(self, x: Tensor):
+        if self.weight.device != 'cpu':
+            self.to('cpu')
+        return super().forward(x.to('cpu')).to(x.device)

--- a/python/llm/src/bigdl/llm/transformers/embedding.py
+++ b/python/llm/src/bigdl/llm/transformers/embedding.py
@@ -19,8 +19,7 @@ import torch
 from torch import Tensor
 
 
-class CPUEmbedding(torch.nn.Embedding):
+class LLMEmbedding(torch.nn.Embedding):
     def forward(self, x: Tensor):
-        if self.weight.device != 'cpu':
-            self.to('cpu')
-        return super().forward(x.to('cpu')).to(x.device)
+        x_shape = x.shape
+        return self.weight[x.reshape(-1)].reshape(*x_shape, -1)

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -67,6 +67,8 @@ class _BaseAutoModelClass:
                                Default to be True.
         :param modules_to_not_convert: list of str value, modules (nn.Module) that are skipped when
                                        conducting model optimizations. Default to be None.
+        :param replace_embedding: Whether to replace the Embedding layer, may need to set it
+            to `True` when running BigDL-LLM on GPU on Windows. Default to be `False`.
 
         :return: a model instance
         """
@@ -114,6 +116,7 @@ class _BaseAutoModelClass:
         # `from_pretrained`` may pop items out in dict
         # and lead to args missing.
         modules_to_not_convert = kwargs.pop("modules_to_not_convert", None)
+        replace_embedding = kwargs.pop("replace_embedding", False)
         _args = copy.deepcopy(args)
         _kwargs = copy.deepcopy(kwargs)
         try:
@@ -126,7 +129,8 @@ class _BaseAutoModelClass:
             model.config.update({"bigdl_lcmu_enabled": False})
         model = model.to("cpu")
         model = ggml_convert_low_bit(model, qtype, optimize_model,
-                                     modules_to_not_convert=modules_to_not_convert)
+                                     modules_to_not_convert=modules_to_not_convert,
+                                     replace_embedding=replace_embedding)
         model.config.update({"bigdl_transformers_low_bit": q_k})
         model.config.update({"tie_word_embeddings": False})
 
@@ -163,6 +167,7 @@ class _BaseAutoModelClass:
         import os
 
         modules_to_not_convert = kwargs.pop("modules_to_not_convert", None)
+        replace_embedding = kwargs.pop("replace_embedding", False)
         # Autofactory
         trust_remote_code = kwargs.pop("trust_remote_code", None)
         kwargs_orig = copy.deepcopy(kwargs)
@@ -273,7 +278,8 @@ class _BaseAutoModelClass:
         # Loading args may differ based on their usage
         quant_device = "meta" if bigdl_lcmu_enabled else "cpu"
         model = ggml_convert_low_bit(model, qtype, optimize_model, device=quant_device,
-                                     modules_to_not_convert=modules_to_not_convert)
+                                     modules_to_not_convert=modules_to_not_convert,
+                                     replace_embedding=replace_embedding)
 
         if is_sharded:
             loaded_state_dict_keys = sharded_metadata["all_checkpoint_keys"]


### PR DESCRIPTION
## Description

Replace `Embedding` layer when loading model in low bit to fix it on CPU

Skip user-defined `Embedding` layer because it may have different `forward` signature with standard `Embedding` layer, such as whisper.

