### PR TITLE
[LLM] Small fixes for finetune related examples and UTs

### DIFF
--- a/.github/workflows/llm_unit_tests.yml
+++ b/.github/workflows/llm_unit_tests.yml
@@ -324,7 +324,8 @@ jobs:
       - name: Run LLM example tests
         shell: bash
         run: |
-          python -m pip install transformers==4.34.0 peft==0.5.0 accelerate==0.23.0
+          python -m pip uninstall datasets -y
+          python -m pip install transformers==4.34.0 datasets peft==0.5.0 accelerate==0.23.0
           python -m pip install bitsandbytes scipy
           # Specific oneapi position on arc ut test machines
           if [[ '${{ matrix.pytorch-version }}' == '2.1' ]]; then

--- a/python/llm/example/GPU/QLoRA-FineTuning/README.md
+++ b/python/llm/example/GPU/QLoRA-FineTuning/README.md
@@ -16,7 +16,7 @@ conda create -n llm python=3.9
 conda activate llm
 # below command will install intel_extension_for_pytorch==2.1.10+xpu as default
 pip install --pre --upgrade bigdl-llm[xpu] -f https://developer.intel.com/ipex-whl-stable-xpu
-pip install datasets transformers==4.34.0
+pip install transformers==4.34.0 datasets
 pip install peft==0.5.0
 pip install accelerate==0.23.0
 pip install bitsandbytes scipy

--- a/python/llm/example/GPU/QLoRA-FineTuning/alpaca-qlora/README.md
+++ b/python/llm/example/GPU/QLoRA-FineTuning/alpaca-qlora/README.md
@@ -12,7 +12,7 @@ conda create -n llm python=3.9
 conda activate llm
 # below command will install intel_extension_for_pytorch==2.1.10+xpu as default
 pip install --pre --upgrade bigdl-llm[xpu] -f https://developer.intel.com/ipex-whl-stable-xpu
-pip install datasets transformers==4.34.0
+pip install transformers==4.34.0 datasets
 pip install fire peft==0.5.0
 pip install oneccl_bind_pt==2.1.100 -f https://developer.intel.com/ipex-whl-stable-xpu # necessary to run distributed finetuning
 pip install accelerate==0.23.0


### PR DESCRIPTION
## Description

The latest `datasets` (2.16.1) with further installed `transformers==4.34.0` will cause installation incompatibility (test pip 23.3.1, setuptools 68.2.2):
![image](https://github.com/intel-analytics/BigDL/assets/54161268/33c97152-e126-42d3-ad90-99d764c5139f)
And will further cause error when `from datasets import load_dataset`:
![image](https://github.com/intel-analytics/BigDL/assets/54161268/88c488ae-9ff6-4778-8bcf-b29eb59515be)

Install `transformers==4.34.0` first and then install `datasets` will automatically install the compatible version for `datasets` and resolve the import error as an workaround.

### How to test?
- [x] Unit test https://github.com/intel-analytics/BigDL/actions/runs/7459241954/job/20295016794?pr=9870