### PR TITLE
[LM] Add stop_word for Qwen model and correct qwen chat format in chat.py

### DIFF
--- a/python/llm/portable-zip/chat.py
+++ b/python/llm/portable-zip/chat.py
@@ -84,7 +84,7 @@ def greedy_generate(model, tokenizer, input_ids, past_key_values, max_gen_len):
 
         now = len(generated_text) - 1
         if now > pos:
-            if '\n<' in generated_text:
+            if '\n<' in generated_text or '\n\'t' in generated_text or '\n\n' in generated_text:
                 break
             else:
                 print("".join(generated_text[pos:now]), end="", flush=True)

--- a/python/llm/portable-zip/chat.py
+++ b/python/llm/portable-zip/chat.py
@@ -58,6 +58,7 @@ HUMAN_ID = "<human>"
 BOT_ID = "<bot>"
 
 def get_stop_words_ids(chat_format, tokenizer):
+    # https://github.com/QwenLM/Qwen/blob/main/examples/vllm_wrapper.py#L23
     if chat_format == "Qwen":
         stop_words_ids = [[tokenizer.im_end_id], [tokenizer.im_start_id], [tokenizer.eod_id]]
     else:
@@ -117,7 +118,8 @@ def stream_chat(model, tokenizer, kv_cache=None, max_gen_len=512, stop_words=[])
     past_key_values = None
     while True:
         user_input = input(Fore.GREEN+"\nHuman: "+Fore.RESET)
-        if user_input == "stop": # let's stop the conversation when user input "stop"
+        # let's stop the conversation when user input "stop"
+        if user_input == "stop":
             break
         prompt = f"{HUMAN_ID} {user_input}\n{BOT_ID} "
         input_ids = tokenizer(prompt, return_tensors="pt").input_ids
@@ -140,7 +142,8 @@ def chatglm2_stream_chat(model, tokenizer):
 
     while True:
         user_input = input(Fore.GREEN+"\nHuman: "+Fore.RESET)
-        if user_input == "stop": # let's stop the conversation when user input "stop"
+        # let's stop the conversation when user input "stop"
+        if user_input == "stop":
             break
         print(Fore.BLUE+"BigDL-LLM: "+Fore.RESET, end="")
         prompt = f"问：{user_input}\n答："
@@ -167,8 +170,10 @@ def qwen_stream_chat(model, tokenizer, kv_cache=None, max_gen_len=512, stop_word
     past_key_values = None
     while True:
         user_input = input(Fore.GREEN+"\nHuman: "+Fore.RESET)
-        if user_input == "stop": # let's stop the conversation when user input "stop"
+        # let's stop the conversation when user input "stop"
+        if user_input == "stop":
             break
+        # https://huggingface.co/Qwen/Qwen-7B-Chat/blob/main/generation_config.json#L2
         prompt = f"""
             <|im_start|>system
             You are a helpful assistant.

--- a/python/llm/portable-zip/chat.py
+++ b/python/llm/portable-zip/chat.py
@@ -229,7 +229,7 @@ if __name__ == "__main__":
     elif model.config.architectures is not None and model.config.architectures[0] == "ChatGLMModel":
         chatglm2_stream_chat(model=model, tokenizer=tokenizer)
     else:
-        kv_cache = StartRecentKVCache()
+        kv_cache = StartRecentKVCache(start_size=start_size)
         stream_chat(model=model,
                     tokenizer=tokenizer,
                     kv_cache=kv_cache)


### PR DESCRIPTION
## Description

The lack of stop_word prevents timely break in this line. https://github.com/intel-analytics/BigDL/blob/467d117f1153609c7fc38a1709cf1a7bc4032126/python/llm/portable-zip/chat.py#L87C22-L87C22

### 1. Why the change?

For Qwen-7B, it needs '\n't' as stop_word.
And for Qwen-1_8B and Qwen-72B, it needs '\n\n' as stop_word.

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

