### PR TITLE
fix baichuan2-7b 1st token performance regression on xpu

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -476,7 +476,7 @@ class LowBitLinear(nn.Linear):
                 x_2d = x_2d.contiguous()
 
             input_seq_size = x_shape[1]
-            if self.training:
+            if self.training and not torch.is_inference_mode_enabled():
                 # training path
                 if x_2d.requires_grad:
                     result = MatMulLowBit.apply(x_2d, self.weight, input_seq_size)

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -439,7 +439,7 @@ class LowBitLinear(nn.Linear):
     def forward(self, x: torch.Tensor):
         # Due to inconsistent training status in some models like Baichuan-7b-Chat,
         # we should check both self.training and torch.is_inference_mode_enabled().
-        is_training = self.training and not torch.is_inference_mode_enabled():
+        is_training = self.training and not torch.is_inference_mode_enabled()
         if is_training:
             # below logic is only for training
             autocast_dtype = get_autocast_dtype(x)


### PR DESCRIPTION
## Description

fix baichuan2-7b 1st token performance regression

### 1. Why the change?

Fixed https://github.com/analytics-zoo/nano/issues/849
The last Linear(lm_head)'s `training` status is true, so the condition in lowbitlinear will be wrong.
Add `and not torch.is_inference_mode_enabled()` for double checking.

### 2. User API changes

None
