### PR TITLE
LLM: separate arc ut

### DIFF
--- a/python/llm/test/inference_gpu/test_transformers_api.py
+++ b/python/llm/test/inference_gpu/test_transformers_api.py
@@ -24,8 +24,6 @@ from transformers import LlamaTokenizer, AutoTokenizer
 
 device = os.environ['DEVICE']
 print(f'Running on {device}')
-if device == 'xpu':
-    import intel_extension_for_pytorch as ipex
 
 @pytest.mark.parametrize('prompt, answer', [
     ('What is the capital of France?\n\n', 'Paris')
@@ -80,7 +78,6 @@ prompt = "Once upon a time, there existed a little girl who liked to have advent
 #     (AutoModelForCausalLM, AutoTokenizer, os.environ.get('LLAMA2_7B_ORIGIN_PATH'))
 #     ])
 # def test_optimize_model(Model, Tokenizer, model_path):
-#     os.environ['BIGDL_LLM_XMX_DISABLED'] = "1"
 #     with torch.inference_mode():
 #         tokenizer = Tokenizer.from_pretrained(model_path, trust_remote_code=True)
 #         input_ids = tokenizer.encode(prompt, return_tensors="pt").to(device)
@@ -106,7 +103,6 @@ prompt = "Once upon a time, there existed a little girl who liked to have advent
 #             .flatten().tolist().count(False)
 #         percent_false = num_false / logits_optimized_model.numel()
 #         assert percent_false < 1e-02
-#     del os.environ['BIGDL_LLM_XMX_DISABLED']
 
 class Test_Optimize_Gpu_Model:
     def setup(self):

--- a/python/llm/test/inference_gpu/test_transformers_api.py
+++ b/python/llm/test/inference_gpu/test_transformers_api.py
@@ -75,6 +75,38 @@ def test_transformers_auto_model_for_speech_seq2seq_int4():
 
 prompt = "Once upon a time, there existed a little girl who liked to have adventures. She wanted to go to places and meet new people, and have fun"
 
+# @pytest.mark.parametrize('Model, Tokenizer, model_path',[
+#     (AutoModelForCausalLM, AutoTokenizer, os.environ.get('MPT_7B_ORIGIN_PATH')),
+#     (AutoModelForCausalLM, AutoTokenizer, os.environ.get('LLAMA2_7B_ORIGIN_PATH'))
+#     ])
+# def test_optimize_model(Model, Tokenizer, model_path):
+#     os.environ['BIGDL_LLM_XMX_DISABLED'] = "1"
+#     with torch.inference_mode():
+#         tokenizer = Tokenizer.from_pretrained(model_path, trust_remote_code=True)
+#         input_ids = tokenizer.encode(prompt, return_tensors="pt").to(device)
+
+#         model = Model.from_pretrained(model_path,
+#                                     load_in_4bit=True,
+#                                     optimize_model=False,
+#                                     trust_remote_code=True)
+#         model = model.to(device)
+#         logits_base_model = (model(input_ids)).logits
+#         model.to('cpu')  # deallocate gpu memory
+
+#         model = Model.from_pretrained(model_path,
+#                                     load_in_4bit=True,
+#                                     optimize_model=True,
+#                                     trust_remote_code=True)
+#         model = model.to(device)
+#         logits_optimized_model = (model(input_ids)).logits
+#         model.to('cpu')
+
+#         tol = 1e-02
+#         num_false = torch.isclose(logits_optimized_model, logits_base_model, rtol=tol, atol=tol)\
+#             .flatten().tolist().count(False)
+#         percent_false = num_false / logits_optimized_model.numel()
+#         assert percent_false < 1e-02
+#     del os.environ['BIGDL_LLM_XMX_DISABLED']
 
 class Test_Optimize_Gpu_Model:
     def setup(self):

--- a/python/llm/test/inference_gpu/test_transformers_api.py
+++ b/python/llm/test/inference_gpu/test_transformers_api.py
@@ -75,38 +75,6 @@ def test_transformers_auto_model_for_speech_seq2seq_int4():
 
 prompt = "Once upon a time, there existed a little girl who liked to have adventures. She wanted to go to places and meet new people, and have fun"
 
-@pytest.mark.parametrize('Model, Tokenizer, model_path',[
-    (AutoModelForCausalLM, AutoTokenizer, os.environ.get('MPT_7B_ORIGIN_PATH')),
-    (AutoModelForCausalLM, AutoTokenizer, os.environ.get('LLAMA2_7B_ORIGIN_PATH'))
-    ])
-def test_optimize_model(Model, Tokenizer, model_path):
-    os.environ['BIGDL_LLM_XMX_DISABLED'] = "1"
-    with torch.inference_mode():
-        tokenizer = Tokenizer.from_pretrained(model_path, trust_remote_code=True)
-        input_ids = tokenizer.encode(prompt, return_tensors="pt").to(device)
-
-        model = Model.from_pretrained(model_path,
-                                    load_in_4bit=True,
-                                    optimize_model=False,
-                                    trust_remote_code=True)
-        model = model.to(device)
-        logits_base_model = (model(input_ids)).logits
-        model.to('cpu')  # deallocate gpu memory
-
-        model = Model.from_pretrained(model_path,
-                                    load_in_4bit=True,
-                                    optimize_model=True,
-                                    trust_remote_code=True)
-        model = model.to(device)
-        logits_optimized_model = (model(input_ids)).logits
-        model.to('cpu')
-
-        tol = 1e-02
-        num_false = torch.isclose(logits_optimized_model, logits_base_model, rtol=tol, atol=tol)\
-            .flatten().tolist().count(False)
-        percent_false = num_false / logits_optimized_model.numel()
-        assert percent_false < 1e-02
-    del os.environ['BIGDL_LLM_XMX_DISABLED']
 
 class Test_Optimize_Gpu_Model:
     def setup(self):

--- a/python/llm/test/inference_gpu/test_transformers_api_disable_xmx.py
+++ b/python/llm/test/inference_gpu/test_transformers_api_disable_xmx.py
@@ -11,7 +11,6 @@ prompt = "Once upon a time, there existed a little girl who liked to have advent
     (AutoModelForCausalLM, AutoTokenizer, os.environ.get('LLAMA2_7B_ORIGIN_PATH'))
     ])
 def test_optimize_model(Model, Tokenizer, model_path):
