### PR TITLE
[LLM] Add support for empty activation

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -448,13 +448,14 @@ class LowBitLinear(nn.Linear):
         if self.bias is not None and self.bias.dtype != x.dtype:
             self.bias.data = self.bias.data.to(x.dtype)
 
-        # [batch, input_token_num, in_len]
+        # [batch, input_num, in_len]
+        # input_num == token num for Transformer
         x_shape = x.shape
-        # Output shape, e.g., [batch, input_token_num, out_len]
+        # Output shape, e.g., [batch, input_num, out_len]
         new_shape = x_shape[:-1] + (self.out_len,)
-        # Activation is empty tensor, e.g., [0, 4096]
+        # Activation is empty tensor, e.g., [1, 0, 4096]
         if 0 in x_shape:
-            # return empty tensor with output shape
+            # return empty tensor with output shape, x.dtype and x.device
             return torch.empty(new_shape, dtype=x.dtype, device=x.device)
 
         x_2d = x.view(-1, x_shape[-1])

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -448,9 +448,17 @@ class LowBitLinear(nn.Linear):
         if self.bias is not None and self.bias.dtype != x.dtype:
             self.bias.data = self.bias.data.to(x.dtype)
 
+        # [batch, input_token_num, in_len]
         x_shape = x.shape
-        x_2d = x.view(-1, x_shape[-1])
+        # Output shape, e.g., [batch, input_token_num, out_len]
+        new_shape = x_shape[:-1] + (self.out_len,)
+        # Activation is empty tensor, e.g., [0, 4096]
+        if 0 in x_shape:
+            # return empty tensor with output shape
+            return torch.empty(new_shape, dtype=x.dtype)
 
+        x_2d = x.view(-1, x_shape[-1])
+        # x0 for weight
         x0 = self.weight.data
 
         if x0.device.type == "xpu":
@@ -489,7 +497,6 @@ class LowBitLinear(nn.Linear):
                 else:
                     result = linear_q4_0.forward_new(x_2d, self.weight.data, self.weight.qtype,
                                                      input_seq_size)
-            new_shape = x_shape[:-1] + (self.out_len,)
             result = result.view(new_shape)
             if self.mp_group is not None:
                 from deepspeed import comm as dist
@@ -513,10 +520,6 @@ class LowBitLinear(nn.Linear):
                     result = F.linear(x, x0_fp32)
                 else:
                     # Weight does not need a convert
-                    new_shape = x_shape[:-1] + (self.out_len,)
-                    # If 0 in input shape, e.g., [0, 4096]
-                    if 0 in x_2d.shape:
-                        return torch.empty(new_shape, dtype=torch.float32)
                     result = ggml_matmul_src1_x_src0_t(x0, x_2d, self.weight_shape, self.qtype)
                     result = result.view(new_shape)
             # allreduce to combine partial results and add bias if necessary

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -513,8 +513,11 @@ class LowBitLinear(nn.Linear):
                     result = F.linear(x, x0_fp32)
                 else:
                     # Weight does not need a convert
-                    result = ggml_matmul_src1_x_src0_t(x0, x_2d, self.weight_shape, self.qtype)
                     new_shape = x_shape[:-1] + (self.out_len,)
+                    # If 0 in input shape, e.g., [0, 4096]
+                    if 0 in x_2d.shape:
+                        return torch.empty(new_shape, dtype=torch.float32)
+                    result = ggml_matmul_src1_x_src0_t(x0, x_2d, self.weight_shape, self.qtype)
                     result = result.view(new_shape)
             # allreduce to combine partial results and add bias if necessary
             if self.mp_group is not None:

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -455,7 +455,7 @@ class LowBitLinear(nn.Linear):
         # Activation is empty tensor, e.g., [0, 4096]
         if 0 in x_shape:
             # return empty tensor with output shape
-            return torch.empty(new_shape, dtype=x.dtype)
+            return torch.empty(new_shape, dtype=x.dtype, device=x.device)
 
         x_2d = x.view(-1, x_shape[-1])
         # x0 for weight


### PR DESCRIPTION
## Description

Add support for empty activation, e.g., [0, 4096]. Empty activation is allowed by PyTorch.

### 1. Why the change?

LowbitLinear cannot handle empty activation, e.g., [0, 4096]

### 2. User API changes

NA

### 3. Summary of the change 

Return empty output when Empty activation.
### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

NA