### PR TITLE
[LLM] Move embedding layer to CPU for iGPU inference

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/embedding.py
+++ b/python/llm/src/bigdl/llm/transformers/embedding.py
@@ -21,5 +21,6 @@ from torch import Tensor
 
 class LLMEmbedding(torch.nn.Embedding):
     def forward(self, x: Tensor):
-        x_shape = x.shape
-        return self.weight[x.reshape(-1)].reshape(*x_shape, -1)
+        if self.weight.device != 'cpu':
+            self.to('cpu')
+        return super().forward(x.to('cpu')).to(x.device)

--- a/python/llm/src/bigdl/llm/transformers/embedding.py
+++ b/python/llm/src/bigdl/llm/transformers/embedding.py
@@ -23,5 +23,4 @@ class LLMEmbedding(torch.nn.Embedding):
     def forward(self, x: Tensor):
         if self.weight.device != 'cpu':
             self.to('cpu')
-            torch.xpu.empty_cache()
         return super().forward(x.to('cpu')).to(x.device)

--- a/python/llm/src/bigdl/llm/transformers/embedding.py
+++ b/python/llm/src/bigdl/llm/transformers/embedding.py
@@ -23,4 +23,5 @@ class LLMEmbedding(torch.nn.Embedding):
     def forward(self, x: Tensor):
         if self.weight.device != 'cpu':
             self.to('cpu')
+            torch.xpu.empty_cache()
         return super().forward(x.to('cpu')).to(x.device)


### PR DESCRIPTION
## Description

Moving embedding layer to CPU for LLM inference on iGPU.

### 1. Why the change?

Due to the large size of embedding layer, calling embedding layer on iGPU may cause some 7B models (Baichuan2, internlm, Aqulia, etc,) OOM on an 8GB iGPU. Besides, calling the embedding layer on iGPU will not theoretically bring performance improvement:  https://github.com/analytics-zoo/nano/issues/693#issuecomment-1788687024


### 2. User API changes

N/A
