### PR TITLE
Fix "local variable 'model' referenced before assignment" for GGUF Mixtral

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/gguf/models/mixtral.py
+++ b/python/llm/src/bigdl/llm/transformers/gguf/models/mixtral.py
@@ -59,6 +59,7 @@ def load_gguf_mixtral(loader: GGUFFileLoader, dtype: torch.dtype = torch.float,
 
     # define an operator function that passed to low-level gguf API
     def process_mixtral(name, tensor):
+        nonlocal model
         # prepare module's name in transformers
         module_name = get_mixtral_module_name(name)
         # prepare module's weight in transformers


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

This submission is to fix the error when loading Mixtral-8x7B-Instruct-v0.1_q4_0.gguf 
`UnboundLocalError: local variable 'model' referenced before assignment`

After this fix, the output is 
<img width="763" alt="image" src="https://github.com/intel-analytics/BigDL/assets/61072813/242c9e93-8a05-422f-a2b7-7a86d8622901">
