### PR TITLE
[LLM] Speculative decoding HF llama example for CPU

### DIFF
--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/README.md
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/README.md
@@ -96,7 +96,7 @@ New Arguments info:
 - `--assistant-model-path ASSISTANT_MODEL_PATH`: argument defining the huggingface repo id for the assistant model (e.g. `meta-llama/Llama-2-7b-chat-hf` and `meta-llama/Llama-2-13b-chat-hf`) to be downloaded, or the path to the huggingface checkpoint folder. 
 
 #### 3.1 Use additional model as assistant model
-By default, we need to add a second model named draft/assistant model to generate draft proposals. Note that assistant model should be similar to main model. It's recommended to use a small version of main model, e.g., Llama-72B as main model and Llama-7B as assistant model.
+By default, we need to add a second model named draft/assistant model to generate draft proposals. Note that assistant model should be similar to main model. It's recommended to use a small version of main model, e.g., Llama-70B as main model and Llama-7B as assistant model.
 
 ```bash
 python speculative_decoding.py --repo-id-or-model-path REPO_ID_OR_MODEL_PATH --assistant-model-path ASSISTANT_MODEL_PATH --prompt PROMPT --n-predict N_PREDICT

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/README.md
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/README.md
@@ -88,6 +88,12 @@ AI, or artificial intelligence, refers to the ability of machines to perform tas
 ### 3. Speculative Decoding
 Speculative decoding is a pivotal technique to accelerate the inference of large language models (LLMs) by employing a smaller draft/assistant model to predict the target model's outputs. Please refer [Assisted Generation](https://huggingface.co/blog/assisted-generation) for details. In the following example, we will use int4 assistant model to acclerate FP32 main model, without impacting accuarcy.
 
+Requirement:
+```bash
+ pip install transformers==4.36.0
+```
+
+Usage:
 ```bash
 python speculative_decoding.py --repo-id-or-model-path REPO_ID_OR_MODEL_PATH --assistant-model-path ASSISTANT_MODEL_PATH --prompt PROMPT --n-predict N_PREDICT
 ```

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/README.md
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/README.md
@@ -90,7 +90,7 @@ Speculative decoding is a pivotal technique to accelerate the inference of large
 
 Requirement:
 ```bash
- pip install transformers==4.36.0
+pip install transformers==4.36.0
 ```
 
 Usage:

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/README.md
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/README.md
@@ -84,3 +84,27 @@ What is AI?
 
 AI, or artificial intelligence, refers to the ability of machines to perform tasks that would typically require human intelligence, such as learning, problem-solving,
 ```
+
+### 3. Speculative Decoding
+Speculative decoding is a pivotal technique to accelerate the inference of large language models (LLMs) by employing a smaller draft/assistant model to predict the target model's outputs. Please refer [Assisted Generation](https://huggingface.co/blog/assisted-generation) for details. In the following example, we will use int4 assistant model to acclerate FP32 main model, without impacting accuarcy.
+
+```bash
+python speculative_decoding.py --repo-id-or-model-path REPO_ID_OR_MODEL_PATH --assistant-model-path ASSISTANT_MODEL_PATH --prompt PROMPT --n-predict N_PREDICT
+```
+
+New Arguments info:
+- `--assistant-model-path ASSISTANT_MODEL_PATH`: argument defining the huggingface repo id for the assistant model (e.g. `meta-llama/Llama-2-7b-chat-hf` and `meta-llama/Llama-2-13b-chat-hf`) to be downloaded, or the path to the huggingface checkpoint folder. 
+
+#### 3.1 Use additional model as assistant model
+By default, we need to add a second model named draft/assistant model to generate draft proposals. Note that assistant model should be similar to main model. It's recommended to use a small version of main model, e.g., Llama-72B as main model and Llama-7B as assistant model.
+
+```bash
+python speculative_decoding.py --repo-id-or-model-path REPO_ID_OR_MODEL_PATH --assistant-model-path ASSISTANT_MODEL_PATH --prompt PROMPT --n-predict N_PREDICT
+```
+
+#### 3.2 Use int4 model as assistant model
+In most cases, it's quite difficult to prepare or choose an assistant model. For example, there isn't any smaller version for main model. To resolve this problem, we can use int4 model as assistant model, which is much faster than the main model.
+
+```bash
+python speculative_decoding.py --repo-id-or-model-path REPO_ID_OR_MODEL_PATH --prompt PROMPT --n-predict N_PREDICT
+```

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/README.md
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/README.md
@@ -96,7 +96,7 @@ New Arguments info:
 - `--assistant-model-path ASSISTANT_MODEL_PATH`: argument defining the huggingface repo id for the assistant model (e.g. `meta-llama/Llama-2-7b-chat-hf` and `meta-llama/Llama-2-13b-chat-hf`) to be downloaded, or the path to the huggingface checkpoint folder. 
 
 #### 3.1 Use additional model as assistant model
