### PR TITLE
LLM : Fix llama draft_model dtype error

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -247,6 +247,7 @@ class _BaseAutoModelClass:
 
             if speculative:
                 from .speculative import speculative_generate, clear_benchmarks
+                
                 # load a sym_int4 model as draft model
                 draft_model = cls.load_convert('sym_int4', optimize_model, *args, **kwargs)
                 model.draft_model = draft_model

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -247,7 +247,6 @@ class _BaseAutoModelClass:
 
             if speculative:
                 from .speculative import speculative_generate, clear_benchmarks
-                
                 # load a sym_int4 model as draft model
                 draft_model = cls.load_convert('sym_int4', optimize_model, *args, **kwargs)
                 model.draft_model = draft_model

--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -729,7 +729,7 @@ def llama_attention_forward_4_36(
 
 def native_sdp(query, key, value, attention_mask,
                bsz, q_len, kv_seq_len, head_dim, num_heads):
-    attn_weights = torch.matmul(query,
+    attn_weights = torch.matmul(query.to(key.dtype),
                                 key.transpose(2, 3)) / math.sqrt(head_dim)
 
     attn_weights_size = (bsz, num_heads, q_len, kv_seq_len)


### PR DESCRIPTION
## Description
Fix llama draft_model dtype error
Also can set torch_dtype [here](https://github.com/intel-analytics/BigDL/blob/main/python/llm/src/bigdl/llm/transformers/model.py#L251)
```bash
 kwargs["torch_dtype"] = torch.float32
 draft_model = cls.load_convert('sym_int4', optimize_model, *args, **kwargs)
```
But cannot distinguish between cpu and xpu( xpu needs fp16, cpu needs fp32).
<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [ ] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
