### PR TITLE
[LLM] Correct prompt format of Yi, Llama2 and Qwen in generate.py

### DIFF
--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/generate.py
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/llama2/generate.py
@@ -22,11 +22,12 @@ from bigdl.llm.transformers import AutoModelForCausalLM
 from transformers import LlamaTokenizer
 
 # you could tune the prompt based on your own model,
-# here the prompt tuning refers to https://huggingface.co/georgesung/llama2_7b_chat_uncensored#prompt-style
-LLAMA2_PROMPT_FORMAT = """### HUMAN:
-{prompt}
-
-### RESPONSE:
+# Refer to https://huggingface.co/TheBloke/Llama-2-70B-Chat-GGML#prompt-template-llama-2-chat
+LLAMA2_PROMPT_FORMAT = """
+[INST] <<SYS>>
+You are a helpful assistant.
+<</SYS>>
+{prompt}[/INST]
 """
 
 if __name__ == '__main__':

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/yi/generate.py
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/yi/generate.py
@@ -21,8 +21,14 @@ import argparse
 from bigdl.llm.transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
 
-# you could tune the prompt based on your own model,
-YI_PROMPT_FORMAT = "{prompt}"
+# Refer to https://huggingface.co/01-ai/Yi-6B-Chat#31-use-the-chat-model
+YI_PROMPT_FORMAT = """
+            <|im_start|>system
+            You are a helpful assistant. If you don't understand what the user means, ask the user to provide more information.<|im_end|>
+            <|im_start|>user
+            {prompt}<|im_end|>
+            <|im_start|>assistant
+"""
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Predict Tokens using `generate()` API for Yi model')

--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/yi/generate.py
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/yi/generate.py
@@ -23,11 +23,11 @@ from transformers import AutoTokenizer
 
 # Refer to https://huggingface.co/01-ai/Yi-6B-Chat#31-use-the-chat-model
 YI_PROMPT_FORMAT = """
-            <|im_start|>system
-            You are a helpful assistant. If you don't understand what the user means, ask the user to provide more information.<|im_end|>
-            <|im_start|>user
-            {prompt}<|im_end|>
-            <|im_start|>assistant
+<|im_start|>system
+You are a helpful assistant. If you don't understand what the user means, ask the user to provide more information.<|im_end|>
+<|im_start|>user
+{prompt}<|im_end|>
+<|im_start|>assistant
 """
 
 if __name__ == '__main__':

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/qwen/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/qwen/generate.py
@@ -23,7 +23,15 @@ from bigdl.llm.transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
 
 # you could tune the prompt based on your own model
-QWEN_PROMPT_FORMAT = "<human>{prompt} <bot>"
+QWEN_PROMPT_FORMAT = """
+<|im_start|>system
+You are a helpful assistant.
+<|im_end|>
+<|im_start|>user
+{prompt}
+<|im_end|>
+<|im_start|>assistant
+"""
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Predict Tokens using `generate()` API for Qwen model')

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/yi/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/yi/generate.py
@@ -24,11 +24,11 @@ from transformers import AutoTokenizer
 
 # Refer to https://huggingface.co/01-ai/Yi-6B-Chat#31-use-the-chat-model
 YI_PROMPT_FORMAT = """
-            <|im_start|>system
-            You are a helpful assistant. If you don't understand what the user means, ask the user to provide more information.<|im_end|>
-            <|im_start|>user
-            {prompt}<|im_end|>
-            <|im_start|>assistant
+<|im_start|>system
+You are a helpful assistant. If you don't understand what the user means, ask the user to provide more information.<|im_end|>
+<|im_start|>user
+{prompt}<|im_end|>
+<|im_start|>assistant
 """
 
 if __name__ == '__main__':

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/yi/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/yi/generate.py
@@ -22,8 +22,14 @@ import argparse
 from bigdl.llm.transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
 
-# you could tune the prompt based on your own model
-YI_PROMPT_FORMAT = "{prompt}"
+# Refer to https://huggingface.co/01-ai/Yi-6B-Chat#31-use-the-chat-model
+YI_PROMPT_FORMAT = """
+            <|im_start|>system
+            You are a helpful assistant. If you don't understand what the user means, ask the user to provide more information.<|im_end|>
+            <|im_start|>user
+            {prompt}<|im_end|>
+            <|im_start|>assistant
+"""
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Predict Tokens using `generate()` API for Yi model')


### PR DESCRIPTION
## Description

The prompt format for model Yi and model Llama2 in generate.py is wrong, which result in worse output.
Yi's prompt format refers to https://huggingface.co/01-ai/Yi-6B-Chat#31-use-the-chat-model
Llama2's prompt format refers to https://huggingface.co/TheBloke/Llama-2-70B-Chat-GGML#prompt-template-llama-2-chat
Qwen's prompt format refers tohttps://huggingface.co/Qwen/Qwen-1_8B-Chat/blob/main/generation_config.json#L2

The prompt format of Llama2 in GPU example and Qwen in CPU example are correct, so only correct prompt format of Llama2 in CPU example, prompt format of Yi in CPU/GPU examples and prompt format of Qwen in GPU example.

### 1. Why the change?

prompt format for model Yi, Llama2 and Qwen in generate.py

### 2. User API changes

Model example


### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

