### PR TITLE
[LLM] Separate windows build UT and build runner

### DIFF
--- a/.github/workflows/llm-binary-build.yml
+++ b/.github/workflows/llm-binary-build.yml
@@ -327,7 +327,7 @@ jobs:
           name: windows-avx2
 
   windows-build-avx2:
-    runs-on: [self-hosted, Windows, AVX-VNNI]
+    runs-on: [self-hosted, Windows, AVX-VNNI-Build]
     needs: check-windows-avx2-artifact
     if: needs.check-windows-avx2-artifact.outputs.if-exists == 'false'
     steps:
@@ -371,7 +371,7 @@ jobs:
           name: windows-avx-vnni
 
   windows-build-avx-vnni:
-    runs-on: [self-hosted, Windows, AVX-VNNI]
+    runs-on: [self-hosted, Windows, AVX-VNNI-Build]
     needs: check-windows-avx-vnni-artifact
     if: needs.check-windows-avx-vnni-artifact.outputs.if-exists == 'false'
     steps:
@@ -480,7 +480,7 @@ jobs:
           name: windows-avx
 
   windows-build-avx:
-    runs-on: [self-hosted, Windows, AVX-VNNI]
+    runs-on: [self-hosted, Windows, AVX-VNNI-Build]
     needs: check-windows-avx-artifact
     if: needs.check-windows-avx-artifact.outputs.if-exists == 'false'
     steps:

--- a/.github/workflows/llm-nightly-test.yml
+++ b/.github/workflows/llm-nightly-test.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         include:
           - os: windows
-            instruction: AVX-VNNI
+            instruction: AVX-VNNI-UT
             python-version: "3.9"
           - os: ubuntu-20.04-lts
             instruction: avx512

--- a/.github/workflows/llm_unit_tests.yml
+++ b/.github/workflows/llm_unit_tests.yml
@@ -44,19 +44,19 @@ jobs:
       matrix:
         include:
           - os: windows
-            instruction: AVX-VNNI
+            instruction: AVX-VNNI-UT
             python-version: "3.9"
           - os: ubuntu-20.04-lts
             instruction: avx512
             python-version: "3.9"
           - os: windows
-            instruction: AVX-VNNI
+            instruction: AVX-VNNI-UT
             python-version: "3.10"
           - os: ubuntu-20.04-lts
             instruction: avx512
             python-version: "3.10"
           - os: windows
-            instruction: AVX-VNNI
+            instruction: AVX-VNNI-UT
             python-version: "3.11"
           - os: ubuntu-20.04-lts
             instruction: avx512


### PR DESCRIPTION
## Description

Currently, both UT and build jobs are running on the same windows runners, which could make build jobs wait too long time. In this PR, we separate windows build and UT runners to make sure the building jobs not waiting for the UT ones.

### How to test?
- [ ] Unit test
