### PR TITLE
Harness workflow dispatch

### DIFF
--- a/.github/workflows/llm-harness-evaluation.yml
+++ b/.github/workflows/llm-harness-evaluation.yml
@@ -21,6 +21,41 @@ on:
 jobs:
   llm-cpp-build:
     uses: ./.github/workflows/llm-binary-build.yml
+  set-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      model_name: ${{ steps.set-matrix.outputs.model_name }}
+      precision: ${{ steps.set-matrix.outputs.model_name }}
+      task: ${{ steps.set-matrix.outputs.model_name }}
+    steps:
+      - name: set-nightly-env
+        if: ${{github.event_name == 'schedule'}}
+        env:
+          NIGHTLY_MATRIX_MODEL_NAME: "[stablelm-3b-4e1t,Mistral-7B-v0.1]"
+          NIGHTLY_MATRIX_TASK: "[truthfulqa, arc]"
+          NIGHTLY_MATRIX_PRECISION: "[mixed_fp4, fp8]"
+        run: |
+            echo "model_name=$NIGHTLY_MATRIX_MODEL_NAME" >> $GIT_ENV
+            echo "precision=$NIGHTLY_MATRIX_PRECISION" >> $GIT_ENV
+            echo "task=$NIGHTLY_MATRIX_TASK" >> $GIT_ENV
+
+      - name: set-pr-env
+        if: ${{github.event_name == 'pull-request'}}
+        env:
+          PR_MATRIX_MODEL_NAME: "[stablelm-3b-4e1t]"
+          PR_MATRIX_TASK: "[truthfulqa]"
+          PR_MATRIX_PRECISION: "[mixed_fp4]"
+        run: |
+            echo "model_name=$PR_MATRIX_MODEL_NAME" >> $GIT_ENV
+            echo "precision=$PR_MATRIX_PRECISION" >> $GIT_ENV
+            echo "task=$PR_MATRIX_TASK" >> $GIT_ENV
+
+      - name: set-matrix
+        id: set-matrix
+        run: |
+            echo "model_name=$model_name" >> $GIT_OUTPUT
+            echo "precision=$precision" >> $GIT_OUTPUT
+            echo "task=$task" >> $GIT_OUTPUT
   llm-harness-evalution:
     timeout-minutes: 1000
     needs: llm-cpp-build

--- a/.github/workflows/llm-harness-evaluation.yml
+++ b/.github/workflows/llm-harness-evaluation.yml
@@ -66,9 +66,9 @@ jobs:
       - name: set-pr-env
         if: ${{github.event_name == 'workflow_dispatch'}}
         env:
-          MANUAL_MATRIX_MODEL_NAME: ${{format('[ {0} ]', join(inputs.model_name, ', '))}}
-          MANUAL_MATRIX_TASK: ${{format('[ {0} ]', join(inputs.task, ', '))}}
-          MANUAL_MATRIX_PRECISION: ${{format('[ {0} ]', join(inputs.precision, ', '))}}
+          MANUAL_MATRIX_MODEL_NAME: ${{format('[ {0} ]', inputs.model_name)}}
+          MANUAL_MATRIX_TASK: ${{format('[ {0} ]', inputs.task)}}
+          MANUAL_MATRIX_PRECISION: ${{format('[ {0} ]', inputs.precision)}}
         run: |
             echo "model_name=$MANUAL_MATRIX_MODEL_NAME" >> $GITHUB_ENV
             echo "precision=$MANUAL_MATRIX_TASK" >> $GITHUB_ENV

--- a/.github/workflows/llm-harness-evaluation.yml
+++ b/.github/workflows/llm-harness-evaluation.yml
@@ -29,6 +29,11 @@ on:
         description: 'A list of precisions added to the job matrix'
         required: true
         type: string
+      runs-on:
+        description: 'Labels to filter the runners.'
+        default: 'accuracy'
+        required: true
+        type: string
 
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
@@ -39,8 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       model_name: ${{ steps.set-matrix.outputs.model_name }}
-      precision: ${{ steps.set-matrix.outputs.model_name }}
-      task: ${{ steps.set-matrix.outputs.model_name }}
+      precision: ${{ steps.set-matrix.outputs.precision }}
+      task: ${{ steps.set-matrix.outputs.task }}
+      runner: ${{ steps.set-matrix.outputs.runner }}
     steps:
       - name: set-nightly-env
         if: ${{github.event_name == 'schedule'}}
