### PR TITLE
Replace torch.bmm with safe_bmm

### DIFF
--- a/python/llm/src/bigdl/llm/optimize.py
+++ b/python/llm/src/bigdl/llm/optimize.py
@@ -193,7 +193,7 @@ def load_low_bit(model, model_path):
 
 
 def optimize_model(model, low_bit='sym_int4', optimize_llm=True, modules_to_not_convert=None,
-                   replace_embedding=False):
+                   replace_embedding=False, safe_bmm=False):
     """
     A method to optimize any pytorch model.
 
@@ -204,6 +204,8 @@ def optimize_model(model, low_bit='sym_int4', optimize_llm=True, modules_to_not_
     :param modules_to_not_convert: list of str value, modules (nn.Module) that are skipped
         when conducting model optimizations. Default to be None.
     :param replace_embedding: Whether to replace the Embedding layer, may need to set it
+        to `True` when running BigDL-LLM on GPU on Windows. Default to be `False`.
+    :param safe_bmm: Whether to replace the torch.bmm ops, may need to set it
         to `True` when running BigDL-LLM on GPU on Windows. Default to be `False`.
 
     :return: The optimized model.
@@ -231,7 +233,8 @@ def optimize_model(model, low_bit='sym_int4', optimize_llm=True, modules_to_not_
                                  qtype=qtype,
                                  optimize_model=optimize_llm,
                                  modules_to_not_convert=modules_to_not_convert,
-                                 replace_embedding=replace_embedding)
+                                 replace_embedding=replace_embedding,
+                                 safe_bmm=safe_bmm)
     # add save_low_bit to pretrained model dynamically
     import types
     model._bigdl_config = dict()

--- a/python/llm/src/bigdl/llm/transformers/bmm.py
+++ b/python/llm/src/bigdl/llm/transformers/bmm.py
@@ -1,0 +1,45 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+
+import torch
+import linear_q4_0
+torch_bmm_old_ = torch.bmm
+
+
+def torch_bmm(a, b):
+    if a.device.type == 'cpu':
+        return torch_bmm_old_(a, b)
+
+    batch, A_rows, common = a.size()
+    B_cols = b.size(2)
+    C = torch.empty((batch, A_rows, B_cols), device=a.device)
+    if a.size(1) == 1:
+        torch_bmm_old_(a, b, out=C)
+    else:
+        linear_q4_0.bmm(a.contiguous(), b.contiguous(), C)
+    return C
+
+
+class SafeBMM:
+    def __init__(self):
+        self._old_bmm = torch_bmm_old_
+
+    def __enter__(self):
+        torch.bmm = torch_bmm
+
+    def __exit__(self, *args, **kwargs):
+        torch.bmm = self._old_bmm

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -172,7 +172,7 @@ def convert_gptq(module, awq=False):
 
 def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                                  current_key_name=None, convert_shape_only=False,
-                                 replace_embedding=False):
+                                 cpu_embedding=False):
     from bigdl.llm.transformers.low_bit_linear import LowBitLinear, FP4Params, FP16Linear
     from bigdl.llm.transformers.embedding import LLMEmbedding
     has_been_replaced = False
@@ -265,7 +265,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                         model._modules[name].requires_grad_(False)
 
                         module.weight = None
-        elif replace_embedding and type(module) == nn.Embedding:
+        elif cpu_embedding and type(module) == nn.Embedding:
             # skip user-defined Embedding layer
             if platform.system().lower() == 'windows':
                 model._modules[name] = LLMEmbedding(
@@ -287,7 +287,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                 modules_to_not_convert,
                 current_key_name,
                 convert_shape_only,
-                replace_embedding,
+                cpu_embedding,
             )
             has_been_replaced = _flag or has_been_replaced
     return model, has_been_replaced
@@ -321,8 +321,8 @@ def _optimize_pre(model):
 
 def ggml_convert_low_bit(model, qtype, optimize_model=True,
                          convert_shape_only=False, device="cpu",
-                         modules_to_not_convert=None, replace_embedding=False,
-                         safe_bmm=False):
+                         modules_to_not_convert=None, cpu_embedding=False,
+                         lightweight_bmm=False):
     logger.info(f"Converting the current model to "
                 f"{list(ggml_tensor_qtype.keys())[list(ggml_tensor_qtype.values()).index(qtype)]} "
                 f"format......")
@@ -333,7 +333,7 @@ def ggml_convert_low_bit(model, qtype, optimize_model=True,
 
     model, has_been_replaced = _replace_with_low_bit_linear(
         model, qtype, modules_to_not_convert,
-        None, convert_shape_only, replace_embedding,
+        None, convert_shape_only, cpu_embedding,
     )
     if not has_been_replaced:
         warnings.warn(
@@ -350,7 +350,7 @@ def ggml_convert_low_bit(model, qtype, optimize_model=True,
         pass
 
     if optimize_model:
-        model = _optimize_post(model, safe_bmm)
+        model = _optimize_post(model, lightweight_bmm)
     return model
 
 
@@ -362,7 +362,7 @@ def convert_forward(m, target_m, new_forward):
         convert_forward(sub_m, target_m, new_forward)
 
 
-def _optimize_post(model, safe_bmm=False):
+def _optimize_post(model, lightweight_bmm=False):
     from packaging import version
     from bigdl.llm.transformers.models.llama import llama_attention_forward_4_31
     from bigdl.llm.transformers.models.llama import llama_rms_norm_forward
@@ -594,7 +594,7 @@ def _optimize_post(model, safe_bmm=False):
         convert_forward(model,
                         module.MistralRMSNorm,
                         llama_rms_norm_forward)
-    elif model.config.model_type == "whisper" and safe_bmm:
+    elif model.config.model_type == "whisper" and lightweight_bmm:
         if platform.system().lower() == 'windows':
             from bigdl.llm.transformers.bmm import SafeBMM
             modeling_module_name = model.__class__.__module__

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -100,6 +100,8 @@ class _BaseAutoModelClass:
                                        conducting model optimizations. Default to be None.
         :param replace_embedding: Whether to replace the Embedding layer, may need to set it
             to `True` when running BigDL-LLM on GPU on Windows. Default to be `False`.
+        :param safe_bmm: Whether to replace the torch.bmm ops, may need to set it
+            to `True` when running BigDL-LLM on GPU on Windows. Default to be `False`.
         :return: a model instance
         """
         pretrained_model_name_or_path = kwargs.get("pretrained_model_name_or_path", None) \
