### PR TITLE
[LLM] Remove unnecessary warning when installing llm

### DIFF
--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -320,8 +320,8 @@ def setup_package():
         },
         extras_require={"all": all_requires,
                         "xpu": xpu_requires,  # default to ipex 2.0 for linux and 2.1 for windows
-                        "xpu_2.0": xpu_20_requires,
-                        "xpu_2.1": xpu_21_requires,
+                        "xpu-2-0": xpu_20_requires,
+                        "xpu-2-1": xpu_21_requires,
                         "serving": serving_requires},
         classifiers=[
             'License :: OSI Approved :: Apache Software License',


### PR DESCRIPTION
## Description

Related issue here: https://github.com/analytics-zoo/nano/issues/899

Reference: https://peps.python.org/pep-0685/#rationale

It seems that distribution extra names will be normalized: "`re.sub(r"[-_.]+", "-", name).lower()` collapses any run of the characters  `-`, `_` and `.` down to a single `-`". 

This means, we could change the [`extras_require` in `setup.py`](https://github.com/intel-analytics/BigDL/blob/main/python/llm/setup.py#L323) from `'xpu_2.1'`/`'xpu_2.0'` to `'xpu-2-1'`/`'xpu-2-0'`, **and meanwhile still using the `'xpu_2.1'`/`'xpu_2.0'` for installation.** After some verification, I found that we could remove warning through this way.


### 4. How to test?
- [x] local install test on Windows and Linux
