### PR TITLE
LLM: replace torch.float32 with auto type

### DIFF
--- a/python/llm/src/bigdl/llm/serving/bigdl_llm_model.py
+++ b/python/llm/src/bigdl/llm/serving/bigdl_llm_model.py
@@ -104,7 +104,7 @@ def load_model(
         device, load_8bit, cpu_offloading
     )
     if device == "cpu":
-        kwargs = {"torch_dtype": torch.float32}
+        kwargs = {"torch_dtype": "auto"}
         if CPU_ISA in ["avx512_bf16", "amx"]:
             try:
                 import intel_extension_for_pytorch as ipex


### PR DESCRIPTION
## Description

Replace `torch.float32` with `auto` to get lower resource needed.

Here's comparison when loading `chatglm2-6b`:

### Using `auto`

<img width="506" alt="image" src="https://github.com/intel-analytics/BigDL/assets/89779290/753b19f4-9590-4a65-bce2-605196e7831c">

### Using `torch.float32` (Actually I killed the process after mem reach 90%, otherwise it will continue loading and crash my computer)

<img width="258" alt="image" src="https://github.com/intel-analytics/BigDL/assets/89779290/17585725-272b-40fc-9f7a-8ebde5698b92">


