### PR TITLE
[LLM] Enable generation of html again for win igpu tests

### DIFF
--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -336,10 +336,10 @@ jobs:
           cd python\llm\dev\benchmark\all-in-one
           python ..\..\..\test\benchmark\concat_csv.py
           move *.csv %CSV_SAVE_PATH%\32-32\
-          REM cd ..\..\..\test\benchmark
-          REM python csv_to_html.py -f %CSV_SAVE_PATH%\32-32\
-          REM if %ERRORLEVEL% neq 0 (exit /b 1)
-          REM move *.csv %CSV_SAVE_PATH%
+          cd ..\..\..\test\benchmark
+          python csv_to_html.py -f %CSV_SAVE_PATH%\32-32\
+          if %ERRORLEVEL% neq 0 (exit /b 1)
+          move *.csv %CSV_SAVE_PATH%
 
           call conda deactivate
 
@@ -404,10 +404,10 @@ jobs:
           cd python\llm\dev\benchmark\all-in-one
           python ..\..\..\test\benchmark\concat_csv.py
           move *.csv %CSV_SAVE_PATH%\32-256\
-          REM cd ..\..\..\test\benchmark
-          REM python csv_to_html.py -f %CSV_SAVE_PATH%\32-256\
-          REM if %ERRORLEVEL% neq 0 (exit /b 1)
-          REM move *.csv %CSV_SAVE_PATH%
+          cd ..\..\..\test\benchmark
+          python csv_to_html.py -f %CSV_SAVE_PATH%\32-256\
+          Rif %ERRORLEVEL% neq 0 (exit /b 1)
+          move *.csv %CSV_SAVE_PATH%
 
           call conda deactivate
 
@@ -472,10 +472,10 @@ jobs:
           cd python\llm\dev\benchmark\all-in-one
           python ..\..\..\test\benchmark\concat_csv.py
           move *.csv %CSV_SAVE_PATH%\32-512\
-          REM cd ..\..\..\test\benchmark
-          REM python csv_to_html.py -f %CSV_SAVE_PATH%\32-512\
-          REM if %ERRORLEVEL% neq 0 (exit /b 1)
-          REM move *.csv %CSV_SAVE_PATH%
+          cd ..\..\..\test\benchmark
+          python csv_to_html.py -f %CSV_SAVE_PATH%\32-512\
+          if %ERRORLEVEL% neq 0 (exit /b 1)
+          move *.csv %CSV_SAVE_PATH%
 
           call conda deactivate
 
@@ -514,10 +514,10 @@ jobs:
 
           cd python\llm\dev\benchmark\all-in-one
           move *.csv %CSV_SAVE_PATH%\512-64\
-          REM cd ..\..\..\test\benchmark
-          REM python csv_to_html.py -f %CSV_SAVE_PATH%\512-64\
-          REM if %ERRORLEVEL% neq 0 (exit /b 1)
-          REM move *.csv %CSV_SAVE_PATH%
+          cd ..\..\..\test\benchmark
+          python csv_to_html.py -f %CSV_SAVE_PATH%\512-64\
+          if %ERRORLEVEL% neq 0 (exit /b 1)
+          move *.csv %CSV_SAVE_PATH%
 
           call conda deactivate
 

--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -406,7 +406,7 @@ jobs:
           move *.csv %CSV_SAVE_PATH%\32-256\
           cd ..\..\..\test\benchmark
           python csv_to_html.py -f %CSV_SAVE_PATH%\32-256\
-          Rif %ERRORLEVEL% neq 0 (exit /b 1)
+          if %ERRORLEVEL% neq 0 (exit /b 1)
           move *.csv %CSV_SAVE_PATH%
 
           call conda deactivate

--- a/python/llm/test/benchmark/igpu-perf/32-512.yaml
+++ b/python/llm/test/benchmark/igpu-perf/32-512.yaml
@@ -11,7 +11,7 @@ repo_id:
   - 'tiiuae/falcon-7b-instruct-with-patch'
   - 'mosaicml/mpt-7b-chat'
   - 'liuhaotian/llava-v1.5-7b'
-  - 'RWKV/rwkv-4-world-7b'
+  # - 'RWKV/rwkv-4-world-7b'
 local_model_hub: 'path to your local model hub'
 warm_up: 1
 num_trials: 3


### PR DESCRIPTION


## Description

- Enable generation of html again for win igpu tests
- Skip rwkv for 32-512 as it is not very stable

