### PR TITLE
LLM: Convert draft_model kv_cache from bf16 to fp32

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/speculative.py
+++ b/python/llm/src/bigdl/llm/transformers/speculative.py
@@ -370,30 +370,30 @@ def speculative_generate(self,
                          v[:, :, :-(max_of_max_matched - max_matched)]) for k, v in past_key_values
                     ]
 
-                # Each iter assign new_matched kv_cache to past_key_values1
-                if self.device.type == 'cpu':
-                    for i in range(len(past_key_values)):
-                        if self.config.model_type == "qwen":
-                            size = tmp_past_key_values[i][0].size(1)
-                            size1 = past_key_values[i][0].size(1)
-                            past_key_values1[i][0][:, size:size1, :, :] = (
-                                past_key_values[i][0][:, size:size1, :, :].to(torch.float32))
-                            past_key_values1[i][1][:, size:size1, :, :] = (
-                                past_key_values[i][1][:, size:size1, :, :].to(torch.float32))
-                        elif self.config.model_type == "chatglm":
-                            size = tmp_past_key_values[i][0].size(0)
-                            size1 = past_key_values[i][0].size(0)
-                            past_key_values1[i][0][size:size1, :, :, :] = (
-                                past_key_values[i][0][size:size1, :, :].to(torch.float32))
-                            past_key_values1[i][1][size:size1, :, :, :] = (
-                                past_key_values[i][1][size:size1, :, :].to(torch.float32))
-                        else:
-                            size = tmp_past_key_values[i][0].size(2)
-                            size1 = past_key_values[i][0].size(2)
-                            past_key_values1[i][0][:, :, size:size1, :] = (
-                                past_key_values[i][0][:, :, size:size1, :].to(torch.float32))
-                            past_key_values1[i][1][:, :, size:size1, :] = (
-                                past_key_values[i][1][:, :, size:size1, :].to(torch.float32))
+            # Each iter assign new_matched kv_cache to past_key_values1
+            if self.device.type == 'cpu':
+                for i in range(len(past_key_values)):
+                    if self.config.model_type == "qwen":
+                        size = tmp_past_key_values[i][0].size(1)
+                        size1 = past_key_values[i][0].size(1)
+                        past_key_values1[i][0][:, size:size1, :, :] = \
+                            past_key_values[i][0][:, size:size1, :, :].to(torch.float32)
+                        past_key_values1[i][1][:, size:size1, :, :] = \
+                            past_key_values[i][1][:, size:size1, :, :].to(torch.float32)
+                    elif self.config.model_type == "chatglm":
+                        size = tmp_past_key_values[i][0].size(0)
+                        size1 = past_key_values[i][0].size(0)
+                        past_key_values1[i][0][size:size1, :, :, :] = \
+                            past_key_values[i][0][size:size1, :, :, :].to(torch.float32)
+                        past_key_values1[i][1][size:size1, :, :, :] = \
+                            past_key_values[i][1][size:size1, :, :, :].to(torch.float32)
+                    else:
+                        size = tmp_past_key_values[i][0].size(2)
+                        size1 = past_key_values[i][0].size(2)
+                        past_key_values1[i][0][:, :, size:size1, :] = \
+                            past_key_values[i][0][:, :, size:size1, :].to(torch.float32)
+                        past_key_values1[i][1][:, :, size:size1, :] = \
+                            past_key_values[i][1][:, :, size:size1, :].to(torch.float32)
 
             generate_ids[:, step:step+output_ids.size(1)] = output_ids
             current_input_ids = output_ids[:, -1:]