@@ -48,10 +54,12 @@ jobs:
           NIGHTLY_MATRIX_MODEL_NAME: '["stablelm-3b-4e1t","Mistral-7B-v0.1"]'
           NIGHTLY_MATRIX_TASK: '["truthfulqa", "arc"]'
           NIGHTLY_MATRIX_PRECISION: '["mixed_fp4", "fp8"]'
+          NIGHTLY_LABELS: '["self-hosted", "llm", "accuracy"]'
         run: |
             echo "model_name=$NIGHTLY_MATRIX_MODEL_NAME" >> $GITHUB_ENV
             echo "precision=$NIGHTLY_MATRIX_PRECISION" >> $GITHUB_ENV
             echo "task=$NIGHTLY_MATRIX_TASK" >> $GITHUB_ENV
+            echo 'runner=$NIGHTLY_LABELS' >> $GITHUB_ENV
 
       - name: set-pr-env
         if: ${{github.event_name == 'pull_request'}}
@@ -59,20 +67,24 @@ jobs:
           PR_MATRIX_MODEL_NAME: '["stablelm-3b-4e1t"]'
           PR_MATRIX_TASK: '["truthfulqa"]'
           PR_MATRIX_PRECISION: '["mixed_fp4", "fp8"]'
+          PR_LABELS: '["self-hosted", "llm", "temp-arc01"]'
         run: |
             echo "model_name=$PR_MATRIX_MODEL_NAME" >> $GITHUB_ENV
             echo "precision=$PR_MATRIX_PRECISION" >> $GITHUB_ENV
             echo "task=$PR_MATRIX_TASK" >> $GITHUB_ENV
+            echo 'runner=$PR_LABELS' >> $GITHUB_ENV
       - name: set-manual-env
         if: ${{github.event_name == 'workflow_dispatch'}}
         env:
           MANUAL_MATRIX_MODEL_NAME: ${{format('[ {0} ]', inputs.model_name)}}
           MANUAL_MATRIX_TASK: ${{format('[ {0} ]', inputs.task)}}
           MANUAL_MATRIX_PRECISION: ${{format('[ {0} ]', inputs.precision)}}
+          MANUAL_LABELS: ${{format('["self-hosted", "llm", {0}]', inputs.precision)}}
         run: |
             echo "model_name=$MANUAL_MATRIX_MODEL_NAME" >> $GITHUB_ENV
             echo "precision=$MANUAL_MATRIX_TASK" >> $GITHUB_ENV
             echo "task=$MANUAL_MATRIX_PRECISION" >> $GITHUB_ENV
+            echo 'runner=$MANUAL_LABELS' >> $GITHUB_ENV
       - name: set-matrix
         id: set-matrix
         run: |
@@ -96,7 +108,7 @@ jobs:
         precision: ${{ fromJson(needs.set-matrix.outputs.precision) }}
         device: [xpu]
         
-    runs-on: [self-hosted, llm, accuracy]
+    runs-on: ${{ fromJson(needs.set-matrix.outputs.runner) }}
     env:
       ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
       ORIGIN_DIR: /mnt/disk1/models

--- a/.github/workflows/llm-harness-evaluation.yml
+++ b/.github/workflows/llm-harness-evaluation.yml
@@ -16,6 +16,20 @@ on:
       - ".github/workflows/llm-harness-evaluation.yml"
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
+    inputs:
+      model_name:
+        description: 'A list of models added to the job matrix.'
+        required: true
+        type: string
+      precision:
+        description: 'A list of precisions added to the job matrix'
+        required: true
+        type: string
+      task:
+        description: 'A list of precisions added to the job matrix'
+        required: true
+        type: string
+
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
@@ -44,12 +58,21 @@ jobs:
         env:
           PR_MATRIX_MODEL_NAME: "[stablelm-3b-4e1t]"
           PR_MATRIX_TASK: "[truthfulqa]"
