### PR TITLE
[vLLM] Add option to adjust KV_CACHE_ALLOC_BLOCK_LENGTH

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -36,6 +36,7 @@ import importlib
 import torch.nn as nn
 from typing import Optional, Tuple, Union, List
 import math
+import os
 import torch.nn.functional as F
 from bigdl.llm.utils.common import invalidInputError
 from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, append_kv_cache
@@ -318,7 +319,7 @@ def llama_attention_selective_batching_forward_4_31(
     **kwargs,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
     # Minimize this value to reduce memory allocation.
-    KV_CACHE_ALLOC_BLOCK_LENGTH = 64
+    KV_CACHE_ALLOC_BLOCK_LENGTH = int(os.environ.get('VLLM_KV_CACHE_ALLOC_BLOCK', 64))
     bsz, q_len, _ = hidden_states.size()
     device = hidden_states.device
     # for flash attention
@@ -621,7 +622,8 @@ def llama_model_selective_batching_forward_4_31(
     # TODO: validate correctness
     device = input_ids.device if input_ids is not None else inputs_embeds.device
     if position_ids is None:
-        invalidInputError("vLLM: position_ids should never be None")
+        invalidInputError(False,
+                          "vLLM: position_ids should never be None")
     else:
         # print(f"Original position_ids is {position_ids}")
         position_ids = position_ids.view(-1, seq_length)

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -319,7 +319,7 @@ def llama_attention_selective_batching_forward_4_31(
     **kwargs,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
     # Minimize this value to reduce memory allocation.
-    KV_CACHE_ALLOC_BLOCK_LENGTH = int(os.environ.get('VLLM_KV_CACHE_ALLOC_BLOCK', 64))
+    VLLM_KV_CACHE_ALLOC_BLOCK_LENGTH = int(os.environ.get('VLLM_KV_CACHE_ALLOC_BLOCK', 64))
     bsz, q_len, _ = hidden_states.size()
     device = hidden_states.device
     # for flash attention
@@ -359,7 +359,7 @@ def llama_attention_selective_batching_forward_4_31(
                                                        self.head_dim,
                                                        kv_seq_len,
                                                        kv_seq_len +
-                                                       KV_CACHE_ALLOC_BLOCK_LENGTH,
+                                                       VLLM_KV_CACHE_ALLOC_BLOCK_LENGTH,
                                                        dtype=past_k.dtype,
                                                        device=device)
             new_cache_k[:] = past_k
@@ -421,7 +421,7 @@ def llama_attention_selective_batching_forward_4_31(
                                                                self.head_dim,
                                                                past_k.size(2),
                                                                current_kv_len +
-                                                               KV_CACHE_ALLOC_BLOCK_LENGTH,
+                                                               VLLM_KV_CACHE_ALLOC_BLOCK_LENGTH,
                                                                dtype=past_k.dtype,
                                                                device=device)
                     new_cache_k[:] = past_k


### PR DESCRIPTION
## Description

This PR contains the following changes:
1. User can now adjust `KV_CACHE_ALLOC_BLOCK_LENGTH` through environment variable `VLLM_KV_CACHE_ALLOC_BLOCK`
### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

None.

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
