### PR TITLE
fix optimize_model not working in harness tests

### DIFF
--- a/python/llm/dev/benchmark/harness/bigdl_llm.py
+++ b/python/llm/dev/benchmark/harness/bigdl_llm.py
@@ -47,8 +47,8 @@ class BigDLLM(AutoCausalLM):
             if k not in self.AutoCausalLM_ARGS:
                 self.bigdl_llm_kwargs[k] = kwargs.pop(k)
 
-        self.bigdl_llm_kwargs['use_cache'] = kwargs.get('use_cache', True)
-        self.bigdl_llm_kwargs['optimize_model'] = kwargs.get('optimize_model', True)
+        self.bigdl_llm_kwargs['use_cache'] = self.bigdl_llm_kwargs.get('use_cache', True)
+        self.bigdl_llm_kwargs['optimize_model'] = self.bigdl_llm_kwargs.get('optimize_model', True)
         AutoModelForCausalLM.from_pretrained = partial(AutoModelForCausalLM.from_pretrained, **self.bigdl_llm_kwargs)
         
         kwargs['trust_remote_code'] = kwargs.get('trust_remote_code', True)


### PR DESCRIPTION
## Description

It was designed to use `--model_args optimize_model=False` to disable `optmize_model` in BigDL and harness tests.  
Current code cannot make it take effect because this argument was popped out before fetching from `kwargs`.
