### PR TITLE
[LLM] Add trust_remote_code for local renamed model in bigdl_llm_model.py

### DIFF
--- a/python/llm/src/bigdl/llm/serving/bigdl_llm_model.py
+++ b/python/llm/src/bigdl/llm/serving/bigdl_llm_model.py
@@ -243,7 +243,7 @@ class BigDLLLMAdapter(BaseModelAdapter):
     def load_model(self, model_path: str, from_pretrained_kwargs: dict):
         revision = from_pretrained_kwargs.get("revision", "main")
         tokenizer = AutoTokenizer.from_pretrained(
-            model_path, use_fast=False, revision=revision
+            model_path, use_fast=False, revision=revision, trust_remote_code=True
         )
         print("Customized bigdl-llm loader")
         from bigdl.llm.transformers import AutoModelForCausalLM


### PR DESCRIPTION
## Description

Realated issue: https://github.com/intel-analytics/BigDL/issues/9707
After renaming the model, there's an error `Tokenizer class QWenTokenizer does not exist or is not currently imported when loading`.

### 1. Why the change?

Add trust_remote_code=True for local renamed model in the method from_pretrained.

### 2. User API changes

serving API


### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

