### PR TITLE
CPU Pinned embedding Layer

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/embedding.py
+++ b/python/llm/src/bigdl/llm/transformers/embedding.py
@@ -23,7 +23,7 @@ from typing import Optional
 
 
 # To prevent insufficient available memory when moving embedding from XPU back to CPU,
-# we can pin the embedding to CPU if `replace_embedding==True`.
+# we can pin the embedding to CPU if `cpu_embedding==True`.
 class CPUPinnedParam(Parameter):
     def to(self, *args, **kwargs):
         device, dtype, non_blocking, convert_to_format = torch._C._nn._parse_to(*args, **kwargs)

--- a/python/llm/src/bigdl/llm/transformers/embedding.py
+++ b/python/llm/src/bigdl/llm/transformers/embedding.py
@@ -21,7 +21,8 @@ from torch.nn import functional as F
 from torch.nn import Parameter
 from typing import Optional
 
-# To prevent insufficient available memory when moving embedding from XPU back to CPU, 
+
+# To prevent insufficient available memory when moving embedding from XPU back to CPU,
 # we can pin the embedding to CPU if `replace_embedding==True`.
 class CPUPinnedParam(Parameter):
     def to(self, *args, **kwargs):
@@ -30,12 +31,21 @@ class CPUPinnedParam(Parameter):
             return self
         return super().to(*args, **kwargs)
 
+
 class LLMEmbedding(torch.nn.Embedding):
-    def __init__(self, num_embeddings: int, embedding_dim: int, padding_idx: Optional[int] = None,
-                 max_norm: Optional[float] = None, norm_type: float = 2., scale_grad_by_freq: bool = False,
-                 sparse: bool = False, _weight: Optional[Tensor] = None, _freeze: bool = False,
+    def __init__(self,
+                 num_embeddings: int,
+                 embedding_dim: int,
+                 padding_idx: Optional[int] = None,
+                 max_norm: Optional[float] = None,
+                 norm_type: float = 2.,
+                 scale_grad_by_freq: bool = False,
+                 sparse: bool = False,
+                 _weight: Optional[Tensor] = None,
+                 _freeze: bool = False,
                  device=None, dtype=None) -> None:
-        super().__init__(num_embeddings, embedding_dim, padding_idx, max_norm, norm_type, scale_grad_by_freq, sparse,
+        super().__init__(num_embeddings, embedding_dim, padding_idx,
+                         max_norm, norm_type, scale_grad_by_freq, sparse,
                          _weight)
         self.weight = CPUPinnedParam(self.weight.data, requires_grad=not _freeze)
 

--- a/python/llm/src/bigdl/llm/transformers/embedding.py
+++ b/python/llm/src/bigdl/llm/transformers/embedding.py
@@ -49,7 +49,7 @@ class LLMEmbedding(torch.nn.Embedding):
                  device=None, dtype=None) -> None:
         super().__init__(num_embeddings, embedding_dim, padding_idx,
                          max_norm, norm_type, scale_grad_by_freq, sparse,
-                         _weight)
+                         _weight, device, dtype)
         self.weight = CPUPinnedParam(self.weight.data, requires_grad=not _freeze)
 
     def forward(self, x: Tensor):

--- a/python/llm/src/bigdl/llm/transformers/embedding.py
+++ b/python/llm/src/bigdl/llm/transformers/embedding.py
@@ -30,7 +30,7 @@ class CPUPinnedParam(Parameter):
         if device.type == 'xpu':
             if convert_to_format is not None and self.dim() in (4, 5):
                 return super().to('cpu', dtype,
-                            non_blocking, memory_format=convert_to_format)
+                                  non_blocking, memory_format=convert_to_format)
             return super().to('cpu', dtype, non_blocking)
         return super().to(*args, **kwargs)
 

--- a/python/llm/src/bigdl/llm/transformers/embedding.py
+++ b/python/llm/src/bigdl/llm/transformers/embedding.py
@@ -28,7 +28,10 @@ class CPUPinnedParam(Parameter):
     def to(self, *args, **kwargs):
         device, dtype, non_blocking, convert_to_format = torch._C._nn._parse_to(*args, **kwargs)
         if device.type == 'xpu':
-            return self
+            if convert_to_format is not None and self.dim() in (4, 5):
+                return super().to('cpu', dtype,
+                            non_blocking, memory_format=convert_to_format)
+            return super().to('cpu', dtype, non_blocking)
         return super().to(*args, **kwargs)
 
 

--- a/python/llm/src/bigdl/llm/transformers/embedding.py
+++ b/python/llm/src/bigdl/llm/transformers/embedding.py
@@ -17,11 +17,27 @@
 
 import torch
 from torch import Tensor
+from torch.nn import functional as F
+from torch.nn import Parameter
+from typing import Optional
 
+# To prevent insufficient available memory when moving embedding from XPU back to CPU, 
+# we can pin the embedding to CPU if `replace_embedding==True`.
+class CPUPinnedParam(Parameter):
+    def to(self, *args, **kwargs):
+        device, dtype, non_blocking, convert_to_format = torch._C._nn._parse_to(*args, **kwargs)
+        if device.type == 'xpu':
+            return self
+        return super().to(*args, **kwargs)
 
 class LLMEmbedding(torch.nn.Embedding):
+    def __init__(self, num_embeddings: int, embedding_dim: int, padding_idx: Optional[int] = None,
+                 max_norm: Optional[float] = None, norm_type: float = 2., scale_grad_by_freq: bool = False,
+                 sparse: bool = False, _weight: Optional[Tensor] = None, _freeze: bool = False,
+                 device=None, dtype=None) -> None:
+        super().__init__(num_embeddings, embedding_dim, padding_idx, max_norm, norm_type, scale_grad_by_freq, sparse,
+                         _weight)
+        self.weight = CPUPinnedParam(self.weight.data, requires_grad=not _freeze)
+
     def forward(self, x: Tensor):
-        if self.weight.device != 'cpu':
-            self.to('cpu')
-            torch.xpu.empty_cache()
         return super().forward(x.to('cpu')).to(x.device)


### PR DESCRIPTION
## Description
To prevent insufficient available memory when moving embedding from XPU back to CPU,  we can always pin the embedding on CPU if `cpu_embedding==True`.

https://github.com/intel-analytics/BigDL/issues/9483

```log
  File "C:\Users\MTL822\miniconda3\envs\audio\lib\site-packages\bigdl\llm\transformers\embedding.py", line 25, in forward
    self.to('cpu')
  File "C:\Users\MTL822\miniconda3\envs\audio\lib\site-packages\torch\nn\modules\module.py", line 1145, in to
    return self._apply(convert)
  File "C:\Users\MTL822\miniconda3\envs\audio\lib\site-packages\torch\nn\modules\module.py", line 820, in _apply
    param_applied = fn(param)
  File "C:\Users\MTL822\miniconda3\envs\audio\lib\site-packages\torch\nn\modules\module.py", line 1143, in convert
    return t.to(device, dtype if t.is_floating_point() or t.is_complex() else None, non_blocking)
RuntimeError: Native API failed. Native API returns: -5 (PI_ERROR_OUT_OF_RESOURCES) -5 (PI_ERROR_OUT_OF_RESOURCES)
```