### PR TITLE
Update all in one benchmark readme

### DIFF
--- a/python/llm/dev/benchmark/all-in-one/README.md
+++ b/python/llm/dev/benchmark/all-in-one/README.md
@@ -9,7 +9,7 @@ pip install omegaconf
 pip install pandas
 ```
 
-Script for MAX GPU uses libtcmalloc.so from gperftools package for potentially better performance.
+Install gperftools to use libtcmalloc.so for MAX GPU to get better performance:
 ```bash
 conda install -c conda-forge -y gperftools=2.10
 ```

--- a/python/llm/dev/benchmark/all-in-one/README.md
+++ b/python/llm/dev/benchmark/all-in-one/README.md
@@ -9,6 +9,11 @@ pip install omegaconf
 pip install pandas
 ```
 
+Script for MAX GPU uses libtcmalloc.so from gperftools package for potentially better performance.
+```bash
+conda install -c conda-forge -y gperftools=2.10
+```
+
 ## Config
 Config YAML file has following format
 ```yaml
@@ -46,3 +51,5 @@ For SPR performance, run `bash run-spr.sh`.
 > Please install torch nightly version to avoid `Illegal instruction (core dumped)` issue, you can follow the following command to install: `pip install --pre --upgrade torch --index-url https://download.pytorch.org/whl/nightly/cpu`
 
 For ARC performance, run `bash run-arc.sh`.
+
+For MAX GPU performance, run `bash run-max-gpu.sh`.


### PR DESCRIPTION
## Description

In the all-in-one performance benchmark, the script run-max-gpu.sh, preloads libtcmalloc.so
```
export LD_PRELOAD=${LD_PRELOAD}:${CONDA_PREFIX}/lib/libtcmalloc.so
```
libtcmalloc.so is not part of BigDL-llm install. Without libtcmalloc.so, the script still runs successfully, but with lower performance in some test cases.

This PR adds instructions for installing gperftools package (which contains libtcmalloc.so) to all-in-one's readme.