--- a/python/llm/src/bigdl/llm/transformers/speculative.py
+++ b/python/llm/src/bigdl/llm/transformers/speculative.py
@@ -190,11 +190,6 @@ def speculative_generate(self,
         else:
             draft_current_input_ids = current_input_ids
             # Target model KV cache to draft model
-            # if self.device.type == 'cpu' and step == 1:
-            #     past_key_values = [
-            #         (k.to(torch.float32), v.to(torch.float32)) for k, v in past_key_values
-            #     ]
-            # draft_past_key_values = past_key_values
 
             # init draft_self_past_key_values:past_key_values1 and assign initial fp32 value
             if self.device.type == 'cpu' and step == 1:
@@ -381,18 +376,24 @@ def speculative_generate(self,
                         if self.config.model_type == "qwen":
                             size = tmp_past_key_values[i][0].size(1)
                             size1 = past_key_values[i][0].size(1)
-                            past_key_values1[i][0][:, size:size1, :, :] = past_key_values[i][0][:, size:size1, :, :].to(torch.float32)
-                            past_key_values1[i][1][:, size:size1, :, :] = past_key_values[i][1][:, size:size1, :, :].to(torch.float32)
+                            past_key_values1[i][0][:, size:size1, :, :] = (
+                                past_key_values[i][0][:, size:size1, :, :].to(torch.float32))
+                            past_key_values1[i][1][:, size:size1, :, :] = (
+                                past_key_values[i][1][:, size:size1, :, :].to(torch.float32))
                         elif self.config.model_type == "chatglm":
                             size = tmp_past_key_values[i][0].size(0)
                             size1 = past_key_values[i][0].size(0)
-                            past_key_values1[i][0][size:size1, :, :, :] = past_key_values[i][0][size:size1,:, :].to(torch.float32)
-                            past_key_values1[i][1][size:size1, :, :, :] = past_key_values[i][1][size:size1,:, :].to(torch.float32)
+                            past_key_values1[i][0][size:size1, :, :, :] = (
+                                past_key_values[i][0][ size:size1, :, :].to(torch.float32))
+                            past_key_values1[i][1][size:size1, :, :, :] = (
+                                past_key_values[i][1][size:size1, :, :].to(torch.float32))
                         else:
                             size = tmp_past_key_values[i][0].size(2)
                             size1 = past_key_values[i][0].size(2)
-                            past_key_values1[i][0][:,:, size:size1, :] = past_key_values[i][0][:,:,size:size1,:].to(torch.float32)
-                            past_key_values1[i][1][:,:, size:size1, :] = past_key_values[i][1][:,:,size:size1,:].to(torch.float32)
+                            past_key_values1[i][0][:, :, size:size1, :] = (
+                                past_key_values[i][0][:, :, size:size1, :].to(torch.float32))
+                            past_key_values1[i][1][:, :, size:size1, :] = (
+                                past_key_values[i][1][:, :, size:size1, :].to(torch.float32))
 
             generate_ids[:, step:step+output_ids.size(1)] = output_ids
             current_input_ids = output_ids[:, -1:]

--- a/python/llm/src/bigdl/llm/transformers/speculative.py
+++ b/python/llm/src/bigdl/llm/transformers/speculative.py
@@ -234,8 +234,8 @@ def speculative_generate(self,
                             torch.float32)
 
             # each iter cut off cur_len kv_cache from past_key_values1
-            tmp_past_key_values = []
             if self.device.type == 'cpu':
+                tmp_past_key_values = []
                 for i in range(len(past_key_values)):
                     if self.config.model_type == "qwen":
                         len1 = past_key_values[0][0].size(1)

--- a/python/llm/src/bigdl/llm/transformers/speculative.py
+++ b/python/llm/src/bigdl/llm/transformers/speculative.py
@@ -384,7 +384,7 @@ def speculative_generate(self,
                             size = tmp_past_key_values[i][0].size(0)
                             size1 = past_key_values[i][0].size(0)
                             past_key_values1[i][0][size:size1, :, :, :] = (
-                                past_key_values[i][0][ size:size1, :, :].to(torch.float32))
+                                past_key_values[i][0][size:size1, :, :].to(torch.float32))
                             past_key_values1[i][1][size:size1, :, :, :] = (
                                 past_key_values[i][1][size:size1, :, :].to(torch.float32))
                         else:

--- a/python/llm/src/bigdl/llm/transformers/speculative.py
+++ b/python/llm/src/bigdl/llm/transformers/speculative.py
@@ -138,6 +138,7 @@ def speculative_generate(self,
     draft_generate_ids = torch.empty([input_ids.size(0), draft_gen_length],
                                      dtype=torch.long, device=self.device)
     past_key_values = None
+    past_key_values1 = []
 
     tmp_matchness = 0
     e2e_tic = 0.0
@@ -189,11 +190,70 @@ def speculative_generate(self,
         else:
             draft_current_input_ids = current_input_ids
             # Target model KV cache to draft model
+            # if self.device.type == 'cpu' and step == 1:
+            #     past_key_values = [
+            #         (k.to(torch.float32), v.to(torch.float32)) for k, v in past_key_values
+            #     ]
+            # draft_past_key_values = past_key_values
+
+            # init draft_self_past_key_values:past_key_values1 and assign initial fp32 value
             if self.device.type == 'cpu' and step == 1:
-                past_key_values = [
-                    (k.to(torch.float32), v.to(torch.float32)) for k, v in past_key_values
-                ]
-            draft_past_key_values = past_key_values
+                for i in range(len(past_key_values)):
+                    len0 = past_key_values[i][0].size(0)
+                    len1 = past_key_values[i][0].size(1)
+                    len2 = past_key_values[i][0].size(2)
+                    len3 = past_key_values[i][0].size(3)
+                    if self.config.model_type == "qwen":
+                        k0 = torch.ones(len0, len1 + max_new_tokens, len2, len3,
+                                        dtype=torch.float32)
+                        v0 = torch.ones(len0, len1 + max_new_tokens, len2, len3,
+                                        dtype=torch.float32)
+                        past_key_values1.append((k0, v0))
+                        past_key_values1[i][0][:, :len1, :, :] = past_key_values[i][0].to(
+                            torch.float32)
+                        past_key_values1[i][1][:, :len1, :, :] = past_key_values[i][1].to(
+                            torch.float32)
+                    elif self.config.model_type == "chatglm":
+                        k0 = torch.ones(len0 + max_new_tokens, len1, len2, len3,
+                                        dtype=torch.float32)
+                        v0 = torch.ones(len0 + max_new_tokens, len1, len2, len3,
+                                        dtype=torch.float32)
+                        past_key_values1.append((k0, v0))
+                        past_key_values1[i][0][:len0, :, :, :] = past_key_values[i][0].to(
+                            torch.float32)
+                        past_key_values1[i][1][:len0, :, :, :] = past_key_values[i][1].to(
+                            torch.float32)
+                    else:
+                        k0 = torch.ones(len0, len1, len2 + max_new_tokens, len3,
+                                        dtype=torch.float32)
+                        v0 = torch.ones(len0, len1, len2 + max_new_tokens, len3,
+                                        dtype=torch.float32)
+                        past_key_values1.append((k0, v0))
+                        past_key_values1[i][0][:, :, :len2, :] = past_key_values[i][0].to(
+                            torch.float32)
+                        past_key_values1[i][1][:, :, :len2, :] = past_key_values[i][1].to(
+                            torch.float32)
+
+            # each iter cut off cur_len kv_cache from past_key_values1
+            tmp_past_key_values = []
+            if self.device.type == 'cpu':
+                for i in range(len(past_key_values)):
+                    if self.config.model_type == "qwen":
+                        len1 = past_key_values[0][0].size(1)
+                        k0 = past_key_values1[i][0][:, :len1, :, :]
+                        v0 = past_key_values1[i][1][:, :len1, :, :]
+                        tmp_past_key_values.append((k0, v0))
+                    elif self.config.model_type == "chatglm":
+                        len0 = past_key_values[0][0].size(0)
+                        k0 = past_key_values1[i][0][:len0, :, :, :]
+                        v0 = past_key_values1[i][1][:len0, :, :, :]
+                        tmp_past_key_values.append((k0, v0))
+                    else:
+                        len2 = past_key_values[0][0].size(2)
+                        k0 = past_key_values1[i][0][:, :, :len2, :]
+                        v0 = past_key_values1[i][1][:, :, :len2, :]
+                        tmp_past_key_values.append((k0, v0))
+            draft_past_key_values = tmp_past_key_values
             draft_generate_ids[:, 0] = current_input_ids
             tic = time.time()
             # Draft model auto-regressively generate k tokens
@@ -310,6 +370,25 @@ def speculative_generate(self,
                         (k[:, :, :-(max_of_max_matched - max_matched)],
                          v[:, :, :-(max_of_max_matched - max_matched)]) for k, v in past_key_values
                     ]
+
+                # Each iter assign new_matched kv_cache to past_key_values1
+                if self.device.type == 'cpu':
+                    for i in range(len(past_key_values)):
+                        if self.config.model_type == "qwen":
+                            size = tmp_past_key_values[i][0].size(1)
+                            size1 = past_key_values[i][0].size(1)
+                            past_key_values1[i][0][:, size:size1, :, :] = past_key_values[i][0][:, size:size1, :, :].to(torch.float32)
+                            past_key_values1[i][1][:, size:size1, :, :] = past_key_values[i][1][:, size:size1, :, :].to(torch.float32)
+                        elif self.config.model_type == "chatglm":
+                            size = tmp_past_key_values[i][0].size(0)
+                            size1 = past_key_values[i][0].size(0)
+                            past_key_values1[i][0][size:size1, :, :, :] = past_key_values[i][0][size:size1,:, :].to(torch.float32)
+                            past_key_values1[i][1][size:size1, :, :, :] = past_key_values[i][1][size:size1,:, :].to(torch.float32)
+                        else:
+                            size = tmp_past_key_values[i][0].size(2)
+                            size1 = past_key_values[i][0].size(2)
+                            past_key_values1[i][0][:,:, size:size1, :] = past_key_values[i][0][:,:,size:size1,:].to(torch.float32)
+                            past_key_values1[i][1][:,:, size:size1, :] = past_key_values[i][1][:,:,size:size1,:].to(torch.float32)
 
             generate_ids[:, step:step+output_ids.size(1)] = output_ids
             current_input_ids = output_ids[:, -1:]

--- a/python/llm/src/bigdl/llm/transformers/speculative.py
+++ b/python/llm/src/bigdl/llm/transformers/speculative.py
@@ -204,20 +204,24 @@ def speculative_generate(self,
                     len2 = past_key_values[i][0].size(2)
                     len3 = past_key_values[i][0].size(3)
                     if self.config.model_type == "qwen":
-                        k0 = torch.ones(len0, len1 + max_new_tokens, len2, len3,
+                        k0 = torch.ones(len0, len2, len1 + max_new_tokens, len3,
                                         dtype=torch.float32)
-                        v0 = torch.ones(len0, len1 + max_new_tokens, len2, len3,
+                        v0 = torch.ones(len0, len2, len1 + max_new_tokens, len3,
                                         dtype=torch.float32)
+                        k0 = k0.transpose(1, 2)
+                        v0 = v0.transpose(1, 2)
                         past_key_values1.append((k0, v0))
                         past_key_values1[i][0][:, :len1, :, :] = past_key_values[i][0].to(
                             torch.float32)
                         past_key_values1[i][1][:, :len1, :, :] = past_key_values[i][1].to(
                             torch.float32)
                     elif self.config.model_type == "chatglm":
-                        k0 = torch.ones(len0 + max_new_tokens, len1, len2, len3,
+                        k0 = torch.ones(len1, len2, len0 + max_new_tokens, len3,
                                         dtype=torch.float32)
-                        v0 = torch.ones(len0 + max_new_tokens, len1, len2, len3,
+                        v0 = torch.ones(len1, len2, len0 + max_new_tokens, len3,
                                         dtype=torch.float32)
+                        k0 = k0.permute(2, 0, 1, 3)
+                        v0 = v0.permute(2, 0, 1, 3)
                         past_key_values1.append((k0, v0))
                         past_key_values1[i][0][:len0, :, :, :] = past_key_values[i][0].to(
                             torch.float32)

--- a/python/llm/src/bigdl/llm/transformers/speculative.py
+++ b/python/llm/src/bigdl/llm/transformers/speculative.py
@@ -252,7 +252,9 @@ def speculative_generate(self,
                         k0 = past_key_values1[i][0][:, :, :len2, :]
                         v0 = past_key_values1[i][1][:, :, :len2, :]
                         tmp_past_key_values.append((k0, v0))
-            draft_past_key_values = tmp_past_key_values
+                draft_past_key_values = tmp_past_key_values
+            else:
+                draft_past_key_values = past_key_values
             draft_generate_ids[:, 0] = current_input_ids
             tic = time.time()
             # Draft model auto-regressively generate k tokens

--- a/python/llm/src/bigdl/llm/transformers/speculative.py
+++ b/python/llm/src/bigdl/llm/transformers/speculative.py
@@ -189,16 +189,16 @@ def speculative_generate(self,
         else:
             draft_current_input_ids = current_input_ids
             # Target model KV cache to draft model
+            if self.device.type == 'cpu' and step == 1:
+                past_key_values = [
+                    (k.to(torch.float32), v.to(torch.float32)) for k, v in past_key_values
+                ]
             draft_past_key_values = past_key_values
             draft_generate_ids[:, 0] = current_input_ids
             tic = time.time()
             # Draft model auto-regressively generate k tokens
             # Early stop when prob less then th_stop_draft
             for step_draft in range(max_step_draft):
-                if self.device.type == 'cpu' and step_draft == 0:
-                    past_key_values = [
-                        (k.to(torch.float32), v.to(torch.float32)) for k, v in past_key_values
-                    ]
                 if self.config.model_type == "chatglm":
                     past_key_value_len = past_key_values[0][0].shape[0]
                     position_ids = torch.Tensor([[past_key_value_len + step_draft]]).long()

--- a/python/llm/src/bigdl/llm/transformers/speculative.py
+++ b/python/llm/src/bigdl/llm/transformers/speculative.py
@@ -195,7 +195,7 @@ def speculative_generate(self,
             # Draft model auto-regressively generate k tokens
             # Early stop when prob less then th_stop_draft
             for step_draft in range(max_step_draft):
-                if self.device.type == 'cpu':
+                if self.device.type == 'cpu' and step_draft == 0:
                     past_key_values = [
                         (k.to(torch.float32), v.to(torch.float32)) for k, v in past_key_values
                     ]

--- a/python/llm/src/bigdl/llm/transformers/speculative.py
+++ b/python/llm/src/bigdl/llm/transformers/speculative.py
@@ -195,6 +195,10 @@ def speculative_generate(self,
             # Draft model auto-regressively generate k tokens
             # Early stop when prob less then th_stop_draft
             for step_draft in range(max_step_draft):
+                if self.device.type == 'cpu':
+                    past_key_values = [
+                        (k.to(torch.float32), v.to(torch.float32)) for k, v in past_key_values
+                    ]
                 if self.config.model_type == "chatglm":
                     past_key_value_len = past_key_values[0][0].shape[0]
                     position_ids = torch.Tensor([[past_key_value_len + step_draft]]).long()


### PR DESCRIPTION
## Description
To solve the issue of draft_model slower, maybe We have three ways to test.
1. Convert draft_model kv_cache from bf16 to fp32 (every iter, when draft_step== 0, draft_model generate time will become  slower causing the average draft_time more slower)
2. (This way) Convert the same kv_cache from bf16 to fp32(only first init), and then the target_model will use fp32 and generate fp32 cache. (The speed of qwen's target_model has not changed, but llama has become slower)
3. Draft_model maintains kv_cache itself, and append new matched kv_cache (Maybe the accept rate will become lower，need to test)
On way1 and way3, the draft_time on step == 0 always more slower than normal_time (need to find the reason)

The reason is the draft_kv_cache convert from bf16 (malloc new memory) will call extend_kv_cache when  draft_step== 0, So we can init the needed kv_cache and reuse it each iter.

With the same chinest promt:
spr01 | Llama-2-13b-chat-hf | chatglm3-6b| Qwen-14B
-- | -- | -- | -- |
before draft_time | 74.752 | 34.252 | 61.053
before target_time | 200.961 | 101.003| 186.477
after draft_time | 64.221 | 29.139 | 53.270
after target_time | 201.692 | 102.653| 188.057 |



<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