-          PR_MATRIX_PRECISION: "[mixed_fp4]"
+          PR_MATRIX_PRECISION: "[mixed_fp4, fp8]"
         run: |
             echo "model_name=$PR_MATRIX_MODEL_NAME" >> $GIT_ENV
             echo "precision=$PR_MATRIX_PRECISION" >> $GIT_ENV
             echo "task=$PR_MATRIX_TASK" >> $GIT_ENV
-
+      - name: set-pr-env
+        if: ${{github.event_name == 'workflow_dispatch'}}
+        env:
+          MANUAL_MATRIX_MODEL_NAME: ${{format('[ {0} ]', join(inputs.model_name, ', '))}}
+          MANUAL_MATRIX_TASK: ${{format('[ {0} ]', join(inputs.task, ', '))}}
+          MANUAL_MATRIX_PRECISION: ${{format('[ {0} ]', join(inputs.precision, ', '))}}
+        run: |
+            echo "model_name=$MANUAL_MATRIX_MODEL_NAME" >> $GIT_ENV
+            echo "precision=$MANUAL_MATRIX_TASK" >> $GIT_ENV
+            echo "task=$MANUAL_MATRIX_PRECISION" >> $GIT_ENV
       - name: set-matrix
         id: set-matrix
         run: |
@@ -58,7 +81,7 @@ jobs:
             echo "task=$task" >> $GIT_OUTPUT
   llm-harness-evalution:
     timeout-minutes: 1000
-    needs: llm-cpp-build
+    needs: [llm-cpp-build, set-matrix]
     strategy:
       fail-fast: false
       matrix:
@@ -68,9 +91,9 @@ jobs:
         #   task: "arc"
         #   precision: "sym_int4" #options: sym_int4, fp4, mixed_fp4, sym_int8, fp8, mixed_fp8
         python-version: ["3.9"]
-        model_name: [stablelm-3b-4e1t,Mistral-7B-v0.1]
-        task: [truthfulqa, arc]
-        precision: [mixed_fp4, fp8] 
+        model_name: ${{ fromJson(needs.set-matrix.outputs.model_name) }}
+        task: ${{ fromJson(needs.set-matrix.outputs.task) }}
+        precision: ${{ fromJson(needs.set-matrix.outputs.precision) }}
         device: [xpu]
         
     runs-on: [self-hosted, llm, accuracy]

--- a/.github/workflows/llm-harness-evaluation.yml
+++ b/.github/workflows/llm-harness-evaluation.yml
@@ -32,7 +32,7 @@ on:
       runs-on:
         description: 'Labels to filter the runners.'
         default: 'accuracy'
-        required: true
+        required: false
         type: string
 
 

--- a/.github/workflows/llm-harness-evaluation.yml
+++ b/.github/workflows/llm-harness-evaluation.yml
@@ -63,7 +63,7 @@ jobs:
             echo "model_name=$PR_MATRIX_MODEL_NAME" >> $GITHUB_ENV
             echo "precision=$PR_MATRIX_PRECISION" >> $GITHUB_ENV
             echo "task=$PR_MATRIX_TASK" >> $GITHUB_ENV
-      - name: set-pr-env
+      - name: set-manual-env
         if: ${{github.event_name == 'workflow_dispatch'}}
         env:
           MANUAL_MATRIX_MODEL_NAME: ${{format('[ {0} ]', inputs.model_name)}}

--- a/.github/workflows/llm-harness-evaluation.yml
+++ b/.github/workflows/llm-harness-evaluation.yml
@@ -49,20 +49,20 @@ jobs:
           NIGHTLY_MATRIX_TASK: "[truthfulqa, arc]"
           NIGHTLY_MATRIX_PRECISION: "[mixed_fp4, fp8]"
         run: |
