### PR TITLE
fix cpuinfo error

### DIFF
--- a/python/llm/src/bigdl/llm/utils/utils.py
+++ b/python/llm/src/bigdl/llm/utils/utils.py
@@ -16,23 +16,7 @@
 
 import sys
 import pathlib
-from bigdl.llm.utils.isa_checker import check_avx_vnni, check_avx2, check_avx512_vnni
 from bigdl.llm.utils.common import invalidInputError, invalidOperationError
-
-
-def get_cpu_flags():
-    flags = ""
-    if sys.platform != "win32":
-        if check_avx512_vnni():
-            flags = "_avx512"
-        elif check_avx_vnni():
-            flags = "_avx2"
-        else:
-            invalidOperationError(False, "Unsupported CPUFLAGS.")
-    else:
-        # flags = "_vnni" if check_avx_vnni() else ""
-        flags = "-api"
-    return flags
 
 
 def get_shared_lib_info(lib_base_name: str):


### PR DESCRIPTION
## Description

using cpuinfo to check architecture may randomly cause error, such as

```
  File "C:\Users\arda\miniconda3\envs\yishuo-llm\lib\site-packages\bigdl\llm\utils\utils.py", line 19, in <module>
    from bigdl.llm.utils.isa_checker import check_avx_vnni, check_avx2, check_avx512_vnni
  File "C:\Users\arda\miniconda3\envs\yishuo-llm\lib\site-packages\bigdl\llm\utils\isa_checker.py", line 57, in <module>
    isa_checker = ISAChecker()
  File "C:\Users\arda\miniconda3\envs\yishuo-llm\lib\site-packages\bigdl\llm\utils\isa_checker.py", line 24, in __init__
    self.flags = cpuid.get_flags(cpuid.get_max_extension_support())
  File "C:\Users\arda\miniconda3\envs\yishuo-llm\lib\site-packages\cpuinfo\cpuinfo.py", line 1087, in get_max_extension_support
    max_extension_support = self._run_asm(
  File "C:\Users\arda\miniconda3\envs\yishuo-llm\lib\site-packages\cpuinfo\cpuinfo.py", line 1011, in _run_asm
    asm.compile()
  File "C:\Users\arda\miniconda3\envs\yishuo-llm\lib\site-packages\cpuinfo\cpuinfo.py", line 938, in compile
    if memmove(self.address, machine_code, size) < 0:
OSError: exception: access violation reading 0x00000226D6FC0000
```

so now only use it when necessary

