### PR TITLE
[LLM] Avoid KV Cache OOM when seq len is larger than 1

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/models/aquila.py
+++ b/python/llm/src/bigdl/llm/transformers/models/aquila.py
@@ -89,7 +89,9 @@ def aquila_attention_forward(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+        # If cache storage is less than required (kv_seq_len）
+        # extend cache storage or re-init cache.
+        if cache_k.stride()[1] < kv_seq_len * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,
                                                        self.num_heads,  # Support GQA

--- a/python/llm/src/bigdl/llm/transformers/models/aquila.py
+++ b/python/llm/src/bigdl/llm/transformers/models/aquila.py
@@ -73,7 +73,9 @@ def aquila_attention_forward(
         .transpose(1, 2)
 
     kv_seq_len = key_states.shape[-2]
+    enough_kv_room = True
     if past_key_value is not None:
+        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=kv_seq_len)
         kv_seq_len += past_key_value[0].shape[-2]
     if query_states.device.type == "xpu" and not (self.training and query_states.requires_grad):
         query_states, key_states = apply_rotary_pos_emb_no_cache_xpu(query_states,
@@ -90,7 +92,6 @@ def aquila_attention_forward(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=key_states.shape[-2])
         if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,

--- a/python/llm/src/bigdl/llm/transformers/models/aquila.py
+++ b/python/llm/src/bigdl/llm/transformers/models/aquila.py
@@ -42,7 +42,8 @@ import torch
 import torch.utils.checkpoint
 from torch import nn
 
-from bigdl.llm.transformers.models.utils import extend_kv_cache, init_kv_cache, append_kv_cache
+from bigdl.llm.transformers.models.utils import extend_kv_cache, init_kv_cache, \
+    append_kv_cache, is_enough_kv_cache_room_4_31
 from bigdl.llm.transformers.models.utils import apply_rotary_pos_emb
 from bigdl.llm.transformers.models.utils import apply_rotary_pos_emb_no_cache_xpu
 from bigdl.llm.utils.common import log4Error
@@ -89,9 +90,8 @@ def aquila_attention_forward(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        # If cache storage is less than required (kv_seq_len）
-        # extend cache storage or re-init cache.
-        if cache_k.stride()[1] < kv_seq_len * cache_k.size(3):
+        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=key_states.shape[-2])
+        if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,
                                                        self.num_heads,  # Support GQA

--- a/python/llm/src/bigdl/llm/transformers/models/baichuan.py
+++ b/python/llm/src/bigdl/llm/transformers/models/baichuan.py
@@ -76,7 +76,9 @@ def baichuan_attention_forward_7b(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        if cache_k.stride()[1] < (cache_k.size(2) + kv_seq_len) * cache_k.size(3):
+        # If cache storage is less than required (kv_seq_len)
+        # extend cache storage or re-init cache.
+        if cache_k.stride()[1] < kv_seq_len * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,
                                                        self.num_heads,
@@ -174,7 +176,9 @@ def baichuan_attention_forward_13b(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        if cache_k.stride()[1] < (cache_k.size(2) + kv_seq_len) * cache_k.size(3):
+        # If cache storage is less than required (kv_seq_len)
+        # extend cache storage or re-init cache.
+        if cache_k.stride()[1] < kv_seq_len * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,
                                                        self.num_heads,

--- a/python/llm/src/bigdl/llm/transformers/models/baichuan.py
+++ b/python/llm/src/bigdl/llm/transformers/models/baichuan.py
@@ -56,7 +56,9 @@ def baichuan_attention_forward_7b(
     value_states = proj[2].view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
 
     kv_seq_len = key_states.shape[-2]
+    enough_kv_room = True
     if past_key_value is not None:
+        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=kv_seq_len)
         kv_seq_len += past_key_value[0].shape[-2]
     if query_states.device.type == "xpu" and not (self.training and query_states.requires_grad):
         query_states, key_states = apply_rotary_pos_emb_no_cache_xpu(query_states,
@@ -77,7 +79,6 @@ def baichuan_attention_forward_7b(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=key_states.shape[-2])
         if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,
@@ -165,7 +166,9 @@ def baichuan_attention_forward_13b(
     value_states = proj[2].view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
 
     kv_seq_len = key_states.shape[-2]
+    enough_kv_room = True
     if past_key_value is not None:
+        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=kv_seq_len)
         kv_seq_len += past_key_value[0].shape[-2]
 
     # if past_key_value is not None:
@@ -177,7 +180,6 @@ def baichuan_attention_forward_13b(
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
 
-        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=key_states.shape[-2])
         if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,

--- a/python/llm/src/bigdl/llm/transformers/models/baichuan.py
+++ b/python/llm/src/bigdl/llm/transformers/models/baichuan.py
@@ -76,7 +76,7 @@ def baichuan_attention_forward_7b(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+        if cache_k.stride()[1] < (cache_k.size(2) + kv_seq_len) * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,
                                                        self.num_heads,
@@ -174,7 +174,7 @@ def baichuan_attention_forward_13b(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+        if cache_k.stride()[1] < (cache_k.size(2) + kv_seq_len) * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,
                                                        self.num_heads,

--- a/python/llm/src/bigdl/llm/transformers/models/baichuan.py
+++ b/python/llm/src/bigdl/llm/transformers/models/baichuan.py
@@ -179,7 +179,6 @@ def baichuan_attention_forward_13b(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-
         if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,

--- a/python/llm/src/bigdl/llm/transformers/models/baichuan2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/baichuan2.py
@@ -128,7 +128,6 @@ def baichuan_attention_forward_7b(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-
         if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,
@@ -233,7 +232,6 @@ def baichuan_attention_forward_13b(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-
         if not enough_kv_room:
             if device.type == 'xpu':
                 torch.xpu.empty_cache()

--- a/python/llm/src/bigdl/llm/transformers/models/baichuan2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/baichuan2.py
@@ -125,7 +125,7 @@ def baichuan_attention_forward_7b(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+        if cache_k.stride()[1] < (cache_k.size(2) + kv_seq_len) * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,
                                                        self.num_heads,
@@ -227,7 +227,7 @@ def baichuan_attention_forward_13b(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+        if cache_k.stride()[1] < (cache_k.size(2) + kv_seq_len) * cache_k.size(3):
             if device.type == 'xpu':
                 torch.xpu.empty_cache()
             # allocate new

--- a/python/llm/src/bigdl/llm/transformers/models/baichuan2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/baichuan2.py
@@ -105,7 +105,9 @@ def baichuan_attention_forward_7b(
     value_states = proj[2].view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
 
     kv_seq_len = key_states.shape[-2]
+    enough_kv_room = True
     if past_key_value is not None:
+        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=kv_seq_len)
         kv_seq_len += past_key_value[0].shape[-2]
     if query_states.device.type == "xpu" and not (self.training and query_states.requires_grad):
         query_states, key_states = apply_rotary_pos_emb_no_cache_xpu(query_states,
@@ -127,7 +129,6 @@ def baichuan_attention_forward_7b(
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
 
-        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=key_states.shape[-2])
         if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,
@@ -219,7 +220,9 @@ def baichuan_attention_forward_13b(
     )
 
     kv_seq_len = key_states.shape[-2]
+    enough_kv_room = True
     if past_key_value is not None:
+        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=kv_seq_len)
         kv_seq_len += past_key_value[0].shape[-2]
 
     # if past_key_value is not None:
@@ -231,7 +234,6 @@ def baichuan_attention_forward_13b(
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
 
-        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=key_states.shape[-2])
         if not enough_kv_room:
             if device.type == 'xpu':
                 torch.xpu.empty_cache()

--- a/python/llm/src/bigdl/llm/transformers/models/baichuan2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/baichuan2.py
@@ -125,7 +125,9 @@ def baichuan_attention_forward_7b(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        if cache_k.stride()[1] < (cache_k.size(2) + kv_seq_len) * cache_k.size(3):
+        # If cache storage is less than required (kv_seq_len)
+        # extend cache storage or re-init cache.
+        if cache_k.stride()[1] < kv_seq_len * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,
                                                        self.num_heads,
@@ -227,7 +229,9 @@ def baichuan_attention_forward_13b(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        if cache_k.stride()[1] < (cache_k.size(2) + kv_seq_len) * cache_k.size(3):
+        # If cache storage is less than required (kv_seq_len)
+        # extend cache storage or re-init cache.
+        if cache_k.stride()[1] < kv_seq_len * cache_k.size(3):
             if device.type == 'xpu':
                 torch.xpu.empty_cache()
             # allocate new

--- a/python/llm/src/bigdl/llm/transformers/models/baichuan2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/baichuan2.py
@@ -24,7 +24,8 @@ import torch
 import torch.utils.checkpoint
 from torch.nn import functional as F
 from bigdl.llm.ggml.quantize import ggml_tensor_qtype
-from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, append_kv_cache
+from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, \
+    append_kv_cache, is_enough_kv_cache_room_4_31
 from bigdl.llm.transformers.models.utils import apply_rotary_pos_emb
 from bigdl.llm.transformers.models.utils import apply_rotary_pos_emb_no_cache_xpu
 from bigdl.llm.transformers.models.utils import mlp_fusion_check
@@ -125,9 +126,9 @@ def baichuan_attention_forward_7b(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        # If cache storage is less than required (kv_seq_len)
-        # extend cache storage or re-init cache.
-        if cache_k.stride()[1] < kv_seq_len * cache_k.size(3):
+
+        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=key_states.shape[-2])
+        if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,
                                                        self.num_heads,
@@ -229,9 +230,9 @@ def baichuan_attention_forward_13b(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        # If cache storage is less than required (kv_seq_len)
-        # extend cache storage or re-init cache.
-        if cache_k.stride()[1] < kv_seq_len * cache_k.size(3):
+
+        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=key_states.shape[-2])
+        if not enough_kv_room:
             if device.type == 'xpu':
                 torch.xpu.empty_cache()
             # allocate new

--- a/python/llm/src/bigdl/llm/transformers/models/bloom.py
+++ b/python/llm/src/bigdl/llm/transformers/models/bloom.py
@@ -38,7 +38,8 @@ import torch
 import torch.utils.checkpoint
 from torch.nn import functional as F
 from bigdl.llm.transformers.models.utils import use_fused_layer_norm
-from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, append_kv_cache
+from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, \
+    append_kv_cache, is_enough_kv_cache_room_4_31
 
 
 KV_CACHE_ALLOC_BLOCK_LENGTH = 256
@@ -121,9 +122,9 @@ def bloom_attention_forward(
         # reuse k, v, self_attention
         cache_k = layer_past[0].transpose(1, 2).view(batch_size, self.num_heads, -1, self.head_dim)
         cache_v = layer_past[1].view(batch_size, self.num_heads, -1, self.head_dim)
-        # If cache storage is less than required (kv_length)
-        # extend cache storage or re-init cache.
-        if cache_k.stride()[1] < kv_length * cache_k.size(3):
+
+        enough_kv_room = is_enough_kv_cache_room_4_31(layer_past, seq_dim=3, seq_len=key_layer.shape[-2])
+        if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(
                 batch_size,

--- a/python/llm/src/bigdl/llm/transformers/models/bloom.py
+++ b/python/llm/src/bigdl/llm/transformers/models/bloom.py
@@ -124,7 +124,6 @@ def bloom_attention_forward(
         # reuse k, v, self_attention
         cache_k = layer_past[0].transpose(1, 2).view(batch_size, self.num_heads, -1, self.head_dim)
         cache_v = layer_past[1].view(batch_size, self.num_heads, -1, self.head_dim)
-
         if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(

--- a/python/llm/src/bigdl/llm/transformers/models/bloom.py
+++ b/python/llm/src/bigdl/llm/transformers/models/bloom.py
@@ -121,7 +121,9 @@ def bloom_attention_forward(
         # reuse k, v, self_attention
         cache_k = layer_past[0].transpose(1, 2).view(batch_size, self.num_heads, -1, self.head_dim)
         cache_v = layer_past[1].view(batch_size, self.num_heads, -1, self.head_dim)
-        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+        # If cache storage is less than required (kv_length)
+        # extend cache storage or re-init cache.
+        if cache_k.stride()[1] < kv_length * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(
                 batch_size,

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm.py
@@ -22,8 +22,7 @@ import torch
 import torch.utils.checkpoint
 import torch.nn.functional as F
 from typing import Optional, Tuple
-from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, \
-    append_kv_cache, is_enough_kv_cache_room_4_31
+from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, append_kv_cache
 
 
 def rotate_half(x):
@@ -67,8 +66,7 @@ def attention_fn(
         cache_k = cache_k.permute(1, 2, 0, 3)
         cache_v = cache_v.permute(1, 2, 0, 3)
         past_length = cache_k.size(2)
-        enough_kv_room = is_enough_kv_cache_room_4_31(cache_k, seq_dim=0, seq_len=cur_length)
-        if not enough_kv_room:
+        if cache_k.stride()[1] < (past_length + cur_length) * cache_k.size(3):
             max_cache_length = past_length + cur_length + KV_CACHE_ALLOC_BLOCK_LENGTH
             new_cache_k, new_cache_v = extend_kv_cache(batch_size,
                                                        self.num_attention_heads_per_partition,

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm.py
@@ -66,7 +66,7 @@ def attention_fn(
         cache_k = cache_k.permute(1, 2, 0, 3)
         cache_v = cache_v.permute(1, 2, 0, 3)
         past_length = cache_k.size(2)
-        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+        if cache_k.stride()[1] < (past_length + cur_length) * cache_k.size(3):
             max_cache_length = past_length + cur_length + KV_CACHE_ALLOC_BLOCK_LENGTH
             new_cache_k, new_cache_v = extend_kv_cache(batch_size,
                                                        self.num_attention_heads_per_partition,

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm.py
@@ -66,6 +66,8 @@ def attention_fn(
         cache_k = cache_k.permute(1, 2, 0, 3)
         cache_v = cache_v.permute(1, 2, 0, 3)
         past_length = cache_k.size(2)
+        # If cache storage is less than required (past_length + cur_length)
+        # extend cache storage or re-init cache.
         if cache_k.stride()[1] < (past_length + cur_length) * cache_k.size(3):
             max_cache_length = past_length + cur_length + KV_CACHE_ALLOC_BLOCK_LENGTH
             new_cache_k, new_cache_v = extend_kv_cache(batch_size,

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -419,7 +419,9 @@ def chatglm2_attention_forward_8eb45c(
         cache_v = cache_v.permute(1, 2, 0, 3)
         past_length = cache_k.size(2)
 
-        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+        # If cache storage is less than required (past_length + cur_length)
+        # extend cache storage or re-init cache.
+        if cache_k.stride()[1] < (past_length + cur_length) * cache_k.size(3):
             max_cache_length = past_length + cur_length + KV_CACHE_ALLOC_BLOCK_LENGTH
             if device.type == "xpu" and batch_size > 1:  # use beam_search for generation.
                 # If batch_size > 1 on gpu, use init_kv_cache to avoid empty cache for ensuring

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -22,7 +22,8 @@ import torch
 from typing import Optional, Tuple, List
 import torch.nn.functional as F
 from transformers.modeling_outputs import BaseModelOutputWithPast
-from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, append_kv_cache
+from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, \
+    append_kv_cache,is_enough_kv_cache_room_4_31
 from bigdl.llm.transformers.models.utils import init_fp8_kv_cache, extend_fp8_kv_cache, \
     append_fp8_kv_cache, restore_fp8_kv_cache, quantize_kv_cache
 from bigdl.llm.transformers.models.utils import use_flash_attention
@@ -415,13 +416,12 @@ def chatglm2_attention_forward_8eb45c(
     # adjust key and value for inference
     if kv_cache is not None:
         cache_k, cache_v = kv_cache
+        enough_kv_room = is_enough_kv_cache_room_4_31(kv_cache, seq_dim=0, seq_len=cur_length)
         cache_k = cache_k.permute(1, 2, 0, 3)
         cache_v = cache_v.permute(1, 2, 0, 3)
         past_length = cache_k.size(2)
 
-        # If cache storage is less than required (past_length + cur_length)
-        # extend cache storage or re-init cache.
-        if cache_k.stride()[1] < (past_length + cur_length) * cache_k.size(3):
+        if not enough_kv_room:
             max_cache_length = past_length + cur_length + KV_CACHE_ALLOC_BLOCK_LENGTH
             if device.type == "xpu" and batch_size > 1:  # use beam_search for generation.
                 # If batch_size > 1 on gpu, use init_kv_cache to avoid empty cache for ensuring

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -23,7 +23,7 @@ from typing import Optional, Tuple, List
 import torch.nn.functional as F
 from transformers.modeling_outputs import BaseModelOutputWithPast
 from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, \
-    append_kv_cache,is_enough_kv_cache_room_4_31
+    append_kv_cache, is_enough_kv_cache_room_4_31
 from bigdl.llm.transformers.models.utils import init_fp8_kv_cache, extend_fp8_kv_cache, \
     append_fp8_kv_cache, restore_fp8_kv_cache, quantize_kv_cache
 from bigdl.llm.transformers.models.utils import use_flash_attention

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2_32k.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2_32k.py
@@ -20,8 +20,7 @@
 import torch
 from typing import Optional, Tuple, Union, List, Callable, Dict, Any
 import torch.nn.functional as F
-from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, \
-    append_kv_cache, is_enough_kv_cache_room_4_31
+from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, append_kv_cache
 
 
 KV_CACHE_ALLOC_BLOCK_LENGTH = 256
@@ -151,8 +150,7 @@ def chatglm2_32k_attention_forward(
         cache_v = cache_v.permute(1, 2, 0, 3)
         past_length = cache_k.size(2)
 
-        enough_kv_room = is_enough_kv_cache_room_4_31(kv_cache, seq_dim=0, seq_len=cur_length)
-        if not enough_kv_room:
+        if cache_k.stride()[1] < (past_length + cur_length) * cache_k.size(3):
             max_cache_length = past_length + cur_length + KV_CACHE_ALLOC_BLOCK_LENGTH
             new_cache_k, new_cache_v = extend_kv_cache(batch_size,
                                                        self.num_attention_heads_per_partition,

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2_32k.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2_32k.py
@@ -151,7 +151,7 @@ def chatglm2_32k_attention_forward(
         cache_v = cache_v.permute(1, 2, 0, 3)
         past_length = cache_k.size(2)
 
-        enough_kv_room = is_enough_kv_cache_room_4_31(cache_k, seq_dim=0, seq_len=cur_length)
+        enough_kv_room = is_enough_kv_cache_room_4_31(kv_cache, seq_dim=0, seq_len=cur_length)
         if not enough_kv_room:
             max_cache_length = past_length + cur_length + KV_CACHE_ALLOC_BLOCK_LENGTH
             new_cache_k, new_cache_v = extend_kv_cache(batch_size,

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2_32k.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2_32k.py
@@ -150,7 +150,7 @@ def chatglm2_32k_attention_forward(
         cache_v = cache_v.permute(1, 2, 0, 3)
         past_length = cache_k.size(2)
 
-        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+        if cache_k.stride()[1] < (past_length + cur_length) * cache_k.size(3):
             max_cache_length = past_length + cur_length + KV_CACHE_ALLOC_BLOCK_LENGTH
             new_cache_k, new_cache_v = extend_kv_cache(batch_size,
                                                        self.num_attention_heads_per_partition,

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2_32k.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2_32k.py
@@ -150,6 +150,8 @@ def chatglm2_32k_attention_forward(
         cache_v = cache_v.permute(1, 2, 0, 3)
         past_length = cache_k.size(2)
 
+        # If cache storage is less than required (past_length + cur_length)
+        # extend cache storage or re-init cache.
         if cache_k.stride()[1] < (past_length + cur_length) * cache_k.size(3):
             max_cache_length = past_length + cur_length + KV_CACHE_ALLOC_BLOCK_LENGTH
             new_cache_k, new_cache_v = extend_kv_cache(batch_size,

--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2_32k.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2_32k.py
@@ -20,7 +20,8 @@
 import torch
 from typing import Optional, Tuple, Union, List, Callable, Dict, Any
 import torch.nn.functional as F
-from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, append_kv_cache
+from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, \
+    append_kv_cache, is_enough_kv_cache_room_4_31
 
 
 KV_CACHE_ALLOC_BLOCK_LENGTH = 256
@@ -150,9 +151,8 @@ def chatglm2_32k_attention_forward(
         cache_v = cache_v.permute(1, 2, 0, 3)
         past_length = cache_k.size(2)
 
-        # If cache storage is less than required (past_length + cur_length)
-        # extend cache storage or re-init cache.
-        if cache_k.stride()[1] < (past_length + cur_length) * cache_k.size(3):
+        enough_kv_room = is_enough_kv_cache_room_4_31(cache_k, seq_dim=0, seq_len=cur_length)
+        if not enough_kv_room:
             max_cache_length = past_length + cur_length + KV_CACHE_ALLOC_BLOCK_LENGTH
             new_cache_k, new_cache_v = extend_kv_cache(batch_size,
                                                        self.num_attention_heads_per_partition,

--- a/python/llm/src/bigdl/llm/transformers/models/falcon.py
+++ b/python/llm/src/bigdl/llm/transformers/models/falcon.py
@@ -97,7 +97,9 @@ def rw_attention_forward_7b(
         # reuse k, v, self_attention
         cache_k = layer_past[0].view(batch_size, self.num_kv, -1, self.head_dim)
         cache_v = layer_past[1].view(batch_size, self.num_kv, -1, self.head_dim)
-        if cache_k.stride()[1] < (cache_k.size(2) + kv_length) * cache_k.size(3):
+        # If cache storage is less than required (past_length + cur_length)
+        # extend cache storage or re-init cache.
+        if cache_k.stride()[1] < kv_length * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(
                 batch_size,
@@ -276,7 +278,9 @@ def rw_attention_forward_40b(
         # reuse k, v, self_attention
         cache_k = layer_past[0].view(batch_size, self.num_heads, -1, self.head_dim)
         cache_v = layer_past[1].view(batch_size, self.num_heads, -1, self.head_dim)
-        if cache_k.stride()[1] < (cache_k.size(2) + kv_length) * cache_k.size(3):
+        # If cache storage is less than required (past_length + cur_length)
+        # extend cache storage or re-init cache.
+        if cache_k.stride()[1] < kv_length * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(
                 batch_size,
@@ -450,7 +454,9 @@ def falcon_attention_forward(
         # reuse k, v, self_attention
         cache_k = layer_past[0].view(batch_size, num_kv_heads, -1, self.head_dim)
         cache_v = layer_past[1].view(batch_size, num_kv_heads, -1, self.head_dim)
-        if cache_k.stride()[1] < (cache_k.size(2) + kv_length) * cache_k.size(3):
+        # If cache storage is less than required (cur_length)
+        # extend cache storage or re-init cache.
+        if cache_k.stride()[1] < kv_length * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(
                 batch_size,

--- a/python/llm/src/bigdl/llm/transformers/models/falcon.py
+++ b/python/llm/src/bigdl/llm/transformers/models/falcon.py
@@ -97,7 +97,7 @@ def rw_attention_forward_7b(
         # reuse k, v, self_attention
         cache_k = layer_past[0].view(batch_size, self.num_kv, -1, self.head_dim)
         cache_v = layer_past[1].view(batch_size, self.num_kv, -1, self.head_dim)
-        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+        if cache_k.stride()[1] < (cache_k.size(2) + kv_length) * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(
                 batch_size,
@@ -276,7 +276,7 @@ def rw_attention_forward_40b(
         # reuse k, v, self_attention
         cache_k = layer_past[0].view(batch_size, self.num_heads, -1, self.head_dim)
         cache_v = layer_past[1].view(batch_size, self.num_heads, -1, self.head_dim)
-        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+        if cache_k.stride()[1] < (cache_k.size(2) + kv_length) * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(
                 batch_size,
@@ -450,7 +450,7 @@ def falcon_attention_forward(
         # reuse k, v, self_attention
         cache_k = layer_past[0].view(batch_size, num_kv_heads, -1, self.head_dim)
         cache_v = layer_past[1].view(batch_size, num_kv_heads, -1, self.head_dim)
-        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+        if cache_k.stride()[1] < (cache_k.size(2) + kv_length) * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(
                 batch_size,

--- a/python/llm/src/bigdl/llm/transformers/models/falcon.py
+++ b/python/llm/src/bigdl/llm/transformers/models/falcon.py
@@ -87,7 +87,9 @@ def rw_attention_forward_7b(
     query_layer, key_layer = self.maybe_rotary(query_layer, key_layer, seq_len)
 
     _, kv_length, _ = key_layer.shape
+    enough_kv_room = True
     if layer_past is not None:
+        enough_kv_room = is_enough_kv_cache_room_4_31(layer_past, seq_dim=-2, seq_len=kv_length)
         kv_length += layer_past[0].shape[-2]
     query_layer = query_layer.view(batch_size, self.num_heads, q_length, self.head_dim)
     key_layer = key_layer.view(batch_size, self.num_kv, q_length, self.head_dim)
@@ -98,7 +100,6 @@ def rw_attention_forward_7b(
         # reuse k, v, self_attention
         cache_k = layer_past[0].view(batch_size, self.num_kv, -1, self.head_dim)
         cache_v = layer_past[1].view(batch_size, self.num_kv, -1, self.head_dim)
-        enough_kv_room = is_enough_kv_cache_room_4_31(layer_past, seq_dim=-2, seq_len=key_layer.shape[-2])
         if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(
@@ -267,7 +268,9 @@ def rw_attention_forward_40b(
     query_layer, key_layer = self.maybe_rotary(query_layer, key_layer, seq_len)
 
     _, kv_length, _ = key_layer.shape
+    enough_kv_room = True
     if layer_past is not None:
+        enough_kv_room = is_enough_kv_cache_room_4_31(layer_past, seq_dim=-2, seq_len=kv_length)
         kv_length += layer_past[0].shape[-2]
     query_layer = query_layer.view(batch_size, self.num_heads, q_length, self.head_dim)
     key_layer = key_layer.view(batch_size, self.num_heads, q_length, self.head_dim)
@@ -278,7 +281,6 @@ def rw_attention_forward_40b(
         # reuse k, v, self_attention
         cache_k = layer_past[0].view(batch_size, self.num_heads, -1, self.head_dim)
         cache_v = layer_past[1].view(batch_size, self.num_heads, -1, self.head_dim)
-        enough_kv_room = is_enough_kv_cache_room_4_31(layer_past, seq_dim=-2, seq_len=key_layer.shape[-2])
         if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(
@@ -443,7 +445,9 @@ def falcon_attention_forward(
     query_layer, key_layer = self.maybe_rotary(query_layer, key_layer, past_kv_length)
 
     _, kv_length, _ = key_layer.shape
+    enough_kv_room = True
     if layer_past is not None:
+        enough_kv_room = is_enough_kv_cache_room_4_31(layer_past, seq_dim=-2, seq_len=kv_length)
         kv_length += layer_past[0].shape[-2]
     query_layer = query_layer.view(batch_size, self.num_heads, query_length, self.head_dim)
     key_layer = key_layer.view(batch_size, num_kv_heads, query_length, self.head_dim)
@@ -453,7 +457,6 @@ def falcon_attention_forward(
         # reuse k, v, self_attention
         cache_k = layer_past[0].view(batch_size, num_kv_heads, -1, self.head_dim)
         cache_v = layer_past[1].view(batch_size, num_kv_heads, -1, self.head_dim)
-        enough_kv_room = is_enough_kv_cache_room_4_31(layer_past, seq_dim=-2, seq_len=key_layer.shape[-2])
         if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(

--- a/python/llm/src/bigdl/llm/transformers/models/gptj.py
+++ b/python/llm/src/bigdl/llm/transformers/models/gptj.py
@@ -20,7 +20,7 @@
 import torch
 from typing import Optional, Tuple, Union
 from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, \
-    apply_rotary_pos_emb, append_kv_cache, is_enough_kv_cache_room_4_31
+    apply_rotary_pos_emb, append_kv_cache
 from transformers.utils.import_utils import is_torch_fx_proxy
 
 
@@ -133,9 +133,7 @@ def gptj_attention_forward(
     kv_seq_len = key.size(-2)
     device = hidden_states.device
 
-    enough_kv_room = True
     if layer_past is not None:
-        enough_kv_room = is_enough_kv_cache_room_4_31(layer_past, seq_dim=1, seq_len=kv_seq_len)
         kv_seq_len += layer_past[0].size(1)
 
     if layer_past is not None:
@@ -144,7 +142,7 @@ def gptj_attention_forward(
         cache_k = cache_k.permute(0, 2, 1, 3)
         cache_v = cache_v.permute(0, 2, 1, 3)
         past_length = cache_k.size(2)
-        if not enough_kv_room:
+        if cache_k.stride()[1] < kv_seq_len * cache_k.size(3):
             new_cache_k, new_cache_v = extend_kv_cache(batch_size,
                                                        self.num_attention_heads,
                                                        self.head_dim,

--- a/python/llm/src/bigdl/llm/transformers/models/gptj.py
+++ b/python/llm/src/bigdl/llm/transformers/models/gptj.py
@@ -133,7 +133,9 @@ def gptj_attention_forward(
     kv_seq_len = key.size(-2)
     device = hidden_states.device
 
+    enough_kv_room = True
     if layer_past is not None:
+        enough_kv_room = is_enough_kv_cache_room_4_31(layer_past, seq_dim=1, seq_len=kv_seq_len)
         kv_seq_len += layer_past[0].size(1)
 
     if layer_past is not None:
@@ -142,7 +144,6 @@ def gptj_attention_forward(
         cache_k = cache_k.permute(0, 2, 1, 3)
         cache_v = cache_v.permute(0, 2, 1, 3)
         past_length = cache_k.size(2)
-        enough_kv_room = is_enough_kv_cache_room_4_31(layer_past, seq_dim=1, seq_len=key.size(-2))
         if not enough_kv_room:
             new_cache_k, new_cache_v = extend_kv_cache(batch_size,
                                                        self.num_attention_heads,

--- a/python/llm/src/bigdl/llm/transformers/models/gptj.py
+++ b/python/llm/src/bigdl/llm/transformers/models/gptj.py
@@ -142,8 +142,9 @@ def gptj_attention_forward(
         cache_k = cache_k.permute(0, 2, 1, 3)
         cache_v = cache_v.permute(0, 2, 1, 3)
         past_length = cache_k.size(2)
-
-        if cache_k.stride()[1] < (past_length + kv_seq_len) * cache_k.size(3):
+        # If cache storage is less than required (kv_seq_len)
+        # extend cache storage or re-init cache.
+        if cache_k.stride()[1] < kv_seq_len * cache_k.size(3):
             new_cache_k, new_cache_v = extend_kv_cache(batch_size,
                                                        self.num_attention_heads,
                                                        self.head_dim,

--- a/python/llm/src/bigdl/llm/transformers/models/gptj.py
+++ b/python/llm/src/bigdl/llm/transformers/models/gptj.py
@@ -143,7 +143,7 @@ def gptj_attention_forward(
         cache_v = cache_v.permute(0, 2, 1, 3)
         past_length = cache_k.size(2)
 
-        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+        if cache_k.stride()[1] < (past_length + kv_seq_len) * cache_k.size(3):
             new_cache_k, new_cache_v = extend_kv_cache(batch_size,
                                                        self.num_attention_heads,
                                                        self.head_dim,

--- a/python/llm/src/bigdl/llm/transformers/models/gptneox.py
+++ b/python/llm/src/bigdl/llm/transformers/models/gptneox.py
@@ -80,7 +80,9 @@ def gptneox_attention_forward(
 
     # Compute token offset for rotary embeddings (when decoding)
     seq_len = key.shape[-2]
+    enough_kv_room = True
     if has_layer_past:
+        enough_kv_room = is_enough_kv_cache_room_4_31(layer_past, seq_len=seq_len)
         seq_len += layer_past[0].shape[-2]
 
     use_fuse_rope = query.device.type == "xpu"
@@ -102,7 +104,6 @@ def gptneox_attention_forward(
     if has_layer_past:
         past_key = layer_past[0]
         past_value = layer_past[1]
-        enough_kv_room = is_enough_kv_cache_room_4_31(layer_past, seq_len=key.shape[-2])
         if not enough_kv_room:
             # allocate new
             new_past_key, new_past_value = extend_kv_cache(bsz,

--- a/python/llm/src/bigdl/llm/transformers/models/gptneox.py
+++ b/python/llm/src/bigdl/llm/transformers/models/gptneox.py
@@ -34,7 +34,8 @@
 import torch
 from typing import Optional, Tuple
 from bigdl.llm.transformers.models.utils import apply_rotary_pos_emb
-from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, append_kv_cache
+from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, \
+    append_kv_cache, is_enough_kv_cache_room_4_31
 from bigdl.llm.transformers.models.utils import apply_rotary_pos_emb_no_cache_xpu
 
 
@@ -101,7 +102,8 @@ def gptneox_attention_forward(
     if has_layer_past:
         past_key = layer_past[0]
         past_value = layer_past[1]
-        if past_key.stride()[1] < seq_len * past_key.size(3):
+        enough_kv_room = is_enough_kv_cache_room_4_31(layer_past, seq_len=key.shape[-2])
+        if not enough_kv_room:
             # allocate new
             new_past_key, new_past_value = extend_kv_cache(bsz,
                                                            self.num_attention_heads,

--- a/python/llm/src/bigdl/llm/transformers/models/gptneox.py
+++ b/python/llm/src/bigdl/llm/transformers/models/gptneox.py
@@ -101,7 +101,7 @@ def gptneox_attention_forward(
     if has_layer_past:
         past_key = layer_past[0]
         past_value = layer_past[1]
-        if past_key.stride()[1] <= past_key.size(2) * past_key.size(3):
+        if past_key.stride()[1] < seq_len * past_key.size(3):
             # allocate new
             new_past_key, new_past_value = extend_kv_cache(bsz,
                                                            self.num_attention_heads,

--- a/python/llm/src/bigdl/llm/transformers/models/internlm.py
+++ b/python/llm/src/bigdl/llm/transformers/models/internlm.py
@@ -95,7 +95,9 @@ def internlm_attention_forward(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        if cache_k.stride()[1] < (cache_k.size(2) + kv_seq_len) * cache_k.size(3):
+        # If cache storage is less than required (kv_seq_len)
+        # extend cache storage or re-init cache.
+        if cache_k.stride()[1] < kv_seq_len * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(
                 bsz,

--- a/python/llm/src/bigdl/llm/transformers/models/internlm.py
+++ b/python/llm/src/bigdl/llm/transformers/models/internlm.py
@@ -95,7 +95,7 @@ def internlm_attention_forward(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+        if cache_k.stride()[1] < (cache_k.size(2) + kv_seq_len) * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(
                 bsz,

--- a/python/llm/src/bigdl/llm/transformers/models/internlm.py
+++ b/python/llm/src/bigdl/llm/transformers/models/internlm.py
@@ -96,7 +96,7 @@ def internlm_attention_forward(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len= key_states.shape[-2])
+        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=key_states.shape[-2])
         if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(

--- a/python/llm/src/bigdl/llm/transformers/models/internlm.py
+++ b/python/llm/src/bigdl/llm/transformers/models/internlm.py
@@ -43,7 +43,8 @@ import torch
 import torch.utils.checkpoint
 from torch import nn
 from bigdl.llm.utils.common import invalidInputError
-from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, append_kv_cache
+from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, \
+    append_kv_cache, is_enough_kv_cache_room_4_31
 from bigdl.llm.transformers.models.utils import apply_rotary_pos_emb
 from bigdl.llm.transformers.models.utils import apply_rotary_pos_emb_no_cache_xpu
 
@@ -95,9 +96,8 @@ def internlm_attention_forward(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        # If cache storage is less than required (kv_seq_len)
-        # extend cache storage or re-init cache.
-        if cache_k.stride()[1] < kv_seq_len * cache_k.size(3):
+        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len= key_states.shape[-2])
+        if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(
                 bsz,

--- a/python/llm/src/bigdl/llm/transformers/models/internlm.py
+++ b/python/llm/src/bigdl/llm/transformers/models/internlm.py
@@ -74,7 +74,9 @@ def internlm_attention_forward(
         .transpose(1, 2)
 
     kv_seq_len = key_states.shape[-2]
+    enough_kv_room = True
     if past_key_value is not None:
+        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=kv_seq_len)
         kv_seq_len += past_key_value[0].shape[-2]
     if query_states.device.type == "xpu" and not (self.training and query_states.requires_grad):
         query_states, key_states = apply_rotary_pos_emb_no_cache_xpu(query_states,
@@ -96,7 +98,6 @@ def internlm_attention_forward(
         # reuse k, v, self_attention
         cache_k = past_key_value[0]
         cache_v = past_key_value[1]
-        enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value, seq_len=key_states.shape[-2])
         if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(

--- a/python/llm/src/bigdl/llm/transformers/models/mistral.py
+++ b/python/llm/src/bigdl/llm/transformers/models/mistral.py
@@ -43,9 +43,9 @@ from torch import nn
 import torch.nn.functional as F
 from bigdl.llm.utils.common import invalidInputError
 from bigdl.llm.transformers.models.utils import init_kv_cache, extend_kv_cache, append_kv_cache
-from bigdl.llm.transformers.models.utils import apply_rotary_pos_emb,\
+from bigdl.llm.transformers.models.utils import apply_rotary_pos_emb, \
     apply_rotary_pos_emb_no_cache_xpu
-from bigdl.llm.transformers.models.utils import is_enough_kv_cache_room_4_31,\
+from bigdl.llm.transformers.models.utils import is_enough_kv_cache_room_4_31, \
     is_enough_kv_cache_room_4_36
 from bigdl.llm.transformers.low_bit_linear import SYM_INT4, FP8E5
 from bigdl.llm.transformers.models.utils import use_flash_attention

--- a/python/llm/src/bigdl/llm/transformers/models/mpt.py
+++ b/python/llm/src/bigdl/llm/transformers/models/mpt.py
@@ -23,8 +23,7 @@ from einops import rearrange
 import math
 import torch.nn.functional as F
 from bigdl.llm.utils.common import invalidInputError
-from bigdl.llm.transformers.models.utils import extend_kv_cache, init_kv_cache, \
-    append_kv_cache, is_enough_kv_cache_room_4_31
+from bigdl.llm.transformers.models.utils import extend_kv_cache, init_kv_cache, append_kv_cache
 
 
 KV_CACHE_ALLOC_BLOCK_LENGTH = 256
@@ -77,10 +76,8 @@ def mpt_scaled_multihead_dot_product_attention(query, key, value, n_heads,
             # v = torch.cat([past_key_value[1], v], dim=2)
             cache_k = past_key_value[0].transpose(2, 3)
             cache_v = past_key_value[1]
-            enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value,
-                                                          seq_dim=-1, seq_len=kv_seq_len)
             kv_seq_len += cache_k.shape[-2]
-            if not enough_kv_room:
+            if cache_k.stride()[1] < kv_seq_len * cache_k.size(3):
                 # allocate new
                 new_cache_k, new_cache_v = extend_kv_cache(bsz,
                                                            kv_n_heads,  # Support GQA

--- a/python/llm/src/bigdl/llm/transformers/models/mpt.py
+++ b/python/llm/src/bigdl/llm/transformers/models/mpt.py
@@ -77,7 +77,9 @@ def mpt_scaled_multihead_dot_product_attention(query, key, value, n_heads,
             cache_k = past_key_value[0].transpose(2, 3)
             cache_v = past_key_value[1]
             kv_seq_len += cache_k.shape[-2]
-            if cache_k.stride()[1] < (cache_k.size(2) + kv_seq_len) * cache_k.size(3):
+            # If cache storage is less than required (kv_seq_len)
+            # extend cache storage or re-init cache.
+            if cache_k.stride()[1] < kv_seq_len * cache_k.size(3):
                 # allocate new
                 new_cache_k, new_cache_v = extend_kv_cache(bsz,
                                                            kv_n_heads,  # Support GQA

--- a/python/llm/src/bigdl/llm/transformers/models/mpt.py
+++ b/python/llm/src/bigdl/llm/transformers/models/mpt.py
@@ -77,7 +77,7 @@ def mpt_scaled_multihead_dot_product_attention(query, key, value, n_heads,
             cache_k = past_key_value[0].transpose(2, 3)
             cache_v = past_key_value[1]
             kv_seq_len += cache_k.shape[-2]
-            if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+            if cache_k.stride()[1] < (cache_k.size(2) + kv_seq_len) * cache_k.size(3):
                 # allocate new
                 new_cache_k, new_cache_v = extend_kv_cache(bsz,
                                                            kv_n_heads,  # Support GQA

--- a/python/llm/src/bigdl/llm/transformers/models/qwen.py
+++ b/python/llm/src/bigdl/llm/transformers/models/qwen.py
@@ -36,7 +36,8 @@ try:
 except ImportError:
     rearrange = None
 
-from bigdl.llm.transformers.models.utils import extend_kv_cache, init_kv_cache, append_kv_cache
+from bigdl.llm.transformers.models.utils import extend_kv_cache, init_kv_cache, \
+    append_kv_cache, is_enough_kv_cache_room_4_31
 from bigdl.llm.transformers.models.utils import init_fp8_kv_cache, extend_fp8_kv_cache, \
     append_fp8_kv_cache, restore_fp8_kv_cache
 from bigdl.llm.transformers.models.utils import rotate_half, quantize_kv_cache
@@ -169,7 +170,8 @@ def qwen_attention_forward(
             v_cache = v_cache.transpose(1, 2)
             # k_cache and v_cache's shape: [bs, num_heads, context_length, head_dim]
 
-            if k_cache.stride(1) < kv_seq_len * k_cache.size(3):
+            enough_kv_room = is_enough_kv_cache_room_4_31(layer_past, seq_dim=1, seq_len=key_size)
+            if not enough_kv_room:
                 # allocate new
                 k_cache, v_cache = extend_fp8_kv_cache(
                     k_cache, v_cache,
@@ -192,7 +194,8 @@ def qwen_attention_forward(
             cache_k, cache_v = layer_past[0], layer_past[1]
             cache_k = cache_k.transpose(1, 2)
             cache_v = cache_v.transpose(1, 2)
-            if cache_k.stride(1) < kv_seq_len * cache_k.size(3):
+            enough_kv_room = is_enough_kv_cache_room_4_31(layer_past, seq_dim=1, seq_len=key_size)
+            if not enough_kv_room:
                 # allocate new
                 new_cache_k, new_cache_v = extend_kv_cache(bsz,
                                                            self.num_heads,

--- a/python/llm/src/bigdl/llm/transformers/models/qwen_vl.py
+++ b/python/llm/src/bigdl/llm/transformers/models/qwen_vl.py
@@ -89,7 +89,9 @@ def qwen_attention_forward_vl(
         # value = torch.cat((past_value, value), dim=1)
         cache_k = layer_past[0].transpose(1, 2)
         cache_v = layer_past[1].transpose(1, 2)
-        if cache_k.stride()[1] < (cache_k.size(2) + kv_seq_len) * cache_k.size(3):
+        # If cache storage is less than required (kv_seq_len)
+        # extend cache storage or re-init cache.
+        if cache_k.stride()[1] < kv_seq_len * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,
                                                        self.num_heads,

--- a/python/llm/src/bigdl/llm/transformers/models/qwen_vl.py
+++ b/python/llm/src/bigdl/llm/transformers/models/qwen_vl.py
@@ -84,15 +84,16 @@ def qwen_attention_forward_vl(
     bsz, _, n_heads, head_dim = key.size()
 
     if layer_past is not None:
+        enough_kv_room = is_enough_kv_cache_room_4_31(layer_past,
+                                                      seq_dim=1,
+                                                      seq_len=kv_seq_len)
         kv_seq_len += layer_past[0].shape[1]
         # past_key, past_value = layer_past[0], layer_past[1]
         # key = torch.cat((past_key, key), dim=1)
         # value = torch.cat((past_value, value), dim=1)
         cache_k = layer_past[0].transpose(1, 2)
         cache_v = layer_past[1].transpose(1, 2)
-        enough_kv_room = is_enough_kv_cache_room_4_31(layer_past,
-                                                      seq_dim=1,
-                                                      seq_len=hidden_states.size()[1])
+
         if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,

--- a/python/llm/src/bigdl/llm/transformers/models/qwen_vl.py
+++ b/python/llm/src/bigdl/llm/transformers/models/qwen_vl.py
@@ -93,7 +93,6 @@ def qwen_attention_forward_vl(
         # value = torch.cat((past_value, value), dim=1)
         cache_k = layer_past[0].transpose(1, 2)
         cache_v = layer_past[1].transpose(1, 2)
-
         if not enough_kv_room:
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,

--- a/python/llm/src/bigdl/llm/transformers/models/qwen_vl.py
+++ b/python/llm/src/bigdl/llm/transformers/models/qwen_vl.py
@@ -89,7 +89,7 @@ def qwen_attention_forward_vl(
         # value = torch.cat((past_value, value), dim=1)
         cache_k = layer_past[0].transpose(1, 2)
         cache_v = layer_past[1].transpose(1, 2)
-        if cache_k.stride()[1] <= cache_k.size(2) * cache_k.size(3):
+        if cache_k.stride()[1] < (cache_k.size(2) + kv_seq_len) * cache_k.size(3):
             # allocate new
             new_cache_k, new_cache_v = extend_kv_cache(bsz,
                                                        self.num_heads,

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -194,17 +194,19 @@ def apply_rotary_pos_emb_cache_freq_xpu(q, k, sin, cos, model_family):
 
 def is_enough_kv_cache_room_4_36(past_key_value, idx, seq_len=1):
     # to determinate if is enough kv cache room in transformers==4.36
+    # seq_len for current seq
     return past_key_value is not None and len(past_key_value.key_cache) > idx and \
         past_key_value.key_cache[idx].stride()[1] > \
         (past_key_value.key_cache[idx].size(2) + seq_len - 1) * \
         past_key_value.key_cache[idx].size(3)
 
 
-def is_enough_kv_cache_room_4_31(past_key_value, seq_len=1):
+def is_enough_kv_cache_room_4_31(past_key_value, seq_dim=2, seq_len=1):
     # to determinate if is enough kv cache room in transformers between 4.31 and 4.35
+    # seq_len for current seq
     return past_key_value is not None and \
         past_key_value[0].stride()[1] > \
-        (past_key_value[0].size(2) + seq_len - 1) * past_key_value[0].size(3)
+        (past_key_value[0].size(seq_dim) + seq_len - 1) * past_key_value[0].size(3)
 
 
 def use_flash_attention(query, key):

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -197,8 +197,8 @@ def is_enough_kv_cache_room_4_36(past_key_value, idx, seq_len=1):
     # seq_len for current seq len
     # For llama like kv cache, i.e., [bs, n_head, seq_len, head_dim]
     return past_key_value is not None and len(past_key_value.key_cache) > idx and \
-        past_key_value.key_cache[idx].stride()[1] > \
-        (past_key_value.key_cache[idx].size(2) + seq_len - 1) * \
+        past_key_value.key_cache[idx].stride()[1] >= \
+        (past_key_value.key_cache[idx].size(2) + seq_len) * \
         past_key_value.key_cache[idx].size(3)
 
 
@@ -207,8 +207,8 @@ def is_enough_kv_cache_room_4_31(past_key_value, seq_len=1):
     # seq_len for current seq len
     # For llama like kv cache, i.e., [bs, n_head, seq_len, head_dim]
     return past_key_value is not None and \
-        past_key_value[0].stride()[1] > \
-        (past_key_value[0].size(2) + seq_len - 1) * past_key_value[0].size(3)
+        past_key_value[0].stride()[1] >= \
+        (past_key_value[0].size(2) + seq_len) * past_key_value[0].size(3)
 
 
 def use_flash_attention(query, key):

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -192,12 +192,12 @@ def apply_rotary_pos_emb_cache_freq_xpu(q, k, sin, cos, model_family):
                           f"{model_family} is not supported.")
 
 
-def is_enough_kv_cache_room_4_36(past_key_value, idx, seq_len=1):
+def is_enough_kv_cache_room_4_36(past_key_value, idx, seq_dim=2, seq_len=1):
     # to determinate if is enough kv cache room in transformers==4.36
     # seq_len for current seq
     return past_key_value is not None and len(past_key_value.key_cache) > idx and \
         past_key_value.key_cache[idx].stride()[1] > \
-        (past_key_value.key_cache[idx].size(2) + seq_len - 1) * \
+        (past_key_value.key_cache[idx].size(seq_dim) + seq_len - 1) * \
         past_key_value.key_cache[idx].size(3)
 
 

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -60,7 +60,7 @@ def append_kv_cache(cache_k, cache_v, key_states, value_states):
     new_cache_k = cache_k.as_strided(new_size, cache_k.stride(), storage_offset=0)
     new_cache_k[:, :, cache_k.size(2):cache_k.size(2) + key_states.size(2), :] = key_states
     new_cache_v = cache_v.as_strided(new_size, cache_v.stride(), storage_offset=0)
-    new_cache_v[:, :, cache_v.size(2):cache_k.size(2) + key_states.size(2), :] = value_states
+    new_cache_v[:, :, cache_v.size(2):cache_v.size(2) + key_states.size(2), :] = value_states
     return new_cache_k, new_cache_v
 
 

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -192,21 +192,23 @@ def apply_rotary_pos_emb_cache_freq_xpu(q, k, sin, cos, model_family):
                           f"{model_family} is not supported.")
 
 
-def is_enough_kv_cache_room_4_36(past_key_value, idx, seq_dim=2, seq_len=1):
+def is_enough_kv_cache_room_4_36(past_key_value, idx, seq_len=1):
     # to determinate if is enough kv cache room in transformers==4.36
-    # seq_len for current seq
+    # seq_len for current seq len
+    # For llama like kv cache, i.e., [bs, n_head, seq_len, head_dim]
     return past_key_value is not None and len(past_key_value.key_cache) > idx and \
         past_key_value.key_cache[idx].stride()[1] > \
-        (past_key_value.key_cache[idx].size(seq_dim) + seq_len - 1) * \
+        (past_key_value.key_cache[idx].size(2) + seq_len - 1) * \
         past_key_value.key_cache[idx].size(3)
 
 
-def is_enough_kv_cache_room_4_31(past_key_value, seq_dim=2, seq_len=1):
+def is_enough_kv_cache_room_4_31(past_key_value, seq_len=1):
     # to determinate if is enough kv cache room in transformers between 4.31 and 4.35
-    # seq_len for current seq
+    # seq_len for current seq len
+    # For llama like kv cache, i.e., [bs, n_head, seq_len, head_dim]
     return past_key_value is not None and \
         past_key_value[0].stride()[1] > \
-        (past_key_value[0].size(seq_dim) + seq_len - 1) * past_key_value[0].size(3)
+        (past_key_value[0].size(2) + seq_len - 1) * past_key_value[0].size(3)
 
 
 def use_flash_attention(query, key):


### PR DESCRIPTION
## Description

Avoid KV Cache OOM when seq len is larger than 1

### 1. Why the change?

Existing KV cache extend only handle seq=1, when seq > 1, KV cache storage may OOM.

### 2. User API changes

* For llama like kv cache, i.e., [bs, n_head, seq_len, head_dim], use is_enough_kv_cache_room_4_31.
* Other format need to check kv_len.

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
