### PR TITLE
add default device meta  when lcmu enabled

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -492,6 +492,7 @@ class _BaseAutoModelClass:
 
         if bigdl_lcmu_enabled:
             with ContextManagers(init_contexts):
+                kwargs["device"] = "meta"
                 model = model_class(config, *model_args, **kwargs)
         else:
             model = model_class(config, *model_args, **kwargs)


### PR DESCRIPTION
## Description

fix https://github.com/intel-analytics/BigDL/issues/9887

### 1. Why the change?

We find out the root cause is chatglm uses [skip_init](https://github.com/pytorch/pytorch/blob/main/torch/nn/utils/init.py#L51-L53) to initialize the model, but the device was default to cpu. The following steps to quantize the model regard the model as a weights initialized model and allocate buffers to linear layers. So finally, there are two set of linear weights for chatglm which contributes to the observation.
The reason why it's normal on linux is that linux platform seems to automatically release memory while windows won't do the same.