-            echo "model_name=$NIGHTLY_MATRIX_MODEL_NAME" >> $GIT_ENV
-            echo "precision=$NIGHTLY_MATRIX_PRECISION" >> $GIT_ENV
-            echo "task=$NIGHTLY_MATRIX_TASK" >> $GIT_ENV
+            echo "model_name=$NIGHTLY_MATRIX_MODEL_NAME" >> $GITHUB_ENV
+            echo "precision=$NIGHTLY_MATRIX_PRECISION" >> $GITHUB_ENV
+            echo "task=$NIGHTLY_MATRIX_TASK" >> $GITHUB_ENV
 
       - name: set-pr-env
-        if: ${{github.event_name == 'pull-request'}}
+        if: ${{github.event_name == 'pull_request'}}
         env:
           PR_MATRIX_MODEL_NAME: "[stablelm-3b-4e1t]"
           PR_MATRIX_TASK: "[truthfulqa]"
           PR_MATRIX_PRECISION: "[mixed_fp4, fp8]"
         run: |
-            echo "model_name=$PR_MATRIX_MODEL_NAME" >> $GIT_ENV
-            echo "precision=$PR_MATRIX_PRECISION" >> $GIT_ENV
-            echo "task=$PR_MATRIX_TASK" >> $GIT_ENV
+            echo "model_name=$PR_MATRIX_MODEL_NAME" >> $GITHUB_ENV
+            echo "precision=$PR_MATRIX_PRECISION" >> $GITHUB_ENV
+            echo "task=$PR_MATRIX_TASK" >> $GITHUB_ENV
       - name: set-pr-env
         if: ${{github.event_name == 'workflow_dispatch'}}
         env:
@@ -70,15 +70,15 @@ jobs:
           MANUAL_MATRIX_TASK: ${{format('[ {0} ]', join(inputs.task, ', '))}}
           MANUAL_MATRIX_PRECISION: ${{format('[ {0} ]', join(inputs.precision, ', '))}}
         run: |
-            echo "model_name=$MANUAL_MATRIX_MODEL_NAME" >> $GIT_ENV
-            echo "precision=$MANUAL_MATRIX_TASK" >> $GIT_ENV
-            echo "task=$MANUAL_MATRIX_PRECISION" >> $GIT_ENV
+            echo "model_name=$MANUAL_MATRIX_MODEL_NAME" >> $GITHUB_ENV
+            echo "precision=$MANUAL_MATRIX_TASK" >> $GITHUB_ENV
+            echo "task=$MANUAL_MATRIX_PRECISION" >> $GITHUB_ENV
       - name: set-matrix
         id: set-matrix
         run: |
-            echo "model_name=$model_name" >> $GIT_OUTPUT
-            echo "precision=$precision" >> $GIT_OUTPUT
-            echo "task=$task" >> $GIT_OUTPUT
+            echo "model_name=$model_name" >> $GITHUB_OUTPUT
+            echo "precision=$precision" >> $GITHUB_OUTPUT
+            echo "task=$task" >> $GITHUB_OUTPUT
   llm-harness-evalution:
     timeout-minutes: 1000
     needs: [llm-cpp-build, set-matrix]

--- a/.github/workflows/llm-harness-evaluation.yml
+++ b/.github/workflows/llm-harness-evaluation.yml
@@ -59,7 +59,7 @@ jobs:
             echo "model_name=$NIGHTLY_MATRIX_MODEL_NAME" >> $GITHUB_ENV
             echo "precision=$NIGHTLY_MATRIX_PRECISION" >> $GITHUB_ENV
             echo "task=$NIGHTLY_MATRIX_TASK" >> $GITHUB_ENV
-            echo 'runner=$NIGHTLY_LABELS' >> $GITHUB_ENV
+            echo "runner=$NIGHTLY_LABELS" >> $GITHUB_ENV
 
       - name: set-pr-env
         if: ${{github.event_name == 'pull_request'}}
@@ -72,7 +72,7 @@ jobs:
             echo "model_name=$PR_MATRIX_MODEL_NAME" >> $GITHUB_ENV
             echo "precision=$PR_MATRIX_PRECISION" >> $GITHUB_ENV
             echo "task=$PR_MATRIX_TASK" >> $GITHUB_ENV
-            echo 'runner=$PR_LABELS' >> $GITHUB_ENV
+            echo "runner=$PR_LABELS" >> $GITHUB_ENV
       - name: set-manual-env
         if: ${{github.event_name == 'workflow_dispatch'}}
         env:
