### PR TITLE
[LLM] vLLM: Delete last_kv_cache before prefilling

### DIFF
--- a/python/llm/src/bigdl/llm/vllm/model_executor/models/bigdl_llama.py
+++ b/python/llm/src/bigdl/llm/vllm/model_executor/models/bigdl_llama.py
@@ -186,6 +186,7 @@ class BigDLLlamaForCausalLM(BigDLModelForCausalLM):
                 "use_cache": True,
                 # "return_dict": True,
             }
+            del self.last_kv_cache
         # pdb.set_trace()
 
         if self.device.type == 'xpu':

--- a/python/llm/src/bigdl/llm/vllm/model_executor/models/bigdl_llama.py
+++ b/python/llm/src/bigdl/llm/vllm/model_executor/models/bigdl_llama.py
@@ -186,7 +186,8 @@ class BigDLLlamaForCausalLM(BigDLModelForCausalLM):
                 "use_cache": True,
                 # "return_dict": True,
             }
-            del self.last_kv_cache
+            if self.last_kv_cache:
+                del self.last_kv_cache
         # pdb.set_trace()
 
         if self.device.type == 'xpu':


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

Remove last_kv_cache before prefilling to empty memory usage.