### PR TITLE
set bigdl-core/zoo-core version to 2.4.0-SNAPSHOT

### DIFF
--- a/scala/assembly/pom.xml
+++ b/scala/assembly/pom.xml
@@ -55,12 +55,12 @@
       <dependency>
         <groupId>com.intel.analytics.zoo</groupId>
         <artifactId>zoo-core-tfnet-linux</artifactId>
-        <version>2.5.0-SNAPSHOT</version>
+        <version>2.4.0-SNAPSHOT</version>
       </dependency>
       <dependency>
         <groupId>com.intel.analytics.zoo</groupId>
         <artifactId>zoo-core-tfnet-mac</artifactId>
-        <version>2.5.0-SNAPSHOT</version>
+        <version>2.4.0-SNAPSHOT</version>
       </dependency>
       <dependency>
             <groupId>com.intel.analytics.bigdl</groupId>

--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -186,7 +186,7 @@
         <dependency>
             <groupId>com.intel.analytics.bigdl.core.dist</groupId>
             <artifactId>all</artifactId>
-            <version>2.5.0-SNAPSHOT</version>
+            <version>2.4.0-SNAPSHOT</version>
             <scope>${bigdl-core-all-scope}</scope>
         </dependency>
         <dependency>

--- a/scala/friesian/pom.xml
+++ b/scala/friesian/pom.xml
@@ -70,13 +70,13 @@
         <dependency>
             <groupId>com.intel.analytics.bigdl.core.dist</groupId>
             <artifactId>all</artifactId>
-            <version>2.5.0-SNAPSHOT</version>
+            <version>2.4.0-SNAPSHOT</version>
             <scope>${bigdl-core-all-scope}</scope>
         </dependency>
         <dependency>
             <groupId>com.intel.analytics.zoo</groupId>
             <artifactId>${core.artifactId}</artifactId>
-            <version>2.5.0-SNAPSHOT</version>
+            <version>2.4.0-SNAPSHOT</version>
             <type>${core.dependencyType}</type>
             <scope>${core.scope}</scope>
         </dependency>
@@ -642,7 +642,7 @@
                 <dependency>
                     <groupId>com.intel.analytics.bigdl.core.dist</groupId>
                     <artifactId>${os-flag}</artifactId>
-                    <version>2.5.0-SNAPSHOT</version>
+                    <version>2.4.0-SNAPSHOT</version>
                     <type>pom</type>
                 </dependency>
             </dependencies>

--- a/scala/orca/pom.xml
+++ b/scala/orca/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.intel.analytics.bigdl.core.dist</groupId>
             <artifactId>all</artifactId>
-            <version>2.5.0-SNAPSHOT</version>
+            <version>2.4.0-SNAPSHOT</version>
             <scope>${bigdl-core-all-scope}</scope>
         </dependency>
         <dependency>
@@ -288,7 +288,7 @@
         <!--<dependency>-->
             <!--<groupId>com.intel.analytics.bigdl.core.dist</groupId>-->
             <!--<artifactId>all</artifactId>-->
-            <!--<version>2.5.0-SNAPSHOT</version>-->
+            <!--<version>2.4.0-SNAPSHOT</version>-->
             <!--<scope>${bigdl-core-all-scope}</scope>-->
         <!--</dependency>-->
         <!--<dependency>-->
@@ -568,7 +568,7 @@
               <dependency>
                 <groupId>com.intel.analytics.bigdl.core.dist</groupId>
                 <artifactId>${os-flag}</artifactId>
-                <version>2.5.0-SNAPSHOT</version>
+                <version>2.4.0-SNAPSHOT</version>
                 <type>pom</type>
               </dependency>
             </dependencies>
@@ -605,7 +605,7 @@
                 <dependency>
                     <groupId>com.intel.analytics.zoo</groupId>
                     <artifactId>zoo-core-dist-all</artifactId>
-                    <version>2.5.0-SNAPSHOT</version>
+                    <version>2.4.0-SNAPSHOT</version>
                     <type>jar</type>
                 </dependency>
             </dependencies>
@@ -621,7 +621,7 @@
                 <dependency>
                     <groupId>com.intel.analytics.zoo</groupId>
                     <artifactId>zoo-core-dist-linux64</artifactId>
-                    <version>2.5.0-SNAPSHOT</version>
+                    <version>2.4.0-SNAPSHOT</version>
                     <type>pom</type>
                     <exclusions>
                         <exclusion>
@@ -644,7 +644,7 @@
                 <dependency>
                     <groupId>com.intel.analytics.zoo</groupId>
                     <artifactId>zoo-core-dist-mac</artifactId>
-                    <version>2.5.0-SNAPSHOT</version>
+                    <version>2.4.0-SNAPSHOT</version>
                     <type>pom</type>
                         <exclusions>
                         <exclusion>
@@ -657,12 +657,12 @@
                 <dependency>
                     <groupId>com.intel.analytics.zoo</groupId>
                     <artifactId>zoo-core-mkl-linux</artifactId>
-                    <version>2.5.0-SNAPSHOT</version>
+                    <version>2.4.0-SNAPSHOT</version>
                 </dependency>
                 <dependency>
                     <groupId>com.intel.analytics.zoo</groupId>
                     <artifactId>zoo-core-pmem-java-linux</artifactId>
-                    <version>2.5.0-SNAPSHOT</version>
+                    <version>2.4.0-SNAPSHOT</version>
                 </dependency>
             </dependencies>
         </profile>

--- a/scala/ppml/pom.xml
+++ b/scala/ppml/pom.xml
@@ -250,7 +250,7 @@
         <dependency>
             <groupId>com.intel.analytics.bigdl.core.dist</groupId>
             <artifactId>all</artifactId>
-            <version>2.5.0-SNAPSHOT</version>
+            <version>2.4.0-SNAPSHOT</version>
             <scope>${bigdl-core-all-scope}</scope>
         </dependency>
         <dependency>

--- a/scala/serving/pom.xml
+++ b/scala/serving/pom.xml
@@ -33,7 +33,7 @@
         <dependency>
             <groupId>com.intel.analytics.bigdl.core.dist</groupId>
             <artifactId>all</artifactId>
-            <version>2.5.0-SNAPSHOT</version>
+            <version>2.4.0-SNAPSHOT</version>
             <scope>${bigdl-core-all-scope}</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
We will not release bigdl-core and zoo-core for 2.4.0 and 2.5.0, we keep using 2.4.0-SNAPSHOT for bigdl-core and zoo-core.