### PR TITLE
LLM: update rms related usage to suport ipex 2.1 new api

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -80,7 +80,7 @@ def chatglm_rms_norm_forward(self, hidden_states):
     if hidden_states.device.type == "xpu" and not (self.training and hidden_states.requires_grad):
         if get_ipex_version() <= "2.0.110+xpu":
             hidden_states, _ = torch.ops.torch_ipex.rms_norm(hidden_states,
-                                                            [self.weight.size(0)], self.weight)
+                                                             [self.weight.size(0)], self.weight)
         else:
             # for ipex >= 2.1
             hidden_states = torch.ops.torch_ipex.fast_rms_norm(hidden_states,


### PR DESCRIPTION
## Description

### 1. Why the change?

Update rms related usage to support ipex 2.1 new api or new pamameters.

### 2. User API changes

No change.

### 3. Summary of the change 

- Support `fast_rms_norm` for ipex >= 2.1 to further accelerate rms norm
perf update here: https://github.com/analytics-zoo/nano/issues/759#issuecomment-1811829580

### 4. How to test?
- [x] Unit test
- [x] Local test for llama2-7b / chatglm2-6b

