### PR TITLE
[LLM] support chatglm3 with bigdl-bf16

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -665,7 +665,5 @@ class BF16Linear(nn.Linear):
         if self.bias is not None and self.bias.dtype != x.dtype:
             self.bias.data = self.bias.data.to(x.dtype)
 
-        result = F.linear(x, self.weight)
-        if self.bias is not None:
-            result += self.bias
+        result = F.linear(x, self.weight, self.bias)
         return result.to(x.dtype)


### PR DESCRIPTION
## Description

During benchmarking BigDL BF16 on SPR, observed high first token latency (>3s) for 1024-128 request on Chatglm3-6B model and worse latency (>60s)
Comparing the two trace diagrams, found that the implementation of bigdl's BF16Linear is different from that of pytorch.


### 1. Why the change?

Modify method F.linear's params


### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...