-    os.environ['BIGDL_LLM_XMX_DISABLED'] = "1"
     with torch.inference_mode():
         tokenizer = Tokenizer.from_pretrained(model_path, trust_remote_code=True)
         input_ids = tokenizer.encode(prompt, return_tensors="pt").to(device)
@@ -37,4 +36,4 @@ def test_optimize_model(Model, Tokenizer, model_path):
             .flatten().tolist().count(False)
         percent_false = num_false / logits_optimized_model.numel()
         assert percent_false < 1e-02
-    del os.environ['BIGDL_LLM_XMX_DISABLED']
+    

--- a/python/llm/test/inference_gpu/test_transformers_api_disable_xmx.py
+++ b/python/llm/test/inference_gpu/test_transformers_api_disable_xmx.py
@@ -1,0 +1,40 @@
+import os
+import pytest
+import torch
+from bigdl.llm.transformers import AutoModelForCausalLM
+from transformers import AutoTokenizer
+
+prompt = "Once upon a time, there existed a little girl who liked to have adventures. She wanted to go to places and meet new people, and have fun"
+
+@pytest.mark.parametrize('Model, Tokenizer, model_path',[
+    (AutoModelForCausalLM, AutoTokenizer, os.environ.get('MPT_7B_ORIGIN_PATH')),
+    (AutoModelForCausalLM, AutoTokenizer, os.environ.get('LLAMA2_7B_ORIGIN_PATH'))
+    ])
+def test_optimize_model(Model, Tokenizer, model_path):
+    os.environ['BIGDL_LLM_XMX_DISABLED'] = "1"
+    with torch.inference_mode():
+        tokenizer = Tokenizer.from_pretrained(model_path, trust_remote_code=True)
+        input_ids = tokenizer.encode(prompt, return_tensors="pt").to(device)
+
+        model = Model.from_pretrained(model_path,
+                                    load_in_4bit=True,
+                                    optimize_model=False,
+                                    trust_remote_code=True)
+        model = model.to(device)
+        logits_base_model = (model(input_ids)).logits
+        model.to('cpu')  # deallocate gpu memory
+
+        model = Model.from_pretrained(model_path,
+                                    load_in_4bit=True,
+                                    optimize_model=True,
+                                    trust_remote_code=True)
+        model = model.to(device)
+        logits_optimized_model = (model(input_ids)).logits
+        model.to('cpu')
+
+        tol = 1e-02
+        num_false = torch.isclose(logits_optimized_model, logits_base_model, rtol=tol, atol=tol)\
+            .flatten().tolist().count(False)
+        percent_false = num_false / logits_optimized_model.numel()
+        assert percent_false < 1e-02
+    del os.environ['BIGDL_LLM_XMX_DISABLED']

