### PR TITLE
LLM: Decoupling bigdl-llm and bigdl-nano

### DIFF
--- a/python/llm/dev/benchmark/all-in-one/README.md
+++ b/python/llm/dev/benchmark/all-in-one/README.md
@@ -1,7 +1,7 @@
 # All in One Benchmark Test
 All in one benchmark test allows users to test all the benchmarks and record them in a result CSV. Users can provide models and related information in `config.yaml`.
 
-Before running, make sure to have [bigdl-llm](../../../README.md) and [bigdl-nano](../../../../nano/README.md) installed.
+Before running, make sure to have [bigdl-llm](../../../README.md).
 
 ## Dependencies
 ```bash

--- a/python/llm/dev/benchmark/all-in-one/run-spr.sh
+++ b/python/llm/dev/benchmark/all-in-one/run-spr.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-source bigdl-nano-init
+source bigdl-llm-init
 export OMP_NUM_THREADS=48
 
 # set following parameters according to the actual specs of the test machine


### PR DESCRIPTION
## Description
- Decoupling bigdl-llm and bigdl-nano to solve python 3.11 installation issue

**Note**
- Try to upgrade Nano default torch option to 2.0 to support python 3.11 (**current ipex and torchvision version don't support python 3.11**), however, it will conflict with many other code / packsges, so pending it until really necessary


### 4. How to test?
- [x] Unit test
