### PR TITLE
LLM: fix transformers version in CPU finetuning example

### DIFF
--- a/python/llm/example/CPU/QLoRA-FineTuning/alpaca-qlora/README.md
+++ b/python/llm/example/CPU/QLoRA-FineTuning/alpaca-qlora/README.md
@@ -8,8 +8,8 @@ This example ports [Alpaca-LoRA](https://github.com/tloen/alpaca-lora/tree/main)
 conda create -n llm python=3.9
 conda activate llm
 pip install --pre --upgrade bigdl-llm[all]
-pip install transformers==4.34.0
-pip install fire datasets peft==0.5.0
+pip install datasets transformers==4.34.0
+pip install fire peft==0.5.0
 pip install accelerate==0.23.0
 ```
 


### PR DESCRIPTION
## Description

Following the installation commands in README, `transformers==4.35.2` is installed finally (because of the latest `dataset`).
Fix installation to ensure `transformers==4.34.0` is used. 

### 4. How to test?
- [ ] Unit test
- [x] Local installation test
