### PR TITLE
[PPML] Fix command injection issue in bigdl_aa.py 

### DIFF
--- a/ppml/tdx/docker/trusted-bigdl-llm/finetune/docker/bigdl_aa.py
+++ b/ppml/tdx/docker/trusted-bigdl-llm/finetune/docker/bigdl_aa.py
@@ -5,6 +5,7 @@ import ssl, os
 import base64
 import requests
 import subprocess
+import shlex
 
 app = Flask(__name__)
 
@@ -32,7 +33,7 @@ def get_cluster_quote_list():
     except Exception as e:
         quote_list.append("launcher", "quote generation failed: %s" % (e))
 
-    command = "sudo -u mpiuser -E bash /ppml/get_worker_quote.sh %s" % (user_report_data)
+    command = "sudo -u mpiuser -E bash /ppml/get_worker_quote.sh %s" % (shlex.quote(user_report_data))
     output = subprocess.check_output(command, shell=True)
 
     with open("/ppml/output/quote.log", "r") as quote_file:


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

Command injection in bigdl_aa.py through /attest (GHSL-2023-260)
The BigDL-AA Agent exposes an [/attest](https://github.com/intel-analytics/BigDL/blob/ac12599a60b00fdd370172f09104a0fb2617b49d/ppml/tdx/docker/trusted-bigdl-llm/finetune/docker/bigdl_aa.py#L22) endpoint, which allows for executing a command containing an arbitrary string.

```
@app.route('/attest', methods=['POST'])
def get_cluster_quote_list():
    data = request.get_json()
    user_report_data = data.get('user_report_data')
    quote_list = []
 
    try:
        quote_b = quote_generator.generate_tdx_quote(user_report_data)
        quote = base64.b64encode(quote_b).decode("utf-8")
        quote_list.append(("launcher", quote))
    except Exception as e:
        quote_list.append("launcher", "quote generation failed: %s" % (e))
 
    command = "sudo -u mpiuser -E bash /ppml/get_worker_quote.sh %s" % (user_report_data)
    output = subprocess.check_output(command, shell=True)

```
Even when providing an invalid value, given that the try block doesn't raise an exception when caught, the user-controlled contents user_report_data flow directly to the command in question, which, using shell=True, allows for shell expansion.
This issue was found with CodeQL for Python's [Uncontrolled command line](https://codeql.github.com/codeql-query-help/python/py-command-line-injection/) query.