### PR TITLE
Keep saving low bit mode with pytorch_model.bin format

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -60,6 +60,7 @@ def save_low_bit(self, *args, **kwargs):
         delattr(self.config, "_pre_quantization_dtype")
 
     self.to('cpu')
+    kwargs['safe_serialization'] = False
     self.save_pretrained(*args, **kwargs)
     import json
     import os


### PR DESCRIPTION
To support to saving low bit mode with pytorch_model.bin format in transformers >= 4.35.0

Related issue:
https://github.com/analytics-zoo/nano/issues/839