### PR TITLE
LLM: add missing function for PyTorch InternLM model

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/models/internlm.py
+++ b/python/llm/src/bigdl/llm/transformers/models/internlm.py
@@ -45,6 +45,7 @@ from torch import nn
 from bigdl.llm.utils.common import invalidInputError
 from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, append_kv_cache
 from bigdl.llm.transformers.models.utils import apply_rotary_pos_emb
+from bigdl.llm.transformers.models.utils import apply_rotary_pos_emb_no_cache_xpu
 
 
 KV_CACHE_ALLOC_BLOCK_LENGTH = 256


### PR DESCRIPTION
Import missing function `apply_rotary_pos_emb_no_cache_xpu` for PyTorch InternLM model. @hkvision, please have a look.