### PR TITLE
LLM: GPU QLoRA update to bf16 to accelerate gradient checkpointing

### DIFF
--- a/python/llm/example/GPU/QLoRA-FineTuning/export_merged_model.py
+++ b/python/llm/example/GPU/QLoRA-FineTuning/export_merged_model.py
@@ -72,15 +72,10 @@ if __name__ == "__main__":
         0
     ].self_attn.q_proj.weight
 
-    assert torch.allclose(first_weight_old, first_weight)
-
     # merge weights - new merging method from peft
     lora_model = lora_model.merge_and_unload()
 
     lora_model.train(False)
-
-    # did we do anything?
-    assert not torch.allclose(first_weight_old, first_weight)
 
     lora_model_sd = lora_model.state_dict()
     deloreanized_sd = {

--- a/python/llm/src/bigdl/llm/transformers/qlora.py
+++ b/python/llm/src/bigdl/llm/transformers/qlora.py
@@ -360,3 +360,15 @@ Accelerator._prepare_ipex = patch_prepare_ipex
 # patch transformer for xpu DDP traing
 from transformers import TrainingArguments
 TrainingArguments._setup_devices = _setup_devices
+
+
+def cast_lora_weight(model, dtype=torch.bfloat16):
+    for name, module in model.named_modules():
+        if isinstance(module, LoraLayer):
+            module = module.to(dtype)
+        if 'norm' in name:
+            module = module.to(torch.float32)
+        if 'lm_head' in name or 'embed_tokens' in name:
+            if hasattr(module, 'weight'):
+                if module.weight.dtype == torch.float32:
+                    module = module.to(dtype)

--- a/python/llm/src/bigdl/llm/transformers/qlora.py
+++ b/python/llm/src/bigdl/llm/transformers/qlora.py
@@ -87,7 +87,10 @@ class LoraLowBitLinear(LowBitLinear, LoraLayer):
 
     def forward(self, x: torch.Tensor):
         autocast_dtype = get_autocast_dtype(x)
-        if autocast_dtype is not None:
+        if x.device.type == "xpu":
+            # force to use bf16 on gpu
+            x = x.to(torch.bfloat16)
+        elif autocast_dtype is not None:
             x = x.to(autocast_dtype)
         result = super().forward(x)
 
@@ -95,7 +98,7 @@ class LoraLowBitLinear(LowBitLinear, LoraLayer):
             return result
         elif self.r[self.active_adapter] > 0:
             result = result.clone()
-            if autocast_dtype is None:
+            if autocast_dtype is None and x.device.type == "cpu":
                 expected_dtype = result.dtype
                 x = x.to(self.lora_A[self.active_adapter].weight.dtype)
                 output = (


### PR DESCRIPTION
## Description

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/775#issuecomment-1820116754

### 2. User API changes

No change.

### 3. Summary of the change 

- Update `LoraLowBitLinear` to force input to bf16 on GPU (to solve gradient checkpointing issue)
- Update related GPU QLoRA examples to cast lora Linear to bf16 (to solve gradient checkpointing issue and reduce GPU memory use in all cases)

### 4. How to test?
- [ ] Unit test
- [x] Local test
