### PR TITLE
Add trust_remote_code=True for run_optimize_model in run.py

### DIFF
--- a/python/llm/dev/benchmark/all-in-one/run.py
+++ b/python/llm/dev/benchmark/all-in-one/run.py
@@ -306,9 +306,10 @@ def run_optimize_model(repo_id,
         model = optimize_model(model, low_bit=low_bit)
         tokenizer = LlamaTokenizer.from_pretrained(model_path, trust_remote_code=True)
     else:
-        model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype='auto', low_cpu_mem_usage=True).eval()
+        model = AutoModelForCausalLM.from_pretrained(model_path, torch_dtype='auto', low_cpu_mem_usage=True,
+                                                     trust_remote_code=True).eval()
         model = optimize_model(model, low_bit=low_bit)
-        tokenizer = AutoTokenizer.from_pretrained(model_path)
+        tokenizer = AutoTokenizer.from_pretrained(model_path, trust_remote_code=True)
     end = time.perf_counter()
     print(">> loading of model costs {}s".format(end - st))
 


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->
Add `trust_remote_code=True` in `BigDL/python/llm/dev/benchmark/all-in-one/run.py` `AutoModelForCausalLM.from_pretrained` at [line 309](https://github.com/intel-analytics/BigDL/blob/main/python/llm/dev/benchmark/all-in-one/run.py#L309) and `AutoTokenizer.from_pretrained` at [line 311](https://github.com/intel-analytics/BigDL/blob/main/python/llm/dev/benchmark/all-in-one/run.py#L311C26-L311C26)