### PR TITLE
LLM: add mlp & qkv fusion for FP16 Llama-7B

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -589,7 +589,6 @@ def _optimize_post(model, lightweight_bmm=False):
         convert_forward(model,
                         transformers.models.llama.modeling_llama.LlamaMLP,
                         llama_mlp_forward)
-        # TODO: add convert for model
         convert_forward(model,
                         transformers.models.llama.modeling_llama.LlamaDecoderLayer,
                         llama_decoder_forward)

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -567,6 +567,7 @@ def _optimize_post(model, lightweight_bmm=False):
     from bigdl.llm.transformers.models.llama import llama_model_selective_batching_forward_4_31
     from bigdl.llm.transformers.models.llama import llama_rms_norm_forward
     from bigdl.llm.transformers.models.llama import llama_mlp_forward
+    from bigdl.llm.transformers.models.llama import llama_decoder_forward
     from transformers.modeling_utils import PreTrainedModel
 
     # All huggingface format models are inherited from `PreTrainedModel`
@@ -588,6 +589,10 @@ def _optimize_post(model, lightweight_bmm=False):
         convert_forward(model,
                         transformers.models.llama.modeling_llama.LlamaMLP,
                         llama_mlp_forward)
+        # TODO: add convert for model
+        convert_forward(model,
+                        transformers.models.llama.modeling_llama.LlamaDecoderLayer,
+                        llama_decoder_forward)
         if version.parse(trans_version) >= version.parse("4.36.0"):
             # transformers version >= 4.36.0
             from bigdl.llm.transformers.models.llama import llama_attention_forward_4_36

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -176,7 +176,8 @@ def llama_decoder_forward(
 ) -> Tuple[torch.FloatTensor, Optional[Tuple[torch.FloatTensor, torch.FloatTensor]]]:
     if "padding_mask" in kwargs:
             warnings.warn(
-                "Passing `padding_mask` is deprecated and will be removed in v4.37. Please make sure use `attention_mask` instead.`"
+                "Passing `padding_mask` is deprecated and will be removed in v4.37."
+                "Please make sure use `attention_mask` instead.`"
             )
 
     residual = hidden_states
@@ -292,12 +293,12 @@ def llama_attention_forward_4_31(
                     self.k_proj.weight.data = self.qkv_proj_weight[1, :, :]
                     self.v_proj.weight.data = self.qkv_proj_weight[2, :, :]
                     torch.xpu.empty_cache()
-                query_states = torch.empty(bsz, q_len, hidden_size, dtype = hidden_states.dtype,
-                                            device=hidden_states.device)
-                key_states = torch.empty(bsz, q_len, hidden_size, dtype = hidden_states.dtype,
-                                            device=hidden_states.device)
-                value_states = torch.empty(bsz, q_len, hidden_size, dtype = hidden_states.dtype,
-                                            device=hidden_states.device)
+                query_states = torch.empty(bsz, q_len, hidden_size, dtype=hidden_states.dtype,
+                                           device=hidden_states.device)
+                key_states = torch.empty(bsz, q_len, hidden_size, dtype=hidden_states.dtype,
+                                         device=hidden_states.device)
+                value_states = torch.empty(bsz, q_len, hidden_size, dtype=hidden_states.dtype,
+                                           device=hidden_states.device)
                 torch.ops.torch_ipex.mm_qkv_out(
                     hidden_states, self.qkv_proj_weight, None,
                     query_states, key_states, value_states

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -312,3 +312,19 @@ def use_fused_layer_norm(x: torch.Tensor, training: bool):
             or x.numel() // x.size(-1) == 1
         )
     )
+
+
+def fp16_fusion_check(proj, x, training):
+    # only use fp16 fusion on PVC inference
+    if proj.qtype != ggml_tensor_qtype["fp16"]:
+        return False
+    if proj.weight_type != 2:
+        return False
+    if training:
+        return False
+    if x.requires_grad:
+        return False
+    device_type = get_xpu_device_type(x)
+    if device_type != "pvc":
+        return False
+    return True

--- a/python/llm/src/bigdl/llm/transformers/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/utils.py
@@ -166,8 +166,8 @@ def get_ipex_version():
 
 
 def get_xpu_device_type(x):
-    if x.device.type == "cpu":
-        return "cpu"
+    if x.device.type != "xpu":
+        return x.device.type
     name = torch.xpu.get_device_name(x.device.index)
     if name.startswith("Intel(R) Arc(TM) A"):
         return "arc"

--- a/python/llm/src/bigdl/llm/transformers/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/utils.py
@@ -166,6 +166,8 @@ def get_ipex_version():
 
 
 def get_xpu_device_type(x):
+    if x.device.type == "cpu":
+        return "cpu"
     name = torch.xpu.get_device_name(x.device.index)
     if name.startswith("Intel(R) Arc(TM) A"):
         return "arc"


### PR DESCRIPTION
## Description


### 1. Why the change?

To further accelerate fp16 performance on PVC.

### 2. User API changes

No change.

### 3. Summary of the change 

- add possible FP16 kernel fusion into llama

### 4. How to test?
- [x] Unit test
- [x] Local test on PVC with transformers==4.31.0, llama2-7b FP16 / INT4
- [x] Local test on PVC with transformers==4.31.0, llama2-13b FP16
- [x] Local test on PVC with transformers==4.36.0, llama2-7b FP16 / INT4
- [x] Local test on PVC with transformers==4.36.0, llama2-13b FP16

Performance verification is update here: https://github.com/analytics-zoo/nano/issues/890#issuecomment-1898496735
