### PR TITLE
Chatglm2 rope optimization on xpu

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -266,7 +266,8 @@ def _optimize_post(model):
             module = importlib.import_module(modeling_module_name)
             from bigdl.llm.transformers.models.chatglm2 import chatglm2_attention_forward_8eb45c
             from bigdl.llm.transformers.models.chatglm2 import core_attn_forward_8eb45c
-            from bigdl.llm.transformers.models.chatglm2 import chatglm_rms_norm_forward, chatglm2_model_forward
+            from bigdl.llm.transformers.models.chatglm2 import chatglm_rms_norm_forward
+            from bigdl.llm.transformers.models.chatglm2 import chatglm2_model_forward
             convert_forward(model,
                             module.SelfAttention,
                             chatglm2_attention_forward_8eb45c

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -266,7 +266,7 @@ def _optimize_post(model):
             module = importlib.import_module(modeling_module_name)
             from bigdl.llm.transformers.models.chatglm2 import chatglm2_attention_forward_8eb45c
             from bigdl.llm.transformers.models.chatglm2 import core_attn_forward_8eb45c
-            from bigdl.llm.transformers.models.chatglm2 import chatglm_rms_norm_forward
+            from bigdl.llm.transformers.models.chatglm2 import chatglm_rms_norm_forward, chatglm2_model_forward
             convert_forward(model,
                             module.SelfAttention,
                             chatglm2_attention_forward_8eb45c
@@ -274,6 +274,9 @@ def _optimize_post(model):
             convert_forward(model,
                             module.CoreAttention,
                             core_attn_forward_8eb45c)
+            convert_forward(model,
+                            module.ChatGLMModel,
+                            chatglm2_model_forward)
             convert_forward(model,
                             module.RMSNorm,
                             chatglm_rms_norm_forward)

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -129,8 +129,9 @@ def chatglm2_model_forward(
     else:
         rotary_pos_emb = rotary_pos_emb[None, :seq_length]
     if use_fuse_rope:
-        # repeat cos sin here, call only once for each token.
-        # if put this to attension forward, it will generate too many times.
+        # Repeat cos sin here, call only once for each token. 
+        # Chatglm2's rotary embedding is similar to gptj's, is rotate_every_two.
+        # If put this to attension forward, it will generate too many times.
         cos, sin = rotary_pos_emb.split(rotary_pos_emb.shape[-1] // 2, dim=-1)
         cos = cos.squeeze(-1)
         sin = sin.squeeze(-1)

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -222,7 +222,7 @@ def chatglm2_attention_forward_8eb45c(
             #query_states = query_layer.permute(1, 2, 0, 3).contiguous()
             query_states = query_layer.transpose(0, 1)#.contiguous()
             query_states, query_states_pass = query_states[..., :rot_dim], query_states[..., rot_dim:]
-            key_states = key_layer.permute(1, 2, 0, 3).contiguous()
+            # key_states = key_layer.permute(1, 2, 0, 3).contiguous()
             key_states = key_layer.transpose(0, 1)#.contiguous()
             key_states, key_states_pass = key_states[..., :rot_dim], key_states[..., rot_dim:]
             cos, sin = rotary_pos_emb.split([1, 1], -1)

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -87,6 +87,7 @@ def chatglm_rms_norm_forward(self, hidden_states):
         return self.weight * hidden_states.to(input_dtype)
     return hidden_states
 
+
 def chatglm2_model_forward(
         self,
         input_ids,
@@ -100,7 +101,8 @@ def chatglm2_model_forward(
         return_dict: Optional[bool] = None,
 ):
     output_hidden_states = (
-        output_hidden_states if output_hidden_states is not None else self.config.output_hidden_states
+        output_hidden_states if output_hidden_states is not None
+            else self.config.output_hidden_states
     )
     use_cache = use_cache if use_cache is not None else self.config.use_cache
     return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -111,8 +113,11 @@ def chatglm2_model_forward(
         inputs_embeds = self.embedding(input_ids)
 
     if full_attention_mask is None:
-        if (attention_mask is not None and not attention_mask.all()) or (past_key_values and seq_length != 1):
-            full_attention_mask = self.get_masks(input_ids, past_key_values, padding_mask=attention_mask)
+        if (attention_mask is not None and not attention_mask.all()) or
+                 (past_key_values and seq_length != 1):
+            full_attention_mask = self.get_masks(input_ids,
+                                                 past_key_values,
+                                                 padding_mask=attention_mask)
 
     use_fuse_rope = input_ids.device.type == "xpu"
     use_fuse_rope = use_fuse_rope and not self.training
@@ -146,7 +151,8 @@ def chatglm2_model_forward(
     )
 
     if not return_dict:
-        return tuple(v for v in [hidden_states, presents, all_hidden_states, all_self_attentions] if v is not None)
+        return tuple(v for v in [hidden_states, presents, all_hidden_states, all_self_attentions]
+                         if v is not None)
 
     return BaseModelOutputWithPast(
         last_hidden_state=hidden_states,
@@ -209,7 +215,8 @@ def chatglm2_attention_forward_8eb45c(
             cos, sin = rotary_pos_emb
             rot_dim = cos.shape[-1]
             query_states = query_layer.transpose(0, 1)
-            query_states, query_states_pass = query_states[..., :rot_dim], query_states[..., rot_dim:]
+            query_states = query_states[..., :rot_dim]
+            query_states_pass = query_states[..., rot_dim:]
             key_states = key_layer.transpose(0, 1)
             key_states, key_states_pass = key_states[..., :rot_dim], key_states[..., rot_dim:]
             torch.ops.torch_ipex.apply_rotary_embedding(query_states, sin, cos, query_states)

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -113,8 +113,8 @@ def chatglm2_model_forward(
         inputs_embeds = self.embedding(input_ids)
 
     if full_attention_mask is None:
-        if (attention_mask is not None and not attention_mask.all()) or
-            (past_key_values and seq_length != 1):
+        if (attention_mask is not None and not attention_mask.all()) or (
+                past_key_values and seq_length != 1):
             full_attention_mask = self.get_masks(input_ids,
                                                  past_key_values,
                                                  padding_mask=attention_mask)
@@ -152,7 +152,7 @@ def chatglm2_model_forward(
 
     if not return_dict:
         return tuple(v for v in [hidden_states, presents, all_hidden_states, all_self_attentions]
-                         if v is not None)
+                     if v is not None)
 
     return BaseModelOutputWithPast(
         last_hidden_state=hidden_states,

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -94,7 +94,7 @@ def chatglm2_model_forward(
         position_ids: Optional[torch.Tensor] = None,
         attention_mask: Optional[torch.BoolTensor] = None,
         full_attention_mask: Optional[torch.BoolTensor] = None,
-        past_key_values: Optional[Tuple[Tuple[torch.Tensor, torch.Tensor], ...]] = None,
+        past_key_values: Optional[Tuple[Tuple[torch.Tensor,torch.Tensor],...]] = None,
         inputs_embeds: Optional[torch.Tensor] = None,
         use_cache: Optional[bool] = None,
         output_hidden_states: Optional[bool] = None,
@@ -102,7 +102,7 @@ def chatglm2_model_forward(
 ):
     output_hidden_states = (
         output_hidden_states if output_hidden_states is not None
-            else self.config.output_hidden_states
+        else self.config.output_hidden_states
     )
     use_cache = use_cache if use_cache is not None else self.config.use_cache
     return_dict = return_dict if return_dict is not None else self.config.use_return_dict
@@ -114,7 +114,7 @@ def chatglm2_model_forward(
 
     if full_attention_mask is None:
         if (attention_mask is not None and not attention_mask.all()) or
-                 (past_key_values and seq_length != 1):
+                (past_key_values and seq_length != 1):
             full_attention_mask = self.get_masks(input_ids,
                                                  past_key_values,
                                                  padding_mask=attention_mask)

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -215,8 +215,7 @@ def chatglm2_attention_forward_8eb45c(
             cos, sin = rotary_pos_emb
             rot_dim = cos.shape[-1]
             query_states = query_layer.transpose(0, 1)
-            query_states = query_states[..., :rot_dim]
-            query_states_pass = query_states[..., rot_dim:]
+            query_states = query_states[..., :rot_dim], query_states[..., rot_dim:]
             key_states = key_layer.transpose(0, 1)
             key_states, key_states_pass = key_states[..., :rot_dim], key_states[..., rot_dim:]
             torch.ops.torch_ipex.apply_rotary_embedding(query_states, sin, cos, query_states)

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -235,6 +235,9 @@ def chatglm2_attention_forward_8eb45c(
             query_layer = apply_rotary_pos_emb_chatglm(query_layer, rotary_pos_emb)
             key_layer = apply_rotary_pos_emb_chatglm(key_layer, rotary_pos_emb)
 
+            assert(torch.equal(query_states, query_layer.transpose(0, 1)[..., :64]))
+            assert(torch.equal(key_states, key_layer.transpose(0, 1)[..., :64]))
+
     if self.multi_query_attention:
         key_length = key_layer.size(0)
         query_group_size = self.num_attention_heads_per_partition // \

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -129,7 +129,7 @@ def chatglm2_model_forward(
     else:
         rotary_pos_emb = rotary_pos_emb[None, :seq_length]
     if use_fuse_rope:
-        # Repeat cos sin here, call only once for each token. 
+        # Repeat cos sin here, call only once for each token.
         # Chatglm2's rotary embedding is similar to gptj's, is rotate_every_two.
         # If put this to attension forward, it will generate too many times.
         cos, sin = rotary_pos_emb.split(rotary_pos_emb.shape[-1] // 2, dim=-1)

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -91,14 +91,14 @@ def chatglm_rms_norm_forward(self, hidden_states):
 def chatglm2_model_forward(
         self,
         input_ids,
-        position_ids: Optional[torch.Tensor] = None,
-        attention_mask: Optional[torch.BoolTensor] = None,
-        full_attention_mask: Optional[torch.BoolTensor] = None,
-        past_key_values: Optional[Tuple[Tuple[torch.Tensor,torch.Tensor],...]] = None,
-        inputs_embeds: Optional[torch.Tensor] = None,
-        use_cache: Optional[bool] = None,
-        output_hidden_states: Optional[bool] = None,
-        return_dict: Optional[bool] = None,
+        position_ids: Optional[torch.Tensor]=None,
+        attention_mask: Optional[torch.BoolTensor]=None,
+        full_attention_mask: Optional[torch.BoolTensor]=None,
+        past_key_values: Optional[Tuple[Tuple[torch.Tensor, torch.Tensor], ...]]=None,
+        inputs_embeds: Optional[torch.Tensor]=None,
+        use_cache: Optional[bool]=None,
+        output_hidden_states: Optional[bool]=None,
+        return_dict: Optional[bool]=None,
 ):
     output_hidden_states = (
         output_hidden_states if output_hidden_states is not None
@@ -114,7 +114,7 @@ def chatglm2_model_forward(
 
     if full_attention_mask is None:
         if (attention_mask is not None and not attention_mask.all()) or
-                (past_key_values and seq_length != 1):
+            (past_key_values and seq_length != 1):
             full_attention_mask = self.get_masks(input_ids,
                                                  past_key_values,
                                                  padding_mask=attention_mask)

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -54,7 +54,7 @@ def split_tensor_along_last_dim(
     return tensor_list
 
 
-# @torch.jit.script
+@torch.jit.script
 def apply_rotary_pos_emb_chatglm(x: torch.Tensor, rope_cache: torch.Tensor) -> torch.Tensor:
     # x: [sq, b, np, hn]
     sq, b, np, hn = x.size(0), x.size(1), x.size(2), x.size(3)

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -86,6 +86,10 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids, model_family):
         q_embed = (q * cos) + (rotate_every_two(q) * sin)
         k_embed = (k * cos) + (rotate_every_two(k) * sin)
         return q_embed, k_embed
+    elif model_family == "chatglm2":
+        q_embed = (q * cos) + (rotate_every_two(q) * sin)
+        k_embed = (k * cos) + (rotate_every_two(k) * sin)
+        return q_embed, k_embed
     else:
         invalidInputError(False,
                           f"{model_family} is not supported.")

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -86,10 +86,6 @@ def apply_rotary_pos_emb(q, k, cos, sin, position_ids, model_family):
         q_embed = (q * cos) + (rotate_every_two(q) * sin)
         k_embed = (k * cos) + (rotate_every_two(k) * sin)
         return q_embed, k_embed
-    elif model_family == "chatglm2":
-        q_embed = (q * cos) + (rotate_every_two(q) * sin)
-        k_embed = (k * cos) + (rotate_every_two(k) * sin)
-        return q_embed, k_embed
     else:
         invalidInputError(False,
                           f"{model_family} is not supported.")


### PR DESCRIPTION
## Description

Speed up chat glm2 on xpu

### 1. Why the change?


Speed up chat glm2 on xpu with ipex


### 2. Summary of the change 
1. use `torch.ops.torch_ipex.apply_rotary_embedding` instead of apply_rotary_pos_emb
2. (sin, cos)'s repeat_interleave in model's forward if xpu is used. (cpu unchanged)
