### PR TITLE
[LLM] Disable llama2 `optimize_model=True` or `False` comparison for now in Arc UTs

### DIFF
--- a/python/llm/test/inference_gpu/test_transformers_api_disable_xmx.py
+++ b/python/llm/test/inference_gpu/test_transformers_api_disable_xmx.py
@@ -27,7 +27,8 @@ prompt = "Once upon a time, there existed a little girl who liked to have advent
 
 @pytest.mark.parametrize('Model, Tokenizer, model_path',[
     (AutoModelForCausalLM, AutoTokenizer, os.environ.get('MPT_7B_ORIGIN_PATH')),
-    (AutoModelForCausalLM, AutoTokenizer, os.environ.get('LLAMA2_7B_ORIGIN_PATH'))
+    # (AutoModelForCausalLM, AutoTokenizer, os.environ.get('LLAMA2_7B_ORIGIN_PATH')),
+    (AutoModelForCausalLM, AutoTokenizer, os.environ.get('FALCON_7B_ORIGIN_PATH')),
     ])
 def test_optimize_model(Model, Tokenizer, model_path):
     with torch.inference_mode():


### PR DESCRIPTION
## Description

https://github.com/analytics-zoo/nano/issues/1007