### PR TITLE
[LLM] support loading llama tokenizer from gguf model

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/gguf/api.py
+++ b/python/llm/src/bigdl/llm/transformers/gguf/api.py
@@ -41,8 +41,8 @@ def load_gguf_model(fpath: str, dtype: torch.dtype = torch.float):
         if model_family == "llama":
             from .models.llama import load_gguf_llama
 
-            model = load_gguf_llama(loader, dtype)
+            model, tokenizer = load_gguf_llama(loader, dtype)
         else:
             invalidInputError(False, f"Unsupported model family: {model_family}")
 
-        return model, low_bit
+        return model, tokenizer, low_bit

--- a/python/llm/src/bigdl/llm/transformers/gguf/gguf.py
+++ b/python/llm/src/bigdl/llm/transformers/gguf/gguf.py
@@ -372,3 +372,25 @@ class GGUFFileLoader:
 
     def tensors_iter(self):
         return self.tensor_loader
+
+    def tokenizer_pieces(self):
+        from transformers.convert_slow_tokenizer import import_protobuf
+        spm_pb2 = import_protobuf("Failed to import protobuf")
+
+        tokens = self.config['tokenizer.ggml.tokens']
+        scores = self.config['tokenizer.ggml.scores']
+        token_types = self.config['tokenizer.ggml.token_type']
+
+        pieces = [
+            spm_pb2.ModelProto.SentencePiece(
+                piece=token,
+                score=score,
+                type=token_type,
+            )
+            for token, score, token_type in tqdm(
+                zip(tokens, scores, token_types),
+                "Loading gguf vocab"
+            )
+        ]
+
+        return pieces

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -194,21 +194,21 @@ class _BaseAutoModelClass:
     @staticmethod
     def from_gguf(fpath: str, optimize_model: bool = True, cpu_embedding: bool = False):
         """
-        Load a gguf model and convert it to bigdl-llm model
+        Load gguf model and tokenizer and convert it to bigdl-llm model and huggingface tokenzier
 
         :param fpath: Path to gguf model file
         :param optimize_model: Whether to further optimize llm model, defaults to True
         :param cpu_embedding: Whether to replace the Embedding layer, may need to set it
             to `True` when running BigDL-LLM on GPU on Windows, defaults to False
 
-        :return: An optimized bigdl-llm model
+        :return: An optimized bigdl-llm model and a huggingface tokenizer
         """
         from bigdl.llm.optimize import optimize_model as optimize_model_fn
 
-        model, low_bit = load_gguf_model(fpath, dtype=torch.half)
+        model, tokenizer, low_bit = load_gguf_model(fpath, dtype=torch.half)
         model = optimize_model_fn(model, low_bit=low_bit, optimize_llm=optimize_model,
                                   cpu_embedding=cpu_embedding)
-        return model
+        return model, tokenizer
 
     @classmethod
     def load_convert(cls, q_k, optimize_model, *args, **kwargs):


### PR DESCRIPTION
## Description

support loading llama tokenizer from gguf model

### 1. Why the change?

support loading llama tokenizer from gguf model

### 2. User API changes

from bigdl.llm.transformers import AutoModelForCausalLM

model, tokenizer = AutoModelForCausalLM.from_gguf("/root/yishuo/llama-2-7b-chat.Q4_0.gguf")

### 3. Summary of the change 

1. load gguf vocab
2. construct a sentencepiece proto using gguf vocab
3. save it
4. construct a LlamaTokenizer from it

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...
