### PR TITLE
Fix the installation dependencies issues related to libsgx-quote-ex

### DIFF
--- a/ppml/tdx/docker/trusted-bigdl-llm/serving/docker/Dockerfile
+++ b/ppml/tdx/docker/trusted-bigdl-llm/serving/docker/Dockerfile
@@ -29,8 +29,10 @@ RUN cd /root && \
     cd /opt/intel && \
     wget https://download.01.org/intel-sgx/sgx-dcap/1.16/linux/distro/ubuntu20.04-server/sgx_debian_local_repo.tgz && \
     tar xzf sgx_debian_local_repo.tgz && \
-    echo 'deb [trusted=yes arch=amd64] file:///opt/intel/sgx_debian_local_repo focal main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
-    wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add - && \
+    echo 'deb [signed-by=/etc/apt/keyrings/intel-sgx-keyring.asc arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu jammy main' | tee /etc/apt/sources.list.d/intel-sgx.list && \
+    rm -f /etc/apt/keyrings/intel-sgx-keyring.asc && \
+    wget https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key && \
+    cat intel-sgx-deb.key | tee /etc/apt/keyrings/intel-sgx-keyring.asc > /dev/null && \
     apt-get update && \
     apt-get install -y libsgx-enclave-common-dev  libsgx-ae-qe3 libsgx-ae-qve libsgx-urts libsgx-dcap-ql libsgx-dcap-default-qpl libsgx-dcap-quote-verify-dev libsgx-dcap-ql-dev libsgx-dcap-default-qpl-dev libsgx-quote-ex-dev libsgx-uae-service libsgx-ra-network libsgx-ra-uefi libtdx-attest libtdx-attest-dev && \
     cd /ppml && \


### PR DESCRIPTION
## Description

When build `bigdl-ppml-trusted-bigdl-llm-serving-tdx`, dependency issues will occur.
Refer to the p10 of [Intel_SGX_SW_Installation_Guide](https://download.01.org/intel-sgx/latest/linux-latest/docs/Intel_SGX_SW_Installation_Guide_for_Linux.pdf), we should use apt/sources.list.d for `Ubuntu 22.04`
![image](https://github.com/intel-analytics/BigDL/assets/47251317/75633571-707d-48ec-ae71-2ad115876902)
![image](https://github.com/intel-analytics/BigDL/assets/47251317/a1540d45-58b8-4f61-ad22-1ba8d13b22c0)
![image](https://github.com/intel-analytics/BigDL/assets/47251317/816bfd12-5546-4147-90d7-8401c2c26fa5)
