### PR TITLE
[LLM] Fix llm api doc rendering failure due to ipex auto importer

### DIFF
--- a/docs/readthedocs/source/conf.py
+++ b/docs/readthedocs/source/conf.py
@@ -20,7 +20,8 @@ import urllib
 
 autodoc_mock_imports = ["openvino", "pytorch_lightning", "keras", "cpuinfo", "sigfig", "prophet",
                         "accelerate", "langchain", "pydantic", "transformers", "ray", "sklearn", "torchmetrics",
-                        "pandas", "pmdarima", "scipy", "optuna", "cloudpickle", "xgboost", "filelock"]
+                        "pandas", "pmdarima", "scipy", "optuna", "cloudpickle", "xgboost", "filelock",
+                        "importlib.metadata", "intel_extension_for_pytorch"]
 
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #sys.path.insert(0, '.')


### PR DESCRIPTION
## Description

Fix llm api doc rendering failure due to ipex auto importer

Preview: https://yuwentestdocs.readthedocs.io/en/fix-llm-apidoc-failure-due-to-autoimporter/doc/PythonAPI/LLM/optimize.html