-By default, we need to add a second model named draft/assistant model to generate draft proposals. Note that assistant model should be similar to main model. It's recommended to use a small version of main model, e.g., Llama-70B as main model and Llama-7B as assistant model.
+By default, we need to add a second model named draft/assistant model to generate draft proposals. Note that assistant model should be similar to main model. It's recommended to use a small version of main model, e.g., Llama-2-70B as main model and Llama-2-7B as assistant model.
 
 ```bash
 python speculative_decoding.py --repo-id-or-model-path REPO_ID_OR_MODEL_PATH --assistant-model-path ASSISTANT_MODEL_PATH --prompt PROMPT --n-predict N_PREDICT

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/speculative_decoding.py
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/speculative_decoding.py
@@ -62,7 +62,7 @@ if __name__ == '__main__':
 
     # Load tokenizer
     tokenizer = LlamaTokenizer.from_pretrained(model_path, trust_remote_code=True)
-    
+
     # Generate predicted tokens
     with torch.inference_mode():
         prompt = LLAMA2_PROMPT_FORMAT.format(prompt=args.prompt)

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/speculative_decoding.py
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/speculative_decoding.py
@@ -34,6 +34,9 @@ if __name__ == '__main__':
     parser.add_argument('--repo-id-or-model-path', type=str, default="meta-llama/Llama-2-7b-chat-hf",
                         help='The huggingface repo id for the Llama2 (e.g. `meta-llama/Llama-2-7b-chat-hf` and `meta-llama/Llama-2-13b-chat-hf`) to be downloaded'
                              ', or the path to the huggingface checkpoint folder')
+    parser.add_argument('--assistant-model-path', type=str, default=None,
+                        help='The huggingface repo id for the assistant model (e.g. `meta-llama/Llama-2-7b-chat-hf` and `meta-llama/Llama-2-13b-chat-hf`) to be downloaded'
+                             ', or the path to the huggingface checkpoint folder')
     parser.add_argument('--prompt', type=str, default="What is AI?",
                         help='Prompt to infer')
     parser.add_argument('--n-predict', type=int, default=32,
@@ -41,13 +44,17 @@ if __name__ == '__main__':
 
     args = parser.parse_args()
     model_path = args.repo_id_or_model_path
-
-    # Load model in 4 bit,
+    assistant_model_path = args.assistant_model_path
+    if assistant_model_path is None:
+        assistant_model_path = assistant_model_path
+    # Load assistant model in 4 bit,
     # which convert the relevant layers in the model into INT4 format
     assistant_model = autolowbit.from_pretrained(model_path,
                                                  load_in_4bit=True,
                                                  optimize_model=False,
                                                  trust_remote_code=True)
+    # Load model in FP32,
+    # which convert the relevant layers in the model into INT4 format
     print("Assistant model loaded!")
     model = AutoModelForCausalLM.from_pretrained(model_path,
                                                  trust_remote_code=True)

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/speculative_decoding.py
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/speculative_decoding.py
@@ -46,7 +46,7 @@ if __name__ == '__main__':
     model_path = args.repo_id_or_model_path
     assistant_model_path = args.assistant_model_path
     if assistant_model_path is None:
-        assistant_model_path = assistant_model_path
+        assistant_model_path = model_path
     # Load assistant model in 4 bit,
     # which convert the relevant layers in the model into INT4 format
     assistant_model = autolowbit.from_pretrained(model_path,

--- a/python/llm/example/CPU/Speculative-Decoding/speculative_decoding.py
+++ b/python/llm/example/CPU/Speculative-Decoding/speculative_decoding.py
@@ -1,0 +1,77 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import torch
+import time
+import argparse
+
+from bigdl.llm.transformers import AutoModelForCausalLM as autolowbit
+from transformers import LlamaTokenizer, AutoModelForCausalLM
+
+# you could tune the prompt based on your own model,
+# here the prompt tuning refers to https://huggingface.co/georgesung/llama2_7b_chat_uncensored#prompt-style
+LLAMA2_PROMPT_FORMAT = """### HUMAN:
+{prompt}
+
+### RESPONSE:
+"""
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description='Predict Tokens using `generate()` API for Llama2 model')
+    parser.add_argument('--repo-id-or-model-path', type=str, default="meta-llama/Llama-2-7b-chat-hf",
+                        help='The huggingface repo id for the Llama2 (e.g. `meta-llama/Llama-2-7b-chat-hf` and `meta-llama/Llama-2-13b-chat-hf`) to be downloaded'
+                             ', or the path to the huggingface checkpoint folder')
+    parser.add_argument('--prompt', type=str, default="What is AI?",
+                        help='Prompt to infer')
+    parser.add_argument('--n-predict', type=int, default=32,
+                        help='Max tokens to predict')
+
+    args = parser.parse_args()
+    model_path = args.repo_id_or_model_path
+
+    # Load model in 4 bit,
+    # which convert the relevant layers in the model into INT4 format
+    assistant_model = autolowbit.from_pretrained(model_path,
+                                                 load_in_4bit=True,
+                                                 optimize_model=False,
+                                                 trust_remote_code=True)
+    print("Assistant model loaded!")
+    model = AutoModelForCausalLM.from_pretrained(model_path,
+                                                 trust_remote_code=True)
+    print("Main model loaded!")
+
+    # Load tokenizer
+    tokenizer = LlamaTokenizer.from_pretrained(model_path, trust_remote_code=True)
+    
+    # Generate predicted tokens
+    with torch.inference_mode():
+        prompt = LLAMA2_PROMPT_FORMAT.format(prompt=args.prompt)
+        input_ids = tokenizer.encode(prompt, return_tensors="pt")
+        st = time.time()
+        # if your selected model is capable of utilizing previous key/value attentions
+        # to enhance decoding speed, but has `"use_cache": false` in its model config,
+        # it is important to set `use_cache=True` explicitly in the `generate` function
+        # to obtain optimal performance with BigDL-LLM INT4 optimizations
+        output = model.generate(input_ids,
+                                max_new_tokens=args.n_predict,
+                                assistant_model=assistant_model)
+        end = time.time()
+        output_str = tokenizer.decode(output[0], skip_special_tokens=True)
+        print(f'Inference time: {end-st} s')
+        print('-'*20, 'Prompt', '-'*20)
+        print(prompt)
+        print('-'*20, 'Output', '-'*20)
+        print(output_str)


### PR DESCRIPTION
## Description

LLM Speculative Decoding example for CPU

### 1. Why the change?

Speculative Decoding can speed up generation with an assistant model. In this example, the assistant model is an int4 version of the main model, so we don't have to load two different models.

### 2. User API changes

### 3. Summary of the change 



### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [X] Application test
- [X] Document test
- [ ] ...

### 5. New dependencies

