### PR TITLE
[LLM Doc] Fix api doc rendering error

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -108,7 +108,6 @@ def is_linear_module(module):
     return result, (in_features, out_features, mp_group)
 
 
-
 def convert_gptq(module, awq=False):
     from bigdl.llm.transformers.low_bit_linear import get_ggml_qk_size
     Q4_1 = get_ggml_qk_size("asym_int4")

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -108,11 +108,11 @@ def is_linear_module(module):
     return result, (in_features, out_features, mp_group)
 
 
-from bigdl.llm.transformers.low_bit_linear import get_ggml_qk_size
-Q4_1 = get_ggml_qk_size("asym_int4")
-
 
 def convert_gptq(module, awq=False):
+    from bigdl.llm.transformers.low_bit_linear import get_ggml_qk_size
+    Q4_1 = get_ggml_qk_size("asym_int4")
+
     scales = module.scales
 
     zeros = torch.bitwise_right_shift(


### PR DESCRIPTION
## Description

Fix api doc rendering error. Currently, all llm api docs are failed to render.

`from bigdl.llm.transformers.low_bit_linear import get_ggml_qk_size` cost `~e^-6` s from the second time of import, and `Q4_1 = get_ggml_qk_size("asym_int4")` costs  `~e^-6`s, which means the overhead led by moving the `import` and `Q4_1=..` into the `convert_gptq` function can be ignored.

### How to test?
- [x] https://yuwentestdocs.readthedocs.io/en/fix-llm-api-doc/doc/PythonAPI/LLM/optimize.html