### PR TITLE
[LLM] Update label for windows build & UTs

### DIFF
--- a/.github/actions/llm/download-llm-binary/action.yml
+++ b/.github/actions/llm/download-llm-binary/action.yml
@@ -17,7 +17,7 @@ runs:
         mv linux-avx/* python/llm/llm-binary/
         mv linux-amx/* python/llm/llm-binary/
         mv windows-avx2/* python/llm/llm-binary/
-        mv windows-avx2-vnni/* python/llm/llm-binary/
+        mv windows-avx-vnni/* python/llm/llm-binary/
         mv windows-avx/* python/llm/llm-binary/
         rm -rf linux-avx2 || true
         rm -rf linux-avx512 || true
@@ -25,5 +25,5 @@ runs:
         rm -rf linux-avx || true
         rm -rf linux-amx || true
         rm -rf windows-avx2 || true
-        rm -rf windows-avx2-vnni || true
+        rm -rf windows-avx-vnni || true
         rm -rf windows-avx || true

--- a/.github/workflows/llm-binary-build.yml
+++ b/.github/workflows/llm-binary-build.yml
@@ -327,7 +327,7 @@ jobs:
           name: windows-avx2
 
   windows-build-avx2:
-    runs-on: [self-hosted, Windows]
+    runs-on: [self-hosted, Windows, AVX-VNNI]
     needs: check-windows-avx2-artifact
     if: needs.check-windows-avx2-artifact.outputs.if-exists == 'false'
     steps:
@@ -359,7 +359,7 @@ jobs:
           path: |
             build/Release
 
-  check-windows-avx2-vnni-artifact:
+  check-windows-avx-vnni-artifact:
     runs-on: ubuntu-latest
     outputs:
       if-exists: ${{steps.check_artifact.outputs.exists}}
@@ -368,12 +368,12 @@ jobs:
         id: check_artifact
         uses: xSAVIKx/artifact-exists-action@v0
         with:
-          name: windows-avx2-vnni
+          name: windows-avx-vnni
 
-  windows-build-avx2-vnni:
-    runs-on: [self-hosted, Windows]
-    needs: check-windows-avx2-vnni-artifact
-    if: needs.check-windows-avx2-vnni-artifact.outputs.if-exists == 'false'
+  windows-build-avx-vnni:
+    runs-on: [self-hosted, Windows, AVX-VNNI]
+    needs: check-windows-avx-vnni-artifact
+    if: needs.check-windows-avx-vnni-artifact.outputs.if-exists == 'false'
     steps:
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -464,7 +464,7 @@ jobs:
       - name: Archive build files
         uses: actions/upload-artifact@v3
         with:
-          name: windows-avx2-vnni
+          name: windows-avx-vnni
           path: |
             release
 
@@ -480,7 +480,7 @@ jobs:
           name: windows-avx
 
   windows-build-avx:
-    runs-on: [self-hosted, Windows]
+    runs-on: [self-hosted, Windows, AVX-VNNI]
     needs: check-windows-avx-artifact
     if: needs.check-windows-avx-artifact.outputs.if-exists == 'false'
     steps:

--- a/.github/workflows/llm-nightly-test.yml
+++ b/.github/workflows/llm-nightly-test.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         include:
           - os: windows
-            instruction: avx2
+            instruction: AVX-VNNI
             python-version: "3.9"
           - os: ubuntu-20.04-lts
             instruction: avx512

--- a/.github/workflows/llm_unit_tests.yml
+++ b/.github/workflows/llm_unit_tests.yml
@@ -44,19 +44,19 @@ jobs:
       matrix:
         include:
           - os: windows
-            instruction: avx2
+            instruction: AVX-VNNI
             python-version: "3.9"
           - os: ubuntu-20.04-lts
             instruction: avx512
             python-version: "3.9"
           - os: windows
-            instruction: avx2
+            instruction: AVX-VNNI
             python-version: "3.10"
           - os: ubuntu-20.04-lts
             instruction: avx512
             python-version: "3.10"
           - os: windows
-            instruction: avx2
+            instruction: AVX-VNNI
             python-version: "3.11"
           - os: ubuntu-20.04-lts
             instruction: avx512


### PR DESCRIPTION
## Description
- Add label AVX_VNNI for windows avx/avx2/avx-vnni binary build. As the label is [self-hosted, windows] before, which will actually choose all windows runner, which is unexpected.
- Change label AVX2 -> AVX_VNNI for windows UT & nightly tests, as they are all currently run on gen12/13 core.

### How to test?
- [ ] Unit test
