### PR TITLE
[LLM] Support llm-awq vicuna-7b-1.5 on arc

### DIFF
--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
@@ -4,6 +4,7 @@ This example shows how to directly run 4-bit AWQ models using BigDL-LLM on Intel
 
 ## Verified Models
 
+### Auto-AWQ Backend
 - [Llama-2-7B-Chat-AWQ](https://huggingface.co/TheBloke/Llama-2-7B-Chat-AWQ)
 - [CodeLlama-7B-AWQ](https://huggingface.co/TheBloke/CodeLlama-7B-AWQ)
 - [Mistral-7B-Instruct-v0.1-AWQ](https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-AWQ)
@@ -14,6 +15,10 @@ This example shows how to directly run 4-bit AWQ models using BigDL-LLM on Intel
 - [Yi-6B-AWQ](https://huggingface.co/TheBloke/Yi-6B-AWQ)
 - [Yi-34B-AWQ](https://huggingface.co/TheBloke/Yi-34B-AWQ)
 - [Mixtral-8x7B-Instruct-v0.1-AWQ](https://huggingface.co/ybelkada/Mixtral-8x7B-Instruct-v0.1-AWQ)
+
+### llm-AWQ Backedn
+
+- [vicuna-7b-1.5-awq](https://huggingface.co/ybelkada/vicuna-7b-1.5-awq)
 
 ## Requirements
 

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Advanced-Quantizations/AWQ/README.md
@@ -16,7 +16,7 @@ This example shows how to directly run 4-bit AWQ models using BigDL-LLM on Intel
 - [Yi-34B-AWQ](https://huggingface.co/TheBloke/Yi-34B-AWQ)
 - [Mixtral-8x7B-Instruct-v0.1-AWQ](https://huggingface.co/ybelkada/Mixtral-8x7B-Instruct-v0.1-AWQ)
 
-### llm-AWQ Backedn
+### llm-AWQ Backend
 
 - [vicuna-7b-1.5-awq](https://huggingface.co/ybelkada/vicuna-7b-1.5-awq)
 


### PR DESCRIPTION
## Description

Tested on arc for vicuna-7b-1.5-awq.
Need to use nightly `bigdl-llm[xpu]`.

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

Support llm-awq vicuna-7b-1.5 on arc

### 4. How to test?
- [x] Application test

### 5. New dependencies
None.