### PR TITLE
LLM: update setup to provide new install option to support ipex 2.1 & oneapi 2024

### DIFF
--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -274,25 +274,26 @@ def setup_package():
     # Linux install with -f https://developer.intel.com/ipex-whl-stable-xpu
     xpu_20_requires = copy.deepcopy(all_requires)
     xpu_20_requires.remove('torch')
+    # xpu_20 only works for linux now
     xpu_20_requires += ["torch==2.0.1a0;platform_system=='Linux'",
-                        "torch==2.0.0a0+gitc6a572f;platform_system=='Windows'",
                         "torchvision==0.15.2a0;platform_system=='Linux'",
                         "intel_extension_for_pytorch==2.0.110+xpu;platform_system=='Linux'",
-                        "intel_extension_for_pytorch==2.0.110+gitba7f6c1;platform_system=='Windows'",
-                        "bigdl-core-xe==" + VERSION + ";(platform_system=='Linux' or platform_system=='Windows')",
+                        "bigdl-core-xe==" + VERSION + ";platform_system=='Linux'",
                         "bigdl-core-xe-esimd==" + VERSION + ";platform_system=='Linux'"]
 
     xpu_21_requires = copy.deepcopy(all_requires)
     xpu_21_requires.remove('torch')
-    # release linux first
-    xpu_21_requires += ["torch==2.1.0a0;platform_system=='Linux'",
-                         # "torch==2.0.0a0+gitc6a572f;platform_system=='Windows'",
-                        "torchvision==0.16.0a0;platform_system=='Linux'",
-                        "intel_extension_for_pytorch==2.1.10+xpu;platform_system=='Linux'",
-                         # "intel_extension_for_pytorch==2.0.110+gitba7f6c1;platform_system=='Windows'",
-                        "bigdl-core-xe-21==" + VERSION + ";platform_system=='Linux'",
+    xpu_21_requires += ["torch==2.1.0a0",
+                        "torchvision==0.16.0a0",
+                        "intel_extension_for_pytorch==2.1.10+xpu",
+                        "bigdl-core-xe-21==" + VERSION,
                         "bigdl-core-xe-esimd-21==" + VERSION + ";platform_system=='Linux'"]
-    xpu_requires = xpu_20_requires
+    # default to ipex 2.0 for linux and 2.1 for windows
+    xpu_requires = copy.deepcopy(xpu_20_requires)
+    xpu_requires.extend(["torch==2.1.0a0;platform_system=='Windows'",
+                         "torchvision==0.16.0a0;platform_system=='Windows'",
+                         "intel_extension_for_pytorch==2.1.10+xpu;platform_system=='Windows'",
+                         "bigdl-core-xe-21==" + VERSION + ";platform_system=='Windows'"])
     serving_requires = ['py-cpuinfo']
     serving_requires += SERVING_DEP
 
@@ -318,7 +319,7 @@ def setup_package():
             ]
         },
         extras_require={"all": all_requires,
-                        "xpu": xpu_requires,  # default to ipex 2.0 now
+                        "xpu": xpu_requires,  # default to ipex 2.0 for linux and 2.1 for windows
                         "xpu_20": xpu_20_requires,
                         "xpu_21": xpu_21_requires,
                         "serving": serving_requires},

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -292,7 +292,7 @@ def setup_package():
                          # "intel_extension_for_pytorch==2.0.110+gitba7f6c1;platform_system=='Windows'",
                         "bigdl-core-xe-21==" + VERSION + ";platform_system=='Linux'",
                         "bigdl-core-xe-esimd-21==" + VERSION + ";platform_system=='Linux'"]
-    xpu_requires = xpu_21_requires
+    xpu_requires = xpu_20_requires
     serving_requires = ['py-cpuinfo']
     serving_requires += SERVING_DEP
 
@@ -318,7 +318,7 @@ def setup_package():
             ]
         },
         extras_require={"all": all_requires,
-                        "xpu": xpu_requires,  # default to lastest ipex public version
+                        "xpu": xpu_requires,  # default to ipex 2.0 now
                         "xpu_20": xpu_20_requires,
                         "xpu_21": xpu_21_requires,
                         "serving": serving_requires},

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -272,16 +272,27 @@ def setup_package():
     all_requires += CONVERT_DEP
 
     # Linux install with -f https://developer.intel.com/ipex-whl-stable-xpu
