### PR TITLE
fix new lowbitlinear status

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -258,6 +258,8 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
 
                     #  fp16 may generalize to other sizes later
                     if new_linear is not None:
+                        if not module.training:
+                            new_linear.eval()
                         model._modules[name] = new_linear
                         has_been_replaced = True
                         # Force requires grad to False to avoid unexpected errors


### PR DESCRIPTION
## Description

A new LowBitLinear's training is True by default, but the model's training maybe false.
We should make them the same.

### 1. Why the change?

Fixed performance down after https://github.com/intel-analytics/BigDL/pull/9621

### 2. User API changes

None