### PR TITLE
[LLM] IPEX auto importer turn on by default for XPU

### DIFF
--- a/python/llm/example/GPU/Deepspeed-AutoTP/deepspeed_autotp.py
+++ b/python/llm/example/GPU/Deepspeed-AutoTP/deepspeed_autotp.py
@@ -33,7 +33,6 @@ world_size = get_int_from_env(["WORLD_SIZE","PMI_SIZE"], "1")
 from bigdl.llm import optimize_model
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/generate.py
@@ -17,7 +17,6 @@
 import torch
 import time
 import argparse
-import intel_extension_for_pytorch as ipex
 from bigdl.llm.transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/GGUF/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/GGUF/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/GPTQ/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/GPTQ/generate.py
@@ -17,7 +17,6 @@
 import torch
 import time
 import argparse
-import intel_extension_for_pytorch as ipex
 from bigdl.llm.transformers import AutoModelForCausalLM
 from transformers import LlamaTokenizer, GPTQConfig
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/aquila/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/aquila/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/aquila2/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/aquila2/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/baichuan/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/baichuan/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/baichuan2/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/baichuan2/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/bluelm/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/bluelm/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/chatglm2/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/chatglm2/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 import numpy as np

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/chatglm2/streamchat.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/chatglm2/streamchat.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 import numpy as np

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/chatglm3/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/chatglm3/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 import numpy as np

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/chatglm3/streamchat.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/chatglm3/streamchat.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 import numpy as np

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/chinese-llama2/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/chinese-llama2/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/codellama/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/codellama/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/distil-whisper/recognize.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/distil-whisper/recognize.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/dolly-v1/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/dolly-v1/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 import numpy as np

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/dolly-v2/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/dolly-v2/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 import numpy as np

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/falcon/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/falcon/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/flan-t5/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/flan-t5/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/gpt-j/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/gpt-j/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/internlm/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/internlm/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/llama2/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/llama2/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/mistral/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/mistral/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/mixtral/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/mixtral/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/mpt/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/mpt/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/phi-1_5/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/phi-1_5/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 import numpy as np

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/qwen-vl/chat.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/qwen-vl/chat.py
@@ -22,7 +22,6 @@ from transformers import AutoTokenizer
 from transformers.generation import GenerationConfig
 
 from bigdl.llm.transformers import AutoModelForCausalLM
-import intel_extension_for_pytorch as ipex
 
 torch.manual_seed(1234)
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/qwen/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/qwen/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/replit/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/replit/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/starcoder/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/starcoder/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/vicuna/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/vicuna/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/voiceassistant/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/voiceassistant/generate.py
@@ -17,7 +17,6 @@
 import os
 import torch
 import time
-import intel_extension_for_pytorch as ipex
 import argparse
 import numpy as np
 import inquirer

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/whisper/recognize.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/whisper/recognize.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/yi/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/yi/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/More-Data-Types/transformers_low_bit_pipeline.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/More-Data-Types/transformers_low_bit_pipeline.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import argparse
 from bigdl.llm.transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer, TextGenerationPipeline

--- a/python/llm/example/GPU/PyTorch-Models/Model/aquila2/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/aquila2/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/baichuan/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/baichuan/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/baichuan2/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/baichuan2/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/bluelm/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/bluelm/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/chatglm2/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/chatglm2/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/chatglm2/streamchat.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/chatglm2/streamchat.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 import numpy as np

--- a/python/llm/example/GPU/PyTorch-Models/Model/chatglm3/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/chatglm3/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/chatglm3/streamchat.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/chatglm3/streamchat.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 import numpy as np

--- a/python/llm/example/GPU/PyTorch-Models/Model/codellama/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/codellama/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/distil-whisper/recognize.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/distil-whisper/recognize.py
@@ -14,7 +14,6 @@
 # limitations under the License.
 #
 
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/dolly-v1/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/dolly-v1/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/dolly-v2/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/dolly-v2/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/flan-t5/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/flan-t5/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/llama2/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/llama2/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/llama2/low_memory_generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/llama2/low_memory_generate.py
@@ -23,7 +23,6 @@ import time
 import warnings
 from typing import Dict, List, Optional, Union
 
-import intel_extension_for_pytorch as ipex
 import torch
 import torch.nn as nn
 from accelerate import init_empty_weights

--- a/python/llm/example/GPU/PyTorch-Models/Model/llava/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/llava/generate.py
@@ -34,7 +34,6 @@
 
 import argparse
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 
 from transformers import AutoModelForCausalLM

--- a/python/llm/example/GPU/PyTorch-Models/Model/mistral/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/mistral/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/mixtral/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/mixtral/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/phi-1_5/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/phi-1_5/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/qwen-vl/chat.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/qwen-vl/chat.py
@@ -22,7 +22,6 @@ from transformers import AutoModelForCausalLM, AutoTokenizer
 from transformers.generation import GenerationConfig
 
 from bigdl.llm import optimize_model
-import intel_extension_for_pytorch as ipex
 
 torch.manual_seed(1234)
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/replit/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/replit/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/starcoder/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/starcoder/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Model/yi/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/yi/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/More-Data-Types/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/More-Data-Types/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 

--- a/python/llm/example/GPU/PyTorch-Models/Save-Load/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Save-Load/generate.py
@@ -15,7 +15,6 @@
 #
 
 import torch
-import intel_extension_for_pytorch as ipex
 import time
 import argparse
 from bigdl.llm import optimize_model

--- a/python/llm/example/GPU/QLoRA-FineTuning/alpaca-qlora/alpaca_qlora_finetuning.py
+++ b/python/llm/example/GPU/QLoRA-FineTuning/alpaca-qlora/alpaca_qlora_finetuning.py
@@ -46,7 +46,6 @@ from peft import (
 )
 from utils.prompter import Prompter
 
-import intel_extension_for_pytorch as ipex
 from bigdl.llm.transformers import AutoModelForCausalLM
 # import them from bigdl.llm.transformers.qlora to get a BigDL-LLM compatible Peft model
 from bigdl.llm.transformers.qlora import get_peft_model, prepare_model_for_kbit_training,\

--- a/python/llm/example/GPU/QLoRA-FineTuning/qlora_finetuning.py
+++ b/python/llm/example/GPU/QLoRA-FineTuning/qlora_finetuning.py
@@ -19,7 +19,6 @@ import os
 
 import transformers
 from transformers import LlamaTokenizer
-import intel_extension_for_pytorch as ipex
 from peft import LoraConfig
 from bigdl.llm.transformers.qlora import get_peft_model, prepare_model_for_kbit_training
 from bigdl.llm.transformers import AutoModelForCausalLM

--- a/python/llm/src/bigdl/llm/__init__.py
+++ b/python/llm/src/bigdl/llm/__init__.py
@@ -24,7 +24,7 @@ from .optimize import optimize_model
 import os
 
 # Default is false, set to true to auto importing Intel Extension for PyTorch.
-BIGDL_IMPORT_IPEX = os.getenv("BIGDL_IMPORT_IPEX", 'False').lower() in ('true', '1', 't')
+BIGDL_IMPORT_IPEX = os.getenv("BIGDL_IMPORT_IPEX", 'True').lower() in ('true', '1', 't')
 if BIGDL_IMPORT_IPEX:
     # Import Intel Extension for PyTorch as ipex if XPU version is installed
     from .utils.ipex_importer import ipex_importer


### PR DESCRIPTION
## Description

Set BIGDL_IMPORT_IPEX default as True, i.e., auto import IPEX when bigdl-xpu is installed.
Remove IPEX import from GPU example.

### 1. Why the change?

Performance tests show no impact from auto importer.

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