-    xpu_requires = copy.deepcopy(all_requires)
-    xpu_requires.remove('torch')
-    xpu_requires += ["torch==2.0.1a0;platform_system=='Linux'",
-                     "torch==2.0.0a0+gitc6a572f;platform_system=='Windows'",
-                     "torchvision==0.15.2a0;platform_system=='Linux'",
-                     "intel_extension_for_pytorch==2.0.110+xpu;platform_system=='Linux'",
-                     "intel_extension_for_pytorch==2.0.110+gitba7f6c1;platform_system=='Windows'",
-                     "bigdl-core-xe==" + VERSION + ";(platform_system=='Linux' or platform_system=='Windows')",
-                     "bigdl-core-xe-esimd==" + VERSION + ";platform_system=='Linux'"]
+    xpu_20_requires = copy.deepcopy(all_requires)
+    xpu_20_requires.remove('torch')
+    xpu_20_requires += ["torch==2.0.1a0;platform_system=='Linux'",
+                        "torch==2.0.0a0+gitc6a572f;platform_system=='Windows'",
+                        "torchvision==0.15.2a0;platform_system=='Linux'",
+                        "intel_extension_for_pytorch==2.0.110+xpu;platform_system=='Linux'",
+                        "intel_extension_for_pytorch==2.0.110+gitba7f6c1;platform_system=='Windows'",
+                        "bigdl-core-xe==" + VERSION + ";(platform_system=='Linux' or platform_system=='Windows')",
+                        "bigdl-core-xe-esimd==" + VERSION + ";platform_system=='Linux'"]
 
+    xpu_21_requires = copy.deepcopy(all_requires)
+    xpu_21_requires.remove('torch')
+    # release linux first
+    xpu_21_requires += ["torch==2.1.0a0;platform_system=='Linux'",
+                         # "torch==2.0.0a0+gitc6a572f;platform_system=='Windows'",
+                        "torchvision==0.16.0a0;platform_system=='Linux'",
+                        "intel_extension_for_pytorch==2.1.10+xpu;platform_system=='Linux'",
+                         # "intel_extension_for_pytorch==2.0.110+gitba7f6c1;platform_system=='Windows'",
+                        "bigdl-core-xe-21==" + VERSION + ";platform_system=='Linux'",
+                        "bigdl-core-xe-esimd-21==" + VERSION + ";platform_system=='Linux'"]
+    xpu_requires = xpu_21_requires
     serving_requires = ['py-cpuinfo']
     serving_requires += SERVING_DEP
 
@@ -307,7 +318,9 @@ def setup_package():
             ]
         },
         extras_require={"all": all_requires,
-                        "xpu": xpu_requires,
+                        "xpu": xpu_requires,  # default to lastest ipex public version
+                        "xpu_20": xpu_20_requires,
+                        "xpu_21": xpu_21_requires,
                         "serving": serving_requires},
         classifiers=[
             'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
## Description

### 1. Why the change?

To provide new install option to support ipex 2.1 & oneapi 2024 .

### 2. User API changes

After this PR, user can install different bigdl-llm release for ipex 2.0/2.1 .
```bash
# on Linux, below installation cmd will install ipex 2.0 and related package, should work with oneapi 2023.2
# on Windows, below installation cmd will install ipex 2.1 and related package, should work with oneapi 2024.0
pip install --pre --upgrade bigdl-llm[xpu] -f https://developer.intel.com/ipex-whl-stable-xpu
# below installation cmd will install ipex 2.1 and related package, should work with oneapi 2024.0
pip install --pre --upgrade bigdl-llm[xpu_21] -f https://developer.intel.com/ipex-whl-stable-xpu
# below installation cmd will install ipex 2.0 and related package, should work with oneapi 2023.2
pip install --pre --upgrade bigdl-llm[xpu_20] -f https://developer.intel.com/ipex-whl-stable-xpu
```

### 3. Summary of the change 

- update setup to provide new install option to support ipex 2.1 & oneapi 2024
Related PR: https://github.com/intel-analytics/llm.cpp/pull/182

### 4. How to test?
- [ ] Local test
- [ ] Unit test

**This PR need to merge after `bigdl-core-xe-21` and `bigdl-core-xe-esimd-21` releases, we will work on related release procedure tomorrow.**
