### PR TITLE
LLM: integrate sdp kernel for FP16 rest token inference on GPU [DG2/ATSM]

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -249,8 +249,12 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
 
                             # convert here
                             m, n = module.weight.data.shape
-                            trans_weight = module.weight.data.reshape(m//16, 16, n)
-                            trans_weight = trans_weight.transpose(1, 2).contiguous()
+                            if module.in_features == 11008:
+                                trans_weight = module.weight.data.reshape(m//8, 8, n)
+                                trans_weight = trans_weight.transpose(1, 2).contiguous()
+                            elif module.in_features == 4096:
+                                trans_weight = module.weight.data.reshape(m//16, 16, n)
+                                trans_weight = trans_weight.transpose(1, 2).contiguous()
                             new_linear._parameters['weight'] = nn.Parameter(trans_weight)
                             if module.bias is not None:
                                 new_linear._parameters['bias'] = nn.Parameter(module.bias.data)\

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -286,7 +286,7 @@ def use_esimd_sdp(q_len, head_dim, query_states):
         # esimd_sdp only has optimization for FP16 now
         return False
     else:
-        device_name = torch.xpu.get_device_name(query_device.index)
+        device_name = torch.xpu.get_device_name(query_states.device.index)
         if device_name.startswith("Intel(R) Arc(TM)") or \
                 device_name.startswith("Intel(R) Data Center GPU Flex"):
             import linear_fp16_esimd

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -219,8 +219,9 @@ def llama_attention_forward_4_31(
                                                      value_states,
                                                      is_causal=True)
         attn_weights = None
-    elif q_len == 1 and query_states.device.type == "xpu" and query_states.dtype == torch.float16  and \
-        flex_sdp_check(self.head_dim, query_states.device):
+    elif q_len == 1 and query_states.device.type == "xpu" and \
+            query_states.dtype == torch.float16 and \
+            flex_sdp_check(self.head_dim, query_states.device):
         # now only use flex sdp for rest token
         import linear_fp16_esimd
         if hasattr(linear_fp16_esimd, "sdp_forward"):
@@ -287,7 +288,8 @@ def flex_sdp_check(head_dim, query_device):
         return False
     else:
         device_name = torch.xpu.get_device_name(query_device.index)
-        if device_name.startswith("Intel(R) Arc(TM)") or device_name.startswith("Intel(R) Data Center GPU Flex"):
+        if device_name.startswith("Intel(R) Arc(TM)") or \
+                device_name.startswith("Intel(R) Data Center GPU Flex"):
             # iGPU?
             return True
         else:

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -219,6 +219,13 @@ def llama_attention_forward_4_31(
                                                      value_states,
                                                      is_causal=True)
         attn_weights = None
+    # need add more check here
+    elif q_len == 1 and query_states.device.type == "xpu" and query_states.dtype ==torch.float16:
+        import sdp_fp16_esimd
+        attn_output = sdp_fp16_esimd.forward(query_states,
+                                             key_states.contiguous(),
+                                             value_states.contiguous())
+        attn_output = attn_output.view(query_states.shape)
     else:
         # otherwise, use native attention
         attn_output, attn_weights = native_sdp(query_states, key_states, value_states,

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -220,6 +220,7 @@ def llama_attention_forward_4_31(
                                                      is_causal=True)
         attn_weights = None
     elif use_esimd_sdp(q_len, self.head_dim, query_states):
+        import linear_fp16_esimd
         attn_output = linear_fp16_esimd.sdp_forward(query_states,
                                                     key_states.contiguous(),
                                                     value_states.contiguous())

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -287,7 +287,7 @@ def use_esimd_sdp(q_len, head_dim, query_states):
         return False
     else:
         device_name = torch.xpu.get_device_name(query_states.device.index)
-        if device_name.startswith("Intel(R) Arc(TM)") or \
+        if device_name.startswith("Intel(R) Arc(TM) A") or \
                 device_name.startswith("Intel(R) Data Center GPU Flex"):
             import linear_fp16_esimd
             if hasattr(linear_fp16_esimd, "sdp_forward"):


### PR DESCRIPTION
## Description

Should merge after https://github.com/intel-analytics/llm.cpp/pull/180 is merged.

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/840

### 2. User API changes

No change.

### 3. Summary of the change 

- update fp16 convert logic as some change in kernel implementation

- supports **sdp** kernel of fp16 and fp32 for **DG2 & ATS-M GPU**, now it can provide optimization for **fp16 rest token**.

As a starting point, only change llama modeling file here, and it can be easily used for other models.

### 4. How to test?
- [x] Unit test
- [x] Local test for `Llama-2-7b-chat-hf` and `Nous-Hermes-Llama2-13b` on arc04
performance update here : https://github.com/analytics-zoo/nano/issues/840#issuecomment-1849646767