### PR TITLE
[LLM] Empty cache after embedding moved to CPU

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/embedding.py
+++ b/python/llm/src/bigdl/llm/transformers/embedding.py
@@ -23,4 +23,5 @@ class LLMEmbedding(torch.nn.Embedding):
     def forward(self, x: Tensor):
         if self.weight.device != 'cpu':
             self.to('cpu')
+            torch.xpu.empty_cache()
         return super().forward(x.to('cpu')).to(x.device)


### PR DESCRIPTION
## Description

Empty cache after embedding moved to CPU for iGPU.

However, this may lead some native effect to the first token latency

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/693#issuecomment-1797944763