### PR TITLE
LLM: fix first token judgement of flash attention

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -367,7 +367,7 @@ def core_attn_forward_8eb45c(self, query_layer, key_layer, value_layer, attentio
     if pytorch_major_version >= 2 and (query_layer.device.type == 'xpu' or query_layer.size(0) > 1):
         query_layer = query_layer.permute(1, 2, 0, 3)
         L, S = query_layer.shape[2], key_layer.shape[2]
-        if attention_mask is None and (use_flash_attention(query_layer) or
+        if attention_mask is None and (use_flash_attention(query_layer, key_layer) or
                                        L == S and query_layer.device.type == "cpu"):
             context_layer = torch.nn.functional.scaled_dot_product_attention(query_layer,
                                                                              key_layer,

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -265,7 +265,8 @@ def llama_attention_forward_4_31(
     value_states = repeat_kv(value_states, self.num_key_value_groups).to(device,
                                                                          dtype=attention_dtype)
 
-    if fsdp_flag:
+    if fsdp_flag and query_states.shape[2] == key_states.shape[2]:
+        # by comparing query and key's length, to make sure it's first token
         attn_output = F.scaled_dot_product_attention(query_states.to(dtype=attention_dtype),
                                                      key_states,
                                                      value_states,

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -122,18 +122,24 @@ def is_enough_kv_cache_room_4_31(past_key_value):
         past_key_value[0].stride()[1] > past_key_value[0].size(2) * past_key_value[0].size(3)
 
 
-def use_flash_attention(query):
-    if query.dim() == 3:
-        bsz, q_len, _ = query.size()
-    elif query.dim() == 4:
-        bsz, _, q_len, _ = query.size()
+def use_flash_attention(query, key):
+    # here we support query's shape is always [batch_size, head_num, q_len, head_dim],
+    # key's shape is always [batch_size, head_num, k_len, head_dim]
+    invalidInputError(query.dim() != 4,
+                      "Here query input of use_flash_attention should be [batch_size, "
+                      "head_num, q_len, head_dim]")
+    invalidInputError(key.dim() != 4,
+                      "Here key input of use_flash_attention should be [batch_size, "
+                      "head_num, k_len, head_dim]")
+    bsz, _, q_len, _ = query.size()
+    k_len = key.size()[2]
     # check whether ipex flash attention can be used
     if bsz > 1:
         # only use flash attention for batch_size = 1 now
         # as flash attention doesn't support attn_mask in ipex 2.1,
         # so it will cause output error for padded batch input
         return False
-    if q_len == 1:
+    if q_len != k_len:
         # now only use flash attention for first token
         # as it seems have no performance benifit for rest token now
         return False

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -125,10 +125,10 @@ def is_enough_kv_cache_room_4_31(past_key_value):
 def use_flash_attention(query, key):
     # here we support query's shape is always [batch_size, head_num, q_len, head_dim],
     # key's shape is always [batch_size, head_num, k_len, head_dim]
-    invalidInputError(query.dim() != 4,
+    invalidInputError(query.dim() == 4,
                       "Here query input of use_flash_attention should be [batch_size, "
                       "head_num, q_len, head_dim]")
-    invalidInputError(key.dim() != 4,
+    invalidInputError(key.dim() == 4,
                       "Here key input of use_flash_attention should be [batch_size, "
                       "head_num, k_len, head_dim]")
     bsz, _, q_len, _ = query.size()


### PR DESCRIPTION
## Description


### 1. Why the change?

Fix flash attention error when past_past_key_values is not None.
Now speculative sampling can works normally.

### 2. User API changes

No change.

### 3. Summary of the change 

- change first token judgement of flash attention to `q_len == k_len` other than `q_len > 1`

### 4. How to test?
- [ ] Unit test
- [x] Local test on pvc for llama2-7b & chatglm3


