### PR TITLE
LLM: fix installation of codellama

### DIFF
--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/codellama/README.md
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/codellama/README.md
@@ -13,6 +13,7 @@ conda create -n llm python=3.9
 conda activate llm
 
 pip install bigdl-llm[all] # install bigdl-llm with 'all' option
+pip install transformers==4.34.1 # CodeLlamaTokenizer is supported in higher version of transformers
 ```
 
 ### 2. Run

--- a/python/llm/example/CPU/PyTorch-Models/Model/codellama/README.md
+++ b/python/llm/example/CPU/PyTorch-Models/Model/codellama/README.md
@@ -15,6 +15,7 @@ conda create -n llm python=3.9 # recommend to use Python 3.9
 conda activate llm
 
 pip install --pre --upgrade bigdl-llm[all] # install the latest bigdl-llm nightly build with 'all' option
+pip install transformers==4.34.1 # CodeLlamaTokenizer is supported in higher version of transformers
 ```
 
 ### 2. Run

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/codellama/readme.md
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/codellama/readme.md
@@ -14,6 +14,7 @@ conda activate llm
 # below command will install intel_extension_for_pytorch==2.0.110+xpu as default
 # you can install specific ipex/torch version for your need
 pip install --pre --upgrade bigdl-llm[xpu] -f https://developer.intel.com/ipex-whl-stable-xpu
+pip install transformers==4.34.1 # CodeLlamaTokenizer is supported in higher version of transformers
 ```
 
 ### 2. Configures OneAPI environment variables

--- a/python/llm/example/GPU/PyTorch-Models/Model/codellama/README.md
+++ b/python/llm/example/GPU/PyTorch-Models/Model/codellama/README.md
@@ -17,6 +17,7 @@ conda activate llm
 # below command will install intel_extension_for_pytorch==2.0.110+xpu as default
 # you can install specific ipex/torch version for your need
 pip install --pre --upgrade bigdl-llm[xpu] -f https://developer.intel.com/ipex-whl-stable-xpu
+pip install transformers==4.34.1 # CodeLlamaTokenizer is supported in higher version of transformers
 ```
 
 ### 2. Configures OneAPI environment variables


### PR DESCRIPTION
## Description

Update installation of codellama examples, `CodeLlamaTokenizer` is not supported in default v4.31 transformers. 

### 4. How to test?
- [ ] Unit test
- [x] Local test