### PR TITLE
LLM: add dot to option name in setup

### DIFF
--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -320,8 +320,8 @@ def setup_package():
         },
         extras_require={"all": all_requires,
                         "xpu": xpu_requires,  # default to ipex 2.0 for linux and 2.1 for windows
-                        "xpu_20": xpu_20_requires,
-                        "xpu_21": xpu_21_requires,
+                        "xpu_2.0": xpu_20_requires,
+                        "xpu_2.1": xpu_21_requires,
                         "serving": serving_requires},
         classifiers=[
             'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
## Description

### 1. Why the change?

https://github.com/intel-analytics/BigDL/pull/9647#issuecomment-1853852027

### 2. User API changes

```bash
# on Linux, below installation cmd will install ipex 2.0 and related package, should work with oneapi 2023.2
# on Windows, below installation cmd will install ipex 2.1 and related package, should work with oneapi 2024.0
pip install --pre --upgrade bigdl-llm[xpu] -f https://developer.intel.com/ipex-whl-stable-xpu
# below installation cmd will install ipex 2.1 and related package, should work with oneapi 2024.0
pip install --pre --upgrade bigdl-llm[xpu_2.1] -f https://developer.intel.com/ipex-whl-stable-xpu
# below installation cmd will install ipex 2.0 and related package, should work with oneapi 2023.2
pip install --pre --upgrade bigdl-llm[xpu_2.0] -f https://developer.intel.com/ipex-whl-stable-xpu
```


### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [x] Unit test

