### PR TITLE
Fix nightly build: revert aiohttp to 3.7.0

### DIFF
--- a/docker/bigdl/install-python-env.sh
+++ b/docker/bigdl/install-python-env.sh
@@ -16,7 +16,7 @@ pip install --no-cache-dir redis && \
 pip install --no-cache-dir ray[tune]==1.9.2 && \
 pip install --no-cache-dir gym[atari]==0.17.1 && \
 pip install --no-cache-dir Pillow==6.2 && \
-pip install --no-cache-dir psutil aiohttp==3.9.0 && \
+pip install --no-cache-dir psutil aiohttp==3.7.0 && \
 pip install --no-cache-dir setproctitle && \
 pip install --no-cache-dir hiredis==1.1.0 && \
 pip install --no-cache-dir async-timeout==3.0.1 && \


### PR DESCRIPTION
This submission is to fix docker nightly build: https://github.com/intel-analytics/BigDL/actions/runs/7085953367/job/19310032991

<img width="362" alt="image" src="https://github.com/intel-analytics/BigDL/assets/61072813/95ee0d9c-114f-45ad-82a0-d39d19f18f6b">

python3.7 currently does not support aiohttp==3.9.0, thus we will revert aiohttp==3.7.0. If there is a need to upgrade bigdl docker image to python3.9+ in the future, we will upgrade aiohttp. Now we don’t spend too much effort on this matter.

Related PR: https://github.com/intel-analytics/BigDL/pull/9580/files