### PR TITLE
GGUF load memory optimization for Mixtral

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -202,7 +202,9 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
         is_linear, linear_args = is_linear_module(module)
         if is_linear and name not in modules_to_not_convert:
             # Check if the current key is not in the `modules_to_not_convert`
-            if not any(key in ".".join(current_key_name) for key in modules_to_not_convert):
+            if (not any(key in ".".join(current_key_name) for key in modules_to_not_convert) and
+                    module.weight.data.device.type != 'meta' and
+                    not isinstance(module, LowBitLinear)):
                 in_features, out_features, mp_group = linear_args
                 with init_empty_weights():
                     new_linear = None

--- a/python/llm/src/bigdl/llm/transformers/gguf/models/mistral.py
+++ b/python/llm/src/bigdl/llm/transformers/gguf/models/mistral.py
@@ -25,6 +25,7 @@ from ..gguf import GGUFFileLoader
 from bigdl.llm.ggml.quantize import ggml_tensor_qtype
 from bigdl.llm.transformers.convert import replace_with_low_bit_linear_for_module
 
+
 def load_gguf_mistral(loader: GGUFFileLoader, dtype: torch.dtype = torch.float,
                       low_bit='sym_int4'):
     config = loader.config
@@ -78,7 +79,7 @@ def load_gguf_mistral(loader: GGUFFileLoader, dtype: torch.dtype = torch.float,
         else:
             set_module_tensor_to_device(model, module_name, "cpu", tensor, dtype=dtype)
         model = replace_with_low_bit_linear_for_module(model, qtype=qtype, module_name=module_name)
-        
+
     tensor_loader = loader.tensor_loader
     tensor_loader.load_while_process(process_mistral)
 


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

This submission optimizes the memory of loading Mixtral gguf model through converting q4_0 to fp16 to int4 layer by layer.