### PR TITLE
[LLM]Solve the problem of calling bmm operator in BF16Linear

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -664,6 +664,17 @@ class BF16Linear(nn.Linear):
             self.weight.data = self.weight.data.to(x.dtype)
         if self.bias is not None and self.bias.dtype != x.dtype:
             self.bias.data = self.bias.data.to(x.dtype)
+        
+        # If x.shape>3, F.linear will use bmm, accounting for performance degradation.
+        original_shape = x.shape
+        # Convert to 2D shape
+        if len(original_shape)>2:
+            x = x.reshape(-1, original_shape[-1])
 
         result = F.linear(x, self.weight, self.bias)
+
+        # Convert to original shape
+        if len(original_shape)>2:
+            result=result.reshape(*original_shape[:-1], result.shape[-1])
+
         return result.to(x.dtype)

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -664,17 +664,17 @@ class BF16Linear(nn.Linear):
             self.weight.data = self.weight.data.to(x.dtype)
         if self.bias is not None and self.bias.dtype != x.dtype:
             self.bias.data = self.bias.data.to(x.dtype)
-        
+
         # If x.shape>3, F.linear will use bmm, accounting for performance degradation.
         original_shape = x.shape
         # Convert to 2D shape
-        if len(original_shape)>2:
+        if len(original_shape) > 2:
             x = x.reshape(-1, original_shape[-1])
 
         result = F.linear(x, self.weight, self.bias)
 
         # Convert to original shape
-        if len(original_shape)>2:
-            result=result.reshape(*original_shape[:-1], result.shape[-1])
+        if len(original_shape) > 2:
+            result = result.reshape(*original_shape[:-1], result.shape[-1])
 
         return result.to(x.dtype)


### PR DESCRIPTION
## Description

During benchmarking BigDL BF16 on SPR, observed high first token latency (>60s) for 1024-128 request on Chatglm3-6B model.
Comparing the two trace diagrams, found that the implementation of bigdl's BF16Linear is different from that of pytorch.

Since the shape of context_layer is 3D, the nn.functional.linear method calls the bmm operator, resulting in a decrease in first token performance.

### 1. Why the change?

When the shape of context_layer is greater than 2D, reshape its shape to 2D


### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

