### PR TITLE
fix csv_to_html

### DIFF
--- a/python/llm/test/benchmark/csv_to_html.py
+++ b/python/llm/test/benchmark/csv_to_html.py
@@ -119,7 +119,7 @@ def main():
         latest_csv.to_html(daily_html)
 
     if args.baseline_path and not diffs_within_normal_range:
-        print("The diffs are outside the normal range: %" + highlight_threshold)
+        print("The diffs are outside the normal range: %" + str(highlight_threshold))
         return 1 
     return 0
 


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

When running llm-perf-regression-test-on-spr, this error occurs:
```log
  File "/actions-runner/_work/BigDL/BigDL/python/llm/test/benchmark/csv_to_html.py", line 122, in main
    print("The diffs are outside the normal range: %" + highlight_threshold)
TypeError: can only concatenate str (not "float") to str
```