@@ -202,6 +204,7 @@ class _BaseAutoModelClass:
         # and lead to args missing.
         modules_to_not_convert = kwargs.pop("modules_to_not_convert", None)
         replace_embedding = kwargs.pop("replace_embedding", False)
+        safe_bmm = kwargs.pop("safe_bmm", False)
         quant_config = kwargs.pop("quantization_config", None)
         _args = copy.deepcopy(args)
         _kwargs = copy.deepcopy(kwargs)
@@ -262,7 +265,7 @@ class _BaseAutoModelClass:
         model = model.to("cpu")
         model = ggml_convert_low_bit(model, qtype, optimize_model,
                                      modules_to_not_convert=modules_to_not_convert,
-                                     replace_embedding=replace_embedding)
+                                     replace_embedding=replace_embedding, safe_bmm=safe_bmm)
         model.config.update({"bigdl_transformers_low_bit": q_k})
         model.config.update({"tie_word_embeddings": False})
 
@@ -300,6 +303,7 @@ class _BaseAutoModelClass:
 
         modules_to_not_convert = kwargs.pop("modules_to_not_convert", None)
         replace_embedding = kwargs.pop("replace_embedding", False)
+        safe_bmm = kwargs.pop("safe_bmm", False)
         # Autofactory
         trust_remote_code = kwargs.pop("trust_remote_code", None)
         kwargs_orig = copy.deepcopy(kwargs)
@@ -411,7 +415,7 @@ class _BaseAutoModelClass:
         quant_device = "meta" if bigdl_lcmu_enabled else "cpu"
         model = ggml_convert_low_bit(model, qtype, optimize_model, device=quant_device,
                                      modules_to_not_convert=modules_to_not_convert,
-                                     replace_embedding=replace_embedding)
+                                     replace_embedding=replace_embedding, safe_bmm=safe_bmm)
 
         if is_sharded:
             loaded_state_dict_keys = sharded_metadata["all_checkpoint_keys"]


### PR DESCRIPTION
## Description

This feature is only enabled for whisper on windows gpu to avoid system crash issue raised by ipex bmm(or mkl). Please do not(and no need to) set `lightweight_bmm=True` on core series.