### PR TITLE
Support for Mixtral AWQ

### DIFF
--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
@@ -13,7 +13,7 @@ This example shows how to directly run 4-bit AWQ models using BigDL-LLM on Intel
 - [llava-v1.5-13B-AWQ](https://huggingface.co/TheBloke/llava-v1.5-13B-AWQ)
 - [Yi-6B-AWQ](https://huggingface.co/TheBloke/Yi-6B-AWQ)
 - [Yi-34B-AWQ](https://huggingface.co/TheBloke/Yi-34B-AWQ)
-- [mixtral-8x7b-v0.1-AWQ](https://huggingface.co/TheBloke/mixtral-8x7b-v0.1-AWQ)
+- [Mixtral-8x7B-Instruct-v0.1-AWQ](https://huggingface.co/ybelkada/Mixtral-8x7B-Instruct-v0.1-AWQ)
 
 ## Requirements
 

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
@@ -33,9 +33,13 @@ conda activate llm
 
 pip install autoawq==0.1.8 --no-deps
 pip install --pre --upgrade bigdl-llm[all] # install bigdl-llm with 'all' option
-pip install transformers==4.36.0
+pip install transformers==4.35.0
 pip install accelerate==0.25.0
 pip install einops
+```
+**Note: For Mixtral model, please use transformers 4.36.0:**
+```bash
+pip install transformers==4.36.0
 ```
 
 ### 2. Run

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
@@ -13,6 +13,7 @@ This example shows how to directly run 4-bit AWQ models using BigDL-LLM on Intel
 - [llava-v1.5-13B-AWQ](https://huggingface.co/TheBloke/llava-v1.5-13B-AWQ)
 - [Yi-6B-AWQ](https://huggingface.co/TheBloke/Yi-6B-AWQ)
 - [Yi-34B-AWQ](https://huggingface.co/TheBloke/Yi-34B-AWQ)
+- [mixtral-8x7b-v0.1-AWQ](https://huggingface.co/TheBloke/mixtral-8x7b-v0.1-AWQ)
 
 ## Requirements
 
@@ -30,10 +31,10 @@ We suggest using conda to manage environment:
 conda create -n llm python=3.9
 conda activate llm
 
-pip install autoawq==0.1.6 --no-deps
+pip install autoawq==0.1.8 --no-deps
 pip install --pre --upgrade bigdl-llm[all] # install bigdl-llm with 'all' option
-pip install transformers==4.35.0
-pip install accelerate==0.24.1
+pip install transformers==4.36.0
+pip install accelerate==0.25.0
 pip install einops
 ```
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
@@ -32,10 +32,14 @@ conda create -n llm python=3.9
 conda activate llm
 
 pip install --pre --upgrade bigdl-llm[xpu] -f https://developer.intel.com/ipex-whl-stable-xpu
-pip install transformers==4.36.0
+pip install transformers==4.35.0
 pip install autoawq==0.1.8 --no-deps
 pip install accelerate==0.25.0
 pip install einops
+```
+**Note: For Mixtral model, please use transformers 4.36.0:**
+```bash
+pip install transformers==4.36.0
 ```
 
 ### 2. Configures OneAPI environment variables

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
@@ -13,6 +13,7 @@ This example shows how to directly run 4-bit AWQ models using BigDL-LLM on Intel
 - [llava-v1.5-13B-AWQ](https://huggingface.co/TheBloke/llava-v1.5-13B-AWQ)
 - [Yi-6B-AWQ](https://huggingface.co/TheBloke/Yi-6B-AWQ)
 - [Yi-34B-AWQ](https://huggingface.co/TheBloke/Yi-34B-AWQ)
+- [mixtral-8x7b-v0.1-AWQ](https://huggingface.co/TheBloke/mixtral-8x7b-v0.1-AWQ)
 
 ## Requirements
 
@@ -31,9 +32,9 @@ conda create -n llm python=3.9
 conda activate llm
 
 pip install --pre --upgrade bigdl-llm[xpu] -f https://developer.intel.com/ipex-whl-stable-xpu
-pip install transformers==4.35.0
-pip install autoawq==0.1.6 --no-deps
-pip install accelerate==0.24.1
+pip install transformers==4.36.0
+pip install autoawq==0.1.8 --no-deps
+pip install accelerate==0.25.0
 pip install einops
 ```
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
@@ -13,7 +13,7 @@ This example shows how to directly run 4-bit AWQ models using BigDL-LLM on Intel
 - [llava-v1.5-13B-AWQ](https://huggingface.co/TheBloke/llava-v1.5-13B-AWQ)
 - [Yi-6B-AWQ](https://huggingface.co/TheBloke/Yi-6B-AWQ)
 - [Yi-34B-AWQ](https://huggingface.co/TheBloke/Yi-34B-AWQ)
-- [mixtral-8x7b-v0.1-AWQ](https://huggingface.co/TheBloke/mixtral-8x7b-v0.1-AWQ)
+- [Mixtral-8x7B-Instruct-v0.1-AWQ](https://huggingface.co/ybelkada/Mixtral-8x7B-Instruct-v0.1-AWQ)
 
 ## Requirements
 

--- a/python/llm/src/bigdl/llm/transformers/awq/awq.py
+++ b/python/llm/src/bigdl/llm/transformers/awq/awq.py
@@ -71,6 +71,7 @@ layer_type_dict = {
     "gpt_neox": "GPTNeoXDecoderLayer",
     "aquila": "AquilaDecoderLayer",
     "Yi": "YiDecoderLayer",
+    "mixtral": "MixtralDecoderLayer",
 }
 
 
@@ -135,6 +136,8 @@ def get_blocks(model):
     elif "mistral" in str(model.__class__).lower():
         layers = model.model.layers
     elif "yi" in str(model.__class__).lower():
+        layers = model.model.layers
+    elif "mixtral" in str(model.__class__).lower():
         layers = model.model.layers
     else:
         invalidInputError(False, f"Model type {type(model)} isn't supported.")
@@ -213,6 +216,8 @@ def _replace_with_awq_layers(model, awq_config: AwqConfig):
 
         # Replace nn.Linear with WQLinear
         for name, module in named_linears.items():
+            if any(key in name for key in awq_config.modules_to_not_convert):
+                continue
             if awq_config.version == 'gemm':
                 q_linear_module = WQLinear_GEMM
             elif awq_config.version == 'gemv':

--- a/python/llm/src/bigdl/llm/transformers/awq/awq_config.py
+++ b/python/llm/src/bigdl/llm/transformers/awq/awq_config.py
@@ -64,6 +64,8 @@ class AwqConfig(QuantizationConfigMixin):
         `AwqBackendPackingMethod.AUTOAWQ`):
             The quantization backend. Some models might be quantized using `llm-awq` backend.
             This is useful for users that quantize their own models using `llm-awq` library.
+        modules_to_not_convert (`list`, *optional*, defaults to []):
+            The modules in qblock while not quantized.
     """
 
     def __init__(

--- a/python/llm/src/bigdl/llm/transformers/awq/awq_config.py
+++ b/python/llm/src/bigdl/llm/transformers/awq/awq_config.py
@@ -73,6 +73,7 @@ class AwqConfig(QuantizationConfigMixin):
         zero_point: bool = True,
         version: AWQLinearVersion = AWQLinearVersion.GEMM,
         backend: AwqBackendPackingMethod = AwqBackendPackingMethod.AUTOAWQ,
+        modules_to_not_convert: list = [],
         **kwargs,
     ):
         self.quant_method = QuantizationMethod.AWQ
@@ -82,6 +83,7 @@ class AwqConfig(QuantizationConfigMixin):
         self.zero_point = zero_point
         self.version = version
         self.backend = backend
+        self.modules_to_not_convert = modules_to_not_convert
 
         self.post_init()
 


### PR DESCRIPTION
## Description

1. support for mixtral autoawq-quantized model.
2. add modules_to_not_convert in AwqConfig, since there are sub-modules in qblock while not quantized, e.g. gate linear in mixtral block_sparse_moe layer. 

### 1. Why the change?

as above

### 2. User API changes

none

### 3. Summary of the change 

Support for Mixtral AWQ

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

transformers==4.36.0 for mixtral only
autoawq==0.1.8
accelerate==0.25.0
