### PR TITLE
LLM: update qlora alpaca example to change lora usage

### DIFF
--- a/python/llm/example/GPU/QLoRA-FineTuning/alpaca-qlora/alpaca_qlora_finetuning.py
+++ b/python/llm/example/GPU/QLoRA-FineTuning/alpaca-qlora/alpaca_qlora_finetuning.py
@@ -217,7 +217,7 @@ def train(
                 bnb_4bit_compute_dtype=torch.bfloat16
             )
             model = AutoModelForCausalLM.from_pretrained(base_model,
-                                                        quantization_config=bnb_config, )
+                                                         quantization_config=bnb_config, )
 
         # below is also supported
         # Load the base model from a directory or the HF Hub to 4-bit format

--- a/python/llm/example/GPU/QLoRA-FineTuning/alpaca-qlora/alpaca_qlora_finetuning.py
+++ b/python/llm/example/GPU/QLoRA-FineTuning/alpaca-qlora/alpaca_qlora_finetuning.py
@@ -196,20 +196,28 @@ def train(
     else:
         # According to the QLoRA paper, using "nf4" could yield better model quality than "int4"
         # Default 4-bit format for qa-lora is sym_int4
-        if training_mode == "qalora":
-            low_bit_format = "int4"
-        elif training_mode == "lora":
-            low_bit_format = "bf16"
+        if training_mode == "lora":
+            model = AutoModelForCausalLM.from_pretrained(
+                base_model,
+                load_in_low_bit="bf16",
+                optimize_model=False,
+                torch_dtype=torch.bfloat16,
+                modules_to_not_convert=["lm_head"],
+            )
         else:
-            low_bit_format = "nf4"
-        bnb_config = BitsAndBytesConfig(
-            load_in_4bit=True,
-            bnb_4bit_use_double_quant=False,
-            bnb_4bit_quant_type=low_bit_format,
-            bnb_4bit_compute_dtype=torch.bfloat16
-        )
-        model = AutoModelForCausalLM.from_pretrained(base_model,
-                                                     quantization_config=bnb_config, )
+            # use bnb_config for qlora/qalora/relora, which use 4bit for base model
+            if training_mode == "qalora":
+                low_bit_format = "int4"
+            else:
+                low_bit_format = "nf4"
+            bnb_config = BitsAndBytesConfig(
+                load_in_4bit=True,
+                bnb_4bit_use_double_quant=False,
+                bnb_4bit_quant_type=low_bit_format,
+                bnb_4bit_compute_dtype=torch.bfloat16
+            )
+            model = AutoModelForCausalLM.from_pretrained(base_model,
+                                                        quantization_config=bnb_config, )
 
         # below is also supported
         # Load the base model from a directory or the HF Hub to 4-bit format


### PR DESCRIPTION
## Description

### 1. Why the change?

As lora just use bf16, not 4bit here, so update related example to not use bnb config for lora finetuning.

### 2. User API changes

None, usage change see example.

### 3. Summary of the change 

- update qlora alpaca example to change lora usage

### 4. How to test?
- [ ] Unit test
- [x] Local test
- [x] Local perf verification