--- a/python/llm/test/inference_gpu/test_transformers_api_disable_xmx.py
+++ b/python/llm/test/inference_gpu/test_transformers_api_disable_xmx.py
@@ -1,8 +1,27 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import os
 import pytest
 import torch
 from bigdl.llm.transformers import AutoModelForCausalLM
 from transformers import AutoTokenizer
+
+device = os.environ['DEVICE']
+print(f'Running on {device}')
 
 prompt = "Once upon a time, there existed a little girl who liked to have adventures. She wanted to go to places and meet new people, and have fun"
 

--- a/python/llm/test/inference_gpu/test_transformers_api_disable_xmx.py
+++ b/python/llm/test/inference_gpu/test_transformers_api_disable_xmx.py
@@ -50,7 +50,7 @@ def test_optimize_model(Model, Tokenizer, model_path):
         logits_optimized_model = (model(input_ids)).logits
         model.to('cpu')
 
-        tol = 1e-02
+        tol = 1e-03
         num_false = torch.isclose(logits_optimized_model, logits_base_model, rtol=tol, atol=tol)\
             .flatten().tolist().count(False)
         percent_false = num_false / logits_optimized_model.numel()

--- a/python/llm/test/run-llm-inference-tests-gpu.sh
+++ b/python/llm/test/run-llm-inference-tests-gpu.sh
@@ -18,6 +18,7 @@ if [ -z "$THREAD_NUM" ]; then
 fi
 export OMP_NUM_THREADS=$THREAD_NUM
 pytest ${LLM_INFERENCE_TEST_DIR}/test_transformers_api.py -v -s
+pytest ${LLM_INFERENCE_TEST_DIR}/test_transformers_api_disable_xmx.py -v -s
 
 now=$(date "+%s")
 time=$((now-start))

--- a/python/llm/test/run-llm-inference-tests-gpu.sh
+++ b/python/llm/test/run-llm-inference-tests-gpu.sh
@@ -18,7 +18,9 @@ if [ -z "$THREAD_NUM" ]; then
 fi
 export OMP_NUM_THREADS=$THREAD_NUM
 pytest ${LLM_INFERENCE_TEST_DIR}/test_transformers_api.py -v -s
+export BIGDL_LLM_XMX_DISABLED=1
 pytest ${LLM_INFERENCE_TEST_DIR}/test_transformers_api_disable_xmx.py -v -s
+export BIGDL_LLM_XMX_DISABLED=0
 
 now=$(date "+%s")
 time=$((now-start))

--- a/python/llm/test/run-llm-inference-tests-gpu.sh
+++ b/python/llm/test/run-llm-inference-tests-gpu.sh
@@ -20,7 +20,7 @@ export OMP_NUM_THREADS=$THREAD_NUM
 pytest ${LLM_INFERENCE_TEST_DIR}/test_transformers_api.py -v -s
 export BIGDL_LLM_XMX_DISABLED=1
 pytest ${LLM_INFERENCE_TEST_DIR}/test_transformers_api_disable_xmx.py -v -s
-export BIGDL_LLM_XMX_DISABLED=0
+unset BIGDL_LLM_XMX_DISABLED
 
 now=$(date "+%s")
 time=$((now-start))


### PR DESCRIPTION
Continue from: https://github.com/intel-analytics/BigDL/pull/9935

The testing api `test_optimize_model` always returns `True` in current practices, so we might update this, and since the new version might encounter some errors related to xmx, we need to separate the tests to run them with different `BIGDL_LLM_XMX_DISABLED`