### PR TITLE
[LLM] Improve chatglm2/3 rest token performance with long context

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/models/baichuan2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/baichuan2.py
@@ -173,7 +173,8 @@ def baichuan_attention_forward_7b(
 
         scaling_factor = 1 / math.sqrt(query_states.size(-1))
         attn_output = torch.matmul(query_states * scaling_factor, key_states.transpose(-2, -1))
-        attn_output += attention_mask
+        if attention_mask is not None:
+            attn_output += attention_mask
         attn_output = torch.softmax(attn_output, -1)
         attn_output = torch.matmul(attn_output, value_states)
 


### PR DESCRIPTION
## Description

When `is_causal` is False and `attenon_mask` is None.
The sdp has three ops:
1. `attn = torch.matmul(query, key * scale)`
2. `attn = torch.softmax(attn, -1)`
3. `context_layer = torch.matmul(attn, value_layer)`

IPEX's sdp used a [trick](https://tinyurl.com/sudb9s96) for numerical stability in the 1st step. But according to the issue, the numerical instability only happens when the model is very large, such as 104B.

There are several almost equivalent ways to compute the 1st step:
- `(query * scale) @ key`
- `query @ (key * scale)`
- `(query @ key) * scale`
- `(query * sqrt(scale)) @ (key * sqrt(scale))`

IPEX's trick used the last one.

The second one and the last one multiple `scale` by `key`, but when input length is 1024, the `query`'s shape is `[1, 32, 1, 128]`,  `key`'s shape is `[1, 32, 128, 1024]`, the `query @ key`'s shape is `[1, 32, 1, 1024]`. Multiple `scale` by `query` is faster than by `key`.

When input length is 1024, total `key` and `value` will take about 1GB memory, so multiple `scale` by `key` is very slow.

This PR used the first way to compute the 1st step for best performance.
