### PR TITLE
[LLM] Fix Langchain UT

### DIFF
--- a/.github/workflows/llm_unit_tests.yml
+++ b/.github/workflows/llm_unit_tests.yml
@@ -202,7 +202,6 @@ jobs:
           pip install -U langchain==0.0.184
           pip install -U chromadb==0.3.25
           pip install -U pandas==2.0.3
-          pip install -U typing_extensions==4.5.0
           bash python/llm/test/run-llm-langchain-tests.sh
   llm-unit-test-on-arc:
     needs: llm-cpp-build


### PR DESCRIPTION
## Description

Failure: https://github.com/intel-analytics/BigDL/actions/runs/7417443395/job/20184001221
`ImportError: cannot import name 'TypeAliasType' from 'typing_extensions'`

This may due to that we manually downgrading `typing-extension` to 4.5.0 for langchain tests, while some other related packages has been updated, which cause incompatibility. (Reference: https://stackoverflow.com/questions/77450322/i-cannot-import-name-typealiastype-from-typing-extensions)

So the downgrading for `typing-extension` is removed here. We may need to have some more verification for related examples and updated their readme later.

### How to test?
- [x] Unit test

