### PR TITLE
LLM: fix wrong batch output caused by flash attention

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -522,9 +522,10 @@ def check_flash_attention_available(query):
     if query.dtype not in [torch.float32, torch.float16]:
         # only use flash attention for fp32/fp16 input
         return False
-    if query.shape[0] > 1:
-        # only use flash attention for batch_size = 1
-        # as we found some precision problem with batch_size > 1
+    if query.shape[0] > 1 or query.size()[0] > 1:
+        # only use flash attention for batch_size = 1 now
+        # as flash attention doesn't support attn_mask in ipex 2.1,
+        # so it will cause output error for padded batch input
         return False
     return True
 

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -137,7 +137,7 @@ def llama_attention_forward_4_31(
     # for flash attention
     original_dtype = hidden_states.dtype
     if not self.training and not hidden_states.requires_grad:
-        fsdp_flag = check_flash_attention_available(hidden_states)
+        fsdp_flag = use_flash_attention(hidden_states)
     else:
         fsdp_flag = False
     if fsdp_flag:
@@ -324,7 +324,7 @@ def llama_attention_selective_batching_forward_4_31(
     original_dtype = hidden_states.dtype
     # TODO: consider this later - flash attention
     # if not self.training and not hidden_states.requires_grad:
-    #     fsdp_flag = check_flash_attention_available(hidden_states)
+    #     fsdp_flag = use_flash_attention(hidden_states)
     # else:
     #     fsdp_flag = False
     # if fsdp_flag and q_len > 1:
@@ -505,7 +505,7 @@ def llama_attention_selective_batching_forward_4_31(
     return attn_output.to(original_dtype), attn_weights, updated_past_key_values
 
 
-def check_flash_attention_available(query):
+def use_flash_attention(query):
     bsz, q_len, _ = query.size()
     # check whether ipex flash attention can be used
     if bsz > 1:

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -508,6 +508,11 @@ def llama_attention_selective_batching_forward_4_31(
 
 def check_flash_attention_available(query):
     # check whether ipex flash attention can be used
+    if query.shape[0] > 1 or query.size()[0] > 1:
+        # only use flash attention for batch_size = 1 now
+        # as flash attention doesn't support attn_mask in ipex 2.1,
+        # so it will cause output error for padded batch input
+        return False
     if query.device.type != "xpu":
         # ipex flash attention only support for xpu
         return False
@@ -521,11 +526,6 @@ def check_flash_attention_available(query):
         return False
     if query.dtype not in [torch.float32, torch.float16]:
         # only use flash attention for fp32/fp16 input
-        return False
-    if query.shape[0] > 1 or query.size()[0] > 1:
-        # only use flash attention for batch_size = 1 now
-        # as flash attention doesn't support attn_mask in ipex 2.1,
-        # so it will cause output error for padded batch input
         return False
     return True
 

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -522,6 +522,10 @@ def check_flash_attention_available(query):
     if query.dtype not in [torch.float32, torch.float16]:
         # only use flash attention for fp32/fp16 input
         return False
+    if query.shape[0] > 1:
+        # only use flash attention for batch_size = 1
+        # as we found some precision problem with batch_size > 1
+        return False
     return True
 
 


### PR DESCRIPTION
## Description

### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/888

### 2. User API changes

No change.

### 3. Summary of the change 

- only use flash attention when batch_size = 1, as when batch_size > 1, flash attention seems have precision issue.

### 4. How to test?
- [x] Unit test
- [x] Local test
