### PR TITLE
[LLM] Add perf test for core on Windows

### DIFF
--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -203,7 +203,7 @@ jobs:
           # - os: windows
           #   platform: lp
           #   python-version: "3.9"
-    runs-on: [self-hosted, "${{matrix.os}}", llm, perf-core, "${{matrix.platform}}"]
+    runs-on: [self-hosted, "${{ matrix.os }}", llm, perf-core, "${{ matrix.platform }}"]
     env:
       ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
     steps:
@@ -238,6 +238,7 @@ jobs:
           # hide time info
           sed -i 's/str(end - st)/"xxxxxx"/g' run.py
           python run.py
-          cp ./*.csv D:/action-runners/nightly_perf_core_${{matrix.platform}}/
+          curl -T ./*.csv ${LLM_FTP_URL}/llm/nightly_perf/core_${{ matrix.platform }}
+          cp ./*.csv D:/action-runners/nightly_perf_core_${{ matrix.platform }}/
           cd ../../../test/benchmark
-          python csv_to_html.py -f D:/action-runners/nightly_perf_core_${{matrix.platform}}/
+          python csv_to_html.py -f D:/action-runners/nightly_perf_core_${{ matrix.platform }}/

--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -238,6 +238,6 @@ jobs:
           # hide time info
           sed -i 's/str(end - st)/"xxxxxx"/g' run.py
           python run.py
-          cp ./*.csv D:\action-runners\nightly_perf_core_${{matrix.platform}}\
+          cp ./*.csv D:/action-runners/nightly_perf_core_${{matrix.platform}}/
           cd ../../../test/benchmark
-          python csv_to_html.py -f D:\action-runners\nightly_perf_core_${{matrix.platform}}\
+          python csv_to_html.py -f D:/action-runners/nightly_perf_core_${{matrix.platform}}/

--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -75,6 +75,7 @@ jobs:
       #   env:
       #     ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
   llm-performance-test-on-arc:
+    if: false # temp skip
     needs: llm-cpp-build
     strategy:
       fail-fast: false
@@ -142,6 +143,7 @@ jobs:
           fi
           
   llm-performance-test-on-spr:
+    if: false # temp skip
     needs: llm-cpp-build
     strategy:
       fail-fast: false

--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -238,6 +238,6 @@ jobs:
           # hide time info
           sed -i 's/str(end - st)/"xxxxxx"/g' run.py
           python run.py
-          cp ./*.csv /mnt/disk1/nightly_perf_core_${{matrix.platform}}/
+          cp ./*.csv D:\action-runners\nightly_perf_core_${{matrix.platform}}\
           cd ../../../test/benchmark
-          python csv_to_html.py -f /mnt/disk1/nightly_perf_core_${{matrix.platform}}/
+          python csv_to_html.py -f D:\action-runners\nightly_perf_core_${{matrix.platform}}\

--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -201,9 +201,9 @@ jobs:
           - os: windows
             platform: dp
             python-version: "3.9"
-          - os: windows
-            platform: lp
-            python-version: "3.9"
+          # - os: windows
+          #   platform: lp
+          #   python-version: "3.9"
     runs-on: [self-hosted, "${{matrix.os}}", llm, perf-core, "${{matrix.platform}}"]
     env:
       ANALYTICS_ZOO_ROOT: ${{ github.workspace }}

--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -204,7 +204,7 @@ jobs:
     runs-on: [self-hosted, "${{ matrix.os }}", llm, perf-core, "${{ matrix.platform }}"]
     env:
       ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
-      CSV_SAVE_PATH: ${{ github.event.schedule && 'D:/action-runners/nightly_perf_core_${{ matrix.platform }}/' || 'D:/action-runners/pr_perf_core_${{ matrix.platform }}/' }}
+      CSV_SAVE_PATH: ${{ github.event.schedule && 'D:/action-runners/nightly_perf_core_' || 'D:/action-runners/pr_perf_core_' }}${{ matrix.platform }}/
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -197,8 +197,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9"]
-    runs-on: [self-hosted, llm, perf-core]
+        include:
+          - os: windows
+            platform: dp
+            python-version: "3.9"
+          - os: windows
+            platform: lp
+            python-version: "3.9"
+    runs-on: [self-hosted, "${{matrix.os}}", llm, perf-core, "${{matrix.platform}}"]
     env:
       ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
     steps:
@@ -214,8 +220,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           python -m pip install --upgrade wheel
-          python -m pip install --upgrade omegaconf
-          python -m pip install --upgrade pandas
+          python -m pip install --upgrade omegaconf pandas
           python -m pip install --upgrade tiktoken einops transformers_stream_generator
     
       - name: Download llm binary
@@ -223,12 +228,6 @@ jobs:
 
       - name: Run LLM install (all) test
         uses: ./.github/actions/llm/setup-llm-env
-
-      - name: Test installed xpu version
-        shell: bash
-        run: |
-          source /opt/intel/oneapi/setvars.sh
-          bash python/llm/test/run-llm-install-tests.sh
 
       - name: Test on core
         shell: bash
@@ -240,6 +239,6 @@ jobs:
           # hide time info
           sed -i 's/print("model generate cost: " + str(end - st))/#print("model generate cost: " + str(end - st))/g' run.py
           python run.py
-          cp ./*.csv /mnt/disk1/nightly_perf_core_desktop/
+          cp ./*.csv /mnt/disk1/nightly_perf_core_${{matrix.platform}}/
           cd ../../../test/benchmark
-          python csv_to_html.py -f /mnt/disk1/nightly_perf_core_desktop/
+          python csv_to_html.py -f /mnt/disk1/nightly_perf_core_${{matrix.platform}}/

--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -190,3 +190,56 @@ jobs:
           cp ./*.csv /mnt/disk1/nightly_perf_cpu/
           cd ../../../test/benchmark
           python csv_to_html.py -f /mnt/disk1/nightly_perf_cpu/
+
+  llm-performance-test-on-core:
+    if: false # temp skip
+    needs: llm-cpp-build
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.9"]
+    runs-on: [self-hosted, llm, perf-core]
+    env:
+      ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade wheel
+          python -m pip install --upgrade omegaconf
+          python -m pip install --upgrade pandas
+          python -m pip install --upgrade tiktoken einops transformers_stream_generator
+    
+      - name: Download llm binary
+        uses: ./.github/actions/llm/download-llm-binary
+
+      - name: Run LLM install (all) test
+        uses: ./.github/actions/llm/setup-llm-env
+
+      - name: Test installed xpu version
+        shell: bash
+        run: |
+          source /opt/intel/oneapi/setvars.sh
+          bash python/llm/test/run-llm-install-tests.sh
+
+      - name: Test on core
+        shell: bash
+        run: |
+          mv python/llm/test/benchmark/core-perf-test.yaml python/llm/dev/benchmark/all-in-one/config.yaml
+          cd python/llm/dev/benchmark/all-in-one
+          export http_proxy=${HTTP_PROXY}
+          export https_proxy=${HTTPS_PROXY}
+          # hide time info
+          sed -i 's/print("model generate cost: " + str(end - st))/#print("model generate cost: " + str(end - st))/g' run.py
+          python run.py
+          cp ./*.csv /mnt/disk1/nightly_perf_core_desktop/
+          cd ../../../test/benchmark
+          python csv_to_html.py -f /mnt/disk1/nightly_perf_core_desktop/

--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -238,7 +238,7 @@ jobs:
           # hide time info
           sed -i 's/str(end - st)/"xxxxxx"/g' run.py
           python run.py
-          curl -T ./*.csv ${LLM_FTP_URL}/llm/nightly_perf/core_${{ matrix.platform }}
+          curl -T ./*.csv ${LLM_FTP_URL}/llm/nightly_perf/core_${{ matrix.platform }}/
           cp ./*.csv D:/action-runners/nightly_perf_core_${{ matrix.platform }}/
           cd ../../../test/benchmark
           python csv_to_html.py -f D:/action-runners/nightly_perf_core_${{ matrix.platform }}/

--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -75,7 +75,6 @@ jobs:
       #   env:
       #     ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
   llm-performance-test-on-arc:
-    if: false # temp skip
     needs: llm-cpp-build
     strategy:
       fail-fast: false
@@ -143,7 +142,6 @@ jobs:
           fi
           
   llm-performance-test-on-spr:
-    if: false # temp skip
     needs: llm-cpp-build
     strategy:
       fail-fast: false
@@ -206,6 +204,7 @@ jobs:
     runs-on: [self-hosted, "${{ matrix.os }}", llm, perf-core, "${{ matrix.platform }}"]
     env:
       ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
+      CSV_SAVE_PATH: ${{ github.event.schedule && 'D:/action-runners/nightly_perf_core_${{ matrix.platform }}/' || 'D:/action-runners/pr_perf_core_${{ matrix.platform }}/' }}
     steps:
       - uses: actions/checkout@v3
 
@@ -238,7 +237,10 @@ jobs:
           # hide time info
           sed -i 's/str(end - st)/"xxxxxx"/g' run.py
           python run.py
-          curl -T ./*.csv ${LLM_FTP_URL}/llm/nightly_perf/core_${{ matrix.platform }}/
-          cp ./*.csv D:/action-runners/nightly_perf_core_${{ matrix.platform }}/
+          cp ./*.csv $CSV_SAVE_PATH
           cd ../../../test/benchmark
-          python csv_to_html.py -f D:/action-runners/nightly_perf_core_${{ matrix.platform }}/
+          python csv_to_html.py -f $CSV_SAVE_PATH
+          cd ../../dev/benchmark/all-in-one/
+          if [ ${{ github.event.schedule}} ]; then
+            curl -T ./*.csv ${LLM_FTP_URL}/llm/nightly_perf/core_${{ matrix.platform }}/
+          fi

--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -192,7 +192,6 @@ jobs:
           python csv_to_html.py -f /mnt/disk1/nightly_perf_cpu/
 
   llm-performance-test-on-core:
-    if: false # temp skip
     needs: llm-cpp-build
     strategy:
       fail-fast: false

--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -228,7 +228,7 @@ jobs:
       - name: Run LLM install (all) test
         uses: ./.github/actions/llm/setup-llm-env
 
-      - name: Test on core
+      - name: Test on core ${{ matrix.platform }}
         shell: bash
         run: |
           mv python/llm/test/benchmark/core-perf-test.yaml python/llm/dev/benchmark/all-in-one/config.yaml

--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -236,7 +236,7 @@ jobs:
           export http_proxy=${HTTP_PROXY}
           export https_proxy=${HTTPS_PROXY}
           # hide time info
-          sed -i 's/print("model generate cost: " + str(end - st))/#print("model generate cost: " + str(end - st))/g' run.py
+          sed -i 's/str(end - st)/"xxxxxx"/g' run.py
           python run.py
           cp ./*.csv /mnt/disk1/nightly_perf_core_${{matrix.platform}}/
           cd ../../../test/benchmark

--- a/python/llm/test/benchmark/core-perf-test.yaml
+++ b/python/llm/test/benchmark/core-perf-test.yaml
@@ -1,0 +1,20 @@
+repo_id:
+  - 'THUDM/chatglm2-6b'
+local_model_hub: 'D:\llm-models'
+warm_up: 1
+num_trials: 3
+num_beams: 1 # default to greedy search
+low_bit: 'sym_int4' # default to use 'sym_int4' (i.e. symmetric int4)
+in_out_pairs:
+  - '32-32'
+  - '1024-128'
+test_api:
+  - "transformer_int4"
+  # - "native_int4"
+  # - "optimize_model"
+  # - "pytorch_autocast_bf16"
+  # - "ipex_fp16_gpu" # on Intel GPU
+  # - "transformer_int4_gpu"  # on Intel GPU
+  # - "optimize_model_gpu"  # on Intel GPU
+  # - "deepspeed_transformer_int4_cpu" # on Intel SPR Server
+

--- a/python/llm/test/benchmark/core-perf-test.yaml
+++ b/python/llm/test/benchmark/core-perf-test.yaml
@@ -1,5 +1,6 @@
 repo_id:
   - 'THUDM/chatglm2-6b'
+  - 'THUDM/chatglm3-6b'
 local_model_hub: 'D:\llm-models'
 warm_up: 1
 num_trials: 3

--- a/python/llm/test/benchmark/core-perf-test.yaml
+++ b/python/llm/test/benchmark/core-perf-test.yaml
@@ -1,6 +1,13 @@
 repo_id:
   - 'THUDM/chatglm2-6b'
   - 'THUDM/chatglm3-6b'
+  - 'internlm/internlm-chat-7b-8k'
+  - 'baichuan-inc/Baichuan2-7B-Chat'
+  - 'Qwen/Qwen-7B-Chat'
+  - 'BAAI/AquilaChat2-7B'
+  - 'meta-llama/Llama-2-7b-chat-hf'
+  - 'WisdomShell/CodeShell-7B'
+  - 'tiiuae/falcon-7b-instruct'
 local_model_hub: 'D:\llm-models'
 warm_up: 1
 num_trials: 3

--- a/python/llm/test/benchmark/core-perf-test.yaml
+++ b/python/llm/test/benchmark/core-perf-test.yaml
@@ -1,13 +1,13 @@
 repo_id:
+  - 'baichuan-inc/Baichuan2-7B-Chat'
   - 'THUDM/chatglm2-6b'
   - 'THUDM/chatglm3-6b'
   - 'internlm/internlm-chat-7b-8k'
-  - 'baichuan-inc/Baichuan2-7B-Chat'
-  - 'Qwen/Qwen-7B-Chat'
+  - 'Qwen/Qwen-7B-Chat-10-12'
   - 'BAAI/AquilaChat2-7B'
   - 'meta-llama/Llama-2-7b-chat-hf'
   - 'WisdomShell/CodeShell-7B'
-  - 'tiiuae/falcon-7b-instruct'
+  - 'tiiuae/falcon-7b-instruct-with-patch'
 local_model_hub: 'D:\llm-models'
 warm_up: 1
 num_trials: 3

--- a/python/llm/test/benchmark/core-perf-test.yaml
+++ b/python/llm/test/benchmark/core-perf-test.yaml
@@ -1,7 +1,7 @@
 repo_id:
-  - 'baichuan-inc/Baichuan2-7B-Chat'
   - 'THUDM/chatglm2-6b'
   - 'THUDM/chatglm3-6b'
+  - 'baichuan-inc/Baichuan2-7B-Chat'
   - 'internlm/internlm-chat-7b-8k'
   - 'Qwen/Qwen-7B-Chat-10-12'
   - 'BAAI/AquilaChat2-7B'


### PR DESCRIPTION
## Description

Add perf test for core on windows. In this pr, we will add perf test for desktop 13 gen core.

Chinese models:
- [x] chatglm2-6b
- [x] chatglm3-6b
- [x] Baichuan2-7B-Chat
- [x] internlm-chat-7b-8k
- [x] Qwen-7B-Chat (10-12)
- [x] AquliaChat2-7B
- [ ] RWKV 7B (pending)
- [ ] Yi-6B (pending)
 
Others:
- [x] Llama-2-7b-chat-hf
- [x] CodeShell-7B
- [x] falcon-7b-instruct (with patch)
- [ ] Mistral-7B-Instruct-v0.1 (pending)
- [ ] distill-whisper large v2 (pending)

### 1. Why the change?

https://github.com/orgs/analytics-zoo/projects/21/views/2?pane=issue&itemId=43965304

### 2. How to test?
- [ ] Unit test