@@ -84,14 +84,14 @@ jobs:
             echo "model_name=$MANUAL_MATRIX_MODEL_NAME" >> $GITHUB_ENV
             echo "precision=$MANUAL_MATRIX_TASK" >> $GITHUB_ENV
             echo "task=$MANUAL_MATRIX_PRECISION" >> $GITHUB_ENV
-            echo 'runner=$MANUAL_LABELS' >> $GITHUB_ENV
+            echo "runner=$MANUAL_LABELS" >> $GITHUB_ENV
       - name: set-matrix
         id: set-matrix
         run: |
             echo "model_name=$model_name" >> $GITHUB_OUTPUT
             echo "precision=$precision" >> $GITHUB_OUTPUT
             echo "task=$task" >> $GITHUB_OUTPUT
-            echo 'runner=$runner' >> $GITHUB_OUTPUT
+            echo "runner=$runner" >> $GITHUB_OUTPUT
   llm-harness-evalution:
     timeout-minutes: 1000
     needs: [llm-cpp-build, set-matrix]

--- a/.github/workflows/llm-harness-evaluation.yml
+++ b/.github/workflows/llm-harness-evaluation.yml
@@ -91,6 +91,7 @@ jobs:
             echo "model_name=$model_name" >> $GITHUB_OUTPUT
             echo "precision=$precision" >> $GITHUB_OUTPUT
             echo "task=$task" >> $GITHUB_OUTPUT
+            echo 'runner=$runner' >> $GITHUB_OUTPUT
   llm-harness-evalution:
     timeout-minutes: 1000
     needs: [llm-cpp-build, set-matrix]

--- a/.github/workflows/llm-harness-evaluation.yml
+++ b/.github/workflows/llm-harness-evaluation.yml
@@ -45,9 +45,9 @@ jobs:
       - name: set-nightly-env
         if: ${{github.event_name == 'schedule'}}
         env:
-          NIGHTLY_MATRIX_MODEL_NAME: "[stablelm-3b-4e1t,Mistral-7B-v0.1]"
-          NIGHTLY_MATRIX_TASK: "[truthfulqa, arc]"
-          NIGHTLY_MATRIX_PRECISION: "[mixed_fp4, fp8]"
+          NIGHTLY_MATRIX_MODEL_NAME: '["stablelm-3b-4e1t","Mistral-7B-v0.1"]'
+          NIGHTLY_MATRIX_TASK: '["truthfulqa", "arc"]'
+          NIGHTLY_MATRIX_PRECISION: '["mixed_fp4", "fp8"]'
         run: |
             echo "model_name=$NIGHTLY_MATRIX_MODEL_NAME" >> $GITHUB_ENV
             echo "precision=$NIGHTLY_MATRIX_PRECISION" >> $GITHUB_ENV
@@ -56,9 +56,9 @@ jobs:
       - name: set-pr-env
         if: ${{github.event_name == 'pull_request'}}
         env:
-          PR_MATRIX_MODEL_NAME: "[stablelm-3b-4e1t]"
-          PR_MATRIX_TASK: "[truthfulqa]"
-          PR_MATRIX_PRECISION: "[mixed_fp4, fp8]"
+          PR_MATRIX_MODEL_NAME: '["stablelm-3b-4e1t"]'
+          PR_MATRIX_TASK: '["truthfulqa"]'
+          PR_MATRIX_PRECISION: '["mixed_fp4", "fp8"]'
         run: |
             echo "model_name=$PR_MATRIX_MODEL_NAME" >> $GITHUB_ENV
             echo "precision=$PR_MATRIX_PRECISION" >> $GITHUB_ENV


### PR DESCRIPTION
## Description

added a `set-matrix` job to parse the combination of jobs from different request type.

Current accepted event to trigger harness jobs:

- pull request
- workflow dispatch (manually run from github action page)
![image](https://github.com/intel-analytics/BigDL/assets/90437536/93182030-0586-4347-abfd-bfdc1e4d463b)
- nightly scheduled