### PR TITLE
LLM: better FP16 support for Intel GPUs

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -201,7 +201,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                             mp_group=mp_group,
                         )
                         device = module.qweight.data.device
-                        invalidInputError(device != "meta",
+                        invalidInputError(device.type != "meta",
                                           "converting from meta device is not supported")
                         # Copy the weights
                         paramsLowBit = FP4Params(data=convert_gptq(module, awq=is_awq),

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -635,6 +635,7 @@ class FP16Linear(nn.Linear):
             trans_weight = trans_weight.data.reshape(m//16, 16, n)
             trans_weight = trans_weight.transpose(1, 2).contiguous()
             self.weight.data = trans_weight
+        self.weight_type = 3
 
 
 class BF16Linear(nn.Linear):

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -584,7 +584,6 @@ class FP16Linear(nn.Linear):
             if x_2d.is_contiguous() is False:
                 x_2d = x_2d.contiguous()
 
-            x0 = self.weight.data
             try:
                 import intel_extension_for_pytorch
                 import linear_fp16_esimd

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -585,7 +585,7 @@ class FP16Linear(nn.Linear):
                     import linear_fp16_esimd
                 except ModuleNotFoundError:
                     invalidInputError(False,
-                                    "Please `pip install bigdl_core_xe_esimd` first.")
+                                      "Please `pip install bigdl_core_xe_esimd` first.")
 
                 if x_2d.shape[0] > 1:
                     # first token or batch size > 1, re-convert weight

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -620,7 +620,7 @@ class FP16Linear(nn.Linear):
         # now esimd kernel can only be used for specific cases (llama2-7b shape)
         if self.in_len == 11008 and self.out_features == 4096:
             return True
-        if self.in_len in 4096 and self.out_features in [4096, 11008]:
+        if self.in_len == 4096 and self.out_features in [4096, 11008]:
             # seems has some issue with Mistral,
             # need a further look to check whether can be used for other out features
             return True

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -590,7 +590,7 @@ class FP16Linear(nn.Linear):
                 import linear_fp16_esimd
             except ModuleNotFoundError:
                 invalidInputError(False,
-                                    "Please `pip install bigdl_core_xe_esimd` first.")
+                                  "Please `pip install bigdl_core_xe_esimd` first.")
 
             if x_2d.shape[0] > 1:
                 # first token or batch size > 1, re-convert weight

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -50,7 +50,8 @@ from torch import Tensor, device, dtype, nn
 from operator import mul
 from functools import reduce
 from bigdl.llm.transformers.xpu_customize_fwd import custom_fwd, custom_bwd
-from bigdl.llm.transformers.utils import get_autocast_dtype
+from bigdl.llm.transformers.utils import get_autocast_dtype, get_xpu_device_type, \
+    get_ipex_version
 
 T = TypeVar("T", bound="torch.nn.Module")
 
@@ -538,57 +539,101 @@ class LowBitLinear(nn.Linear):
 
 
 class FP16Linear(nn.Linear):
-    def __init__(self, input_features, output_features, qtype, bias=True,
-                 conver_to_half=True, mp_group=None):
+    def __init__(self, input_features, output_features, bias=True,
+                 mp_group=None, weight_type=1):
         super().__init__(input_features, output_features, bias)
         self.in_len = input_features
         self.out_len = output_features
         self.weight_shape = (self.out_len, self.in_len)
         self.weight_length = self.out_len * self.in_len
-        self.qtype = qtype
-        self.conver_to_half = conver_to_half
+        self.qtype = ggml_tensor_qtype["fp16"]
         self.mp_group = mp_group
+        # weigh_type = 1 means original weight
+        # weigh_type = 2 means weight has been transposed
+        # weigh_type = 3 means weight has been transposed by esimd method
+        self.weight_type = 1
 
     def forward(self, x: torch.Tensor):
-        if self.bias is not None and self.bias.dtype != x.dtype:
-            self.bias.data = self.bias.data.to(x.dtype)
-
-        x_shape = x.shape
-        x_2d = x.view(-1, x_shape[-1])
-
-        x0 = self.weight.data
         # only work for GPU
         invalidInputError(x0.device.type == "xpu",
-                          "FP16 only works for GPU")
-        try:
-            import intel_extension_for_pytorch
-            import linear_fp16_esimd
-        except ModuleNotFoundError:
-            invalidInputError(False,
-                              "Please `pip install bigdl_core_xe` first.")
+                          "FP16Linear only works for Intel GPUs")
+        x = x.to(torch.float16)
+        if self.bias is not None and self.bias.dtype != x.dtype:
+                self.bias.data = self.bias.data.to(x.dtype)
+        if self.weight is not None and self.weight.dtype != x.dtype:
+            self.weight.data = self.weight.data.to(x.dtype)
 
-        if x_2d.is_contiguous() is False:
-            x_2d = x_2d.contiguous()
+        dtype_type = get_xpu_device_type(x)
 
-        if x_2d.shape[0] > 1:
-            # first token or batch size > 1, re-convert weight
-            original_weight = self.weight.data.transpose(1, 2)
-            original_weight = original_weight.reshape(self.out_len, self.in_len)
-            result = F.linear(x_2d, original_weight.contiguous())
-            del original_weight
+        if dtype == "pvc":
+            return inference(x)
         else:
-            # rest token, use esimd optimization
-            result = linear_fp16_esimd.forward(x_2d, self.weight.data)
+            if self.in_len in [4096, 11008]:
+                # use esimd fp16 kernel for inference
+                if self.self.weight_type != 3:
+                    # convert weight first to use esimd fp16 kernel
+                    self.convert_weight_for_esimd_kernel()
+                # esimd fp16 kernel for inference
+                x_shape = x.shape
+                x_2d = x.view(-1, x_shape[-1])
+                if x_2d.is_contiguous() is False:
+                    x_2d = x_2d.contiguous()
 
-        new_shape = x_shape[:-1] + (self.out_len,)
-        result = result.view(new_shape)
-        if self.mp_group is not None:
-            from deepspeed import comm as dist
-            dist.inference_all_reduce(result, group=self.mp_group)
-        if self.bias is not None:
-            result += self.bias
+                x0 = self.weight.data
+                try:
+                    import intel_extension_for_pytorch
+                    import linear_fp16_esimd
+                except ModuleNotFoundError:
+                    invalidInputError(False,
+                                    "Please `pip install bigdl_core_xe_esimd` first.")
 
-        return result.to(x.dtype)
+                if x_2d.shape[0] > 1:
+                    # first token or batch size > 1, re-convert weight
+                    original_weight = self.weight.data.transpose(1, 2)
+                    original_weight = original_weight.reshape(self.out_len, self.in_len)
+                    result = F.linear(x_2d, original_weight.contiguous())
+                    del original_weight
+                else:
+                    # rest token, use esimd optimization
+                    result = linear_fp16_esimd.forward(x_2d, self.weight.data)
+
+                new_shape = x_shape[:-1] + (self.out_len,)
+                result = result.view(new_shape)
+                if self.mp_group is not None:
+                    from deepspeed import comm as dist
+                    dist.inference_all_reduce(result, group=self.mp_group)
+                if self.bias is not None:
+                    result += self.bias
+
+                return result.to(x.dtype)
+            else:
+                return inference(x)
+
+    def inference(x):
+        if get_ipex_version() < "2.1.10+xpu":
+            return F.linear(x, self.weight, self.bias)
+        else:
+            if self.weight_type == 1:
+                self.weight = self.weight.transpose(0, 1).contiguous()
+            return torch.ops.torch_ipex.matmul_bias_out(x, self.weight, self.bias)
+
+    def convert_weight_for_esimd_kernel():
+        if self.in_len == 11008:
+            if self.weight_type == 2:
+                trans_weight = self.weight.data.transpose(0, 1)
+            else:
+                trans_weight = self.weight.data
+            trans_weight = self.weight.data.reshape(m//8, 8, n)
+            trans_weight = trans_weight.transpose(1, 2).contiguous()
+            self.weight.data = trans_weight
+        elif self.in_len == 4096:
+            if self.weight_type == 2:
+                trans_weight = self.weight.data.transpose(0, 1)
+            else:
+                trans_weight = self.weight.data
+            trans_weight = module.weight.data.reshape(m//16, 16, n)
+            trans_weight = trans_weight.transpose(1, 2).contiguous()
+            self.weight.data = trans_weight
 
 
 class BF16Linear(nn.Linear):

--- a/python/llm/src/bigdl/llm/transformers/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/utils.py
@@ -149,3 +149,29 @@ def get_autocast_dtype(x):
     else:
         invalidInputError(False,
                           f"Device {x.device} is not supported.")
+
+
+_ipex_version = None
+
+
+def get_ipex_version():
+
+    global _ipex_version
+    if _ipex_version is not None:
+        return _ipex_version
+
+    import intel_extension_for_pytorch as ipex
+    _ipex_version = ipex.__version__
+    return _ipex_version
+
+
+def get_xpu_device_type(x):
+    name = torch.xpu.get_device_name(x.device.index)
+    if name.startswith("Intel(R) Arc(TM) A"):
+        return "arc"
+    elif name.startswith("Intel(R) Data Center GPU Flex"):
+        return "flex"
+    elif name.startswith("Intel(R) Data Center GPU Max"):
+        return "pvc"
+    else:
+        return "others"


### PR DESCRIPTION
## Description


### 1. Why the change?

https://github.com/analytics-zoo/nano/issues/890#issuecomment-1869437620
https://github.com/analytics-zoo/nano/issues/890#issuecomment-1869920497

### 2. User API changes

- Optimized fp16 usage

```python
from bigdl.llm.transformers import AutoModelForCausalLM
from transformers import AutoTokenizer
model = AutoModelForCausalLM.from_pretrained(model_path, 
                                             torch_dtype=torch.float16,
                                             load_in_low_bit="fp16", 
                                             trust_remote_code=True,
                                             use_cache=True)
tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
model = model.to('xpu')
```
- You can also do save & load (**must under same ipex version**), although it is maybe unnecessary ：)
```
model.save_low_bit(dir_path)
model = AutoModelForCausalLM.load_low_bit((dir_path)
```
### 3. Summary of the change 

- better FP16 support for Intel GPUs

### 4. How to test?
- [x] Unit test
- [x] Local test of llama2-7b on pvc (ipex 2.1)
- [x] Local test of llama2-7b on pvc (ipex 2.0)
- [x] Local test of llama2-7b on arc (ipex 2.1)
- [x] Local test of llama2-7b on arc (ipex 2.0)
- [x] Local test of mistral-7b on pvc (ipex 2.1)
- [x] Local test of mistral-7b on pvc (ipex 2.0)
- [x] Local test of mistral-7b on arc (ipex 2.1)
- [x] Local test of mistral-7b on arc (ipex 2.0)
- [x] save & load verification on pvc
- [x] save & load verification on arc

