### PR TITLE
[LLM] Skip CPU performance test for now

### DIFF
--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -26,6 +26,7 @@ jobs:
   llm-cpp-build:
     uses: ./.github/workflows/llm-binary-build.yml
   llm-performance-test:
+    if: false # skip cpu performance test for now; may add it back with separated runner
     needs: llm-cpp-build
     strategy:
       fail-fast: false

--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -100,6 +100,7 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
+          python -m pip install --upgrade wheel
           python -m pip install --upgrade omegaconf
           python -m pip install --upgrade pandas
           python -m pip install --upgrade einops


### PR DESCRIPTION
## Description

Skip CPU performance test for now as it is not actually record for daily llm performance on CPU. And as it is conducted on the same runner with GPU performance test, it may influence the environment for GPU perf test.

We may set up a separated runner for CPU performance test, and update the CPU performance test in a more organized way later.


### How to test?
- [x] Unit test

