### PR TITLE
fix unexpected keyword argument 'device' 

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -507,6 +507,11 @@ class _BaseAutoModelClass:
             with ContextManagers(init_contexts):
                 if config.architectures is not None \
                     and config.architectures[0] in ["ChatGLMModel", "ChatGLMForConditionalGeneration"]:
+                    """
+                    ChatGLMModel uses skip_init by default, which will force modules placed on cpu 
+                    if the device is not specified. This will further cause replaced linear allocating
+                    memory on cpu.
+                    """ 
                     kwargs["device"] = "meta"
                 model = model_class(config, *model_args, **kwargs)
         else:

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -506,7 +506,7 @@ class _BaseAutoModelClass:
         if bigdl_lcmu_enabled:
             with ContextManagers(init_contexts):
                 if config.architectures is not None and config.architectures[0] in \
-                  ["ChatGLMModel", "ChatGLMForConditionalGeneration"]:
+                   ["ChatGLMModel", "ChatGLMForConditionalGeneration"]:
 
                     """
                     ChatGLMModel uses skip_init by default, which will force modules placed on cpu

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -506,11 +506,11 @@ class _BaseAutoModelClass:
         if bigdl_lcmu_enabled:
             with ContextManagers(init_contexts):
                 if config.architectures is not None and config.architectures[0] in \
-                    ["ChatGLMModel", "ChatGLMForConditionalGeneration"]:
+                ["ChatGLMModel", "ChatGLMForConditionalGeneration"]:
                     """
                     ChatGLMModel uses skip_init by default, which will force modules placed on cpu
-                    if the device is not specified. This will further cause replaced linear allocating
-                    memory on cpu.
+                    if the device is not specified. This will further cause replaced linear 
+                    allocating memory on cpu.
                     """
                     kwargs["device"] = "meta"
                 model = model_class(config, *model_args, **kwargs)

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -505,7 +505,9 @@ class _BaseAutoModelClass:
 
         if bigdl_lcmu_enabled:
             with ContextManagers(init_contexts):
-                kwargs["device"] = "meta"
+                if config.architectures is not None \
+                    and config.architectures[0] in ["ChatGLMModel", "ChatGLMForConditionalGeneration"]:
+                    kwargs["device"] = "meta"
                 model = model_class(config, *model_args, **kwargs)
         else:
             model = model_class(config, *model_args, **kwargs)

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -506,10 +506,11 @@ class _BaseAutoModelClass:
         if bigdl_lcmu_enabled:
             with ContextManagers(init_contexts):
                 if config.architectures is not None and config.architectures[0] in \
-                ["ChatGLMModel", "ChatGLMForConditionalGeneration"]:
+                  ["ChatGLMModel", "ChatGLMForConditionalGeneration"]:
+
                     """
                     ChatGLMModel uses skip_init by default, which will force modules placed on cpu
-                    if the device is not specified. This will further cause replaced linear 
+                    if the device is not specified. This will further cause replaced linear
                     allocating memory on cpu.
                     """
                     kwargs["device"] = "meta"

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -505,13 +505,13 @@ class _BaseAutoModelClass:
 
         if bigdl_lcmu_enabled:
             with ContextManagers(init_contexts):
-                if config.architectures is not None \
-                    and config.architectures[0] in ["ChatGLMModel", "ChatGLMForConditionalGeneration"]:
+                if config.architectures is not None and config.architectures[0] in \
+                    ["ChatGLMModel", "ChatGLMForConditionalGeneration"]:
                     """
-                    ChatGLMModel uses skip_init by default, which will force modules placed on cpu 
+                    ChatGLMModel uses skip_init by default, which will force modules placed on cpu
                     if the device is not specified. This will further cause replaced linear allocating
                     memory on cpu.
-                    """ 
+                    """
                     kwargs["device"] = "meta"
                 model = model_class(config, *model_args, **kwargs)
         else:


### PR DESCRIPTION
## Description

Fix nightly test failure
[](https://github.com/intel-analytics/BigDL/actions/runs/7626141255/job/20793066834)

This is caused by fixing chatglm3 #9941 , we added `device="meta"` to model init funtion while other models may not accept this argument. So here, I added an if sentence to make it work only for chatglm.
### 1. Why the change?
Fix nightly test failure
[](https://github.com/intel-analytics/BigDL/actions/runs/7626141255/job/20793066834)
