### PR TITLE
xetla mmint4

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -75,6 +75,56 @@ IQ2_XS = ggml_tensor_qtype["gguf_iq2_xs"]
 Q2_K = ggml_tensor_qtype["q2_k"]
 
 
+# The ggml_weight is col major and packs two rows at a stride of Q4_0//2.
+#
+# The returning weight is row major and packs two rows at a stride of 16//2.
+# 16 is the tile_size_y used in mm_int4, so that we can do something like
+# new_weight_tile = concat(weight_tile & 0x0F, weight_tile >> 4).
+#
+# A more complex packing strategy is to permute the weight so that the
+# new_weight_tile is directly VNNI packed, but I did not find significant
+# performance improvement.
+#
+# Note this format cannot be used directly in IPEX's mm_int4, which expects
+# row major but packing two consecutive columns.
+def q4_0_xpu_transpose(ggml_weight, weight_shape):
+    from bigdl.llm.transformers.low_bit_linear import get_block_size
+    Q4_0 = get_block_size("sym_int4")
+
+    n, k = weight_shape
+    ggml_weight_only = ggml_weight[:n*k//2]
+    ggml_scales = ggml_weight[n*k//2:]
+
+    qweight = ggml_weight_only.clone()
+    scales = ggml_scales.view(torch.float16).clone()
+
+    qweight_0 = qweight & 0x0F
+    qweight_1 = qweight >> 4
+
+    qweight_0 = qweight_0.reshape(n, -1, Q4_0//2)
+    qweight_1 = qweight_1.reshape(n, -1, Q4_0//2)
+    qweight = torch.cat([qweight_0, qweight_1], dim=-1)
+    qweight = qweight.reshape(n, k//16, 2, 8)
+    qweight = qweight.bitwise_left_shift(
+        torch.tensor([0, 4], dtype=torch.uint8, device=ggml_weight.device).reshape(1, 1, 2, 1))
+
+    qweight = torch.bitwise_or(qweight[:, :, 0, :], qweight[:, :, 1, :])
+    qweight = qweight.reshape(n, k//2)
+    qweight = qweight.transpose(0, 1).contiguous()
+
+    scales = scales.reshape(n, k//Q4_0).transpose(0, 1).contiguous()
+
+    # 119 is the value of 0x77
+    zeros = torch.ones([k//Q4_0, n//2], dtype=torch.uint8, device=ggml_weight.device) * (119)
+
+    qweight_bytes = qweight.view(torch.uint8).view(-1)
+    scales_bytes = scales.view(torch.uint8).view(-1)
+    zeros_bytes = zeros.view(torch.uint8).view(-1)
+
+    weight = torch.concat([qweight_bytes, zeros_bytes, scales_bytes], dim=0)
+    return weight
+
+
 def get_block_size(qtype: str):
     return ggml.ggml_qk_size(ggml_tensor_qtype[qtype])
 
@@ -208,7 +258,8 @@ class FP4Params(torch.nn.Parameter):
                 convert_shape_only=False,
                 qtype=None,
                 imatrix=None,
-                in_features=None):
+                in_features=None,
+                enable_xetla=False,):
         if data is None:
             data = torch.empty(0)
 
@@ -220,6 +271,7 @@ class FP4Params(torch.nn.Parameter):
         self.convert_shape_only = convert_shape_only
         self.imatrix = imatrix
         self.in_features = in_features
+        self.enable_xetla = enable_xetla
         return self
 
     def ggml_mse(self, w, ggml_qtype, device):
@@ -308,13 +360,20 @@ class FP4Params(torch.nn.Parameter):
             self.data = ggml_q_format_convet_cpu2xpu(self.data,
                                                      reduce(mul, self._shape, 1),
                                                      self.qtype)
+            if self.enable_xetla:
+                self.data = q4_0_xpu_transpose(self.data, self._shape)
             new_param = FP4Params(super().to(device=device,
                                              dtype=dtype,
                                              non_blocking=non_blocking),
                                   requires_grad=self.requires_grad,
                                   quantized=self.quantized,
                                   _shape=self._shape,
-                                  qtype=self.qtype)
+                                  qtype=self.qtype,
+                                  enable_xetla=self.enable_xetla)
+            if self.enable_xetla:
+                device_type = get_xpu_device_type(new_param.data)
+                invalidInputError(device_type == "pvc",
+                                  f"xetla is only supported on PVC, but got {device_type}")
             return new_param
         elif (device is not None and device.type == "cpu" and self.data.device.type == "xpu"):
             new_param = FP4Params(super().to(device=device,
@@ -323,7 +382,11 @@ class FP4Params(torch.nn.Parameter):
                                   requires_grad=self.requires_grad,
                                   quantized=self.quantized,
                                   _shape=self._shape,
-                                  qtype=self.qtype)
+                                  qtype=self.qtype,
+                                  enable_xetla=self.enable_xetla)
+            if self.enable_xetla:
+                invalidInputError(False,
+                                  "xetla is not supported on CPUs but got enable_xetla=True")
             new_param.data = ggml_q_format_convet_xpu2cpu(new_param.data,
                                                           reduce(mul, new_param._shape, 1),
                                                           new_param.qtype)
@@ -335,7 +398,8 @@ class FP4Params(torch.nn.Parameter):
                                   requires_grad=self.requires_grad,
                                   quantized=self.quantized,
                                   _shape=self._shape,
-                                  qtype=self.qtype)
+                                  qtype=self.qtype,
+                                  enable_xetla=self.enable_xetla)
             return new_param
 
 
@@ -441,11 +505,12 @@ class MatMulLowBitCPU(torch.autograd.Function):
 
 class LowBitLinear(nn.Linear):
     def __init__(self, input_features, output_features, qtype, bias=True,
-                 conver_to_half=True, mp_group=None):
+                 conver_to_half=True, mp_group=None, enable_xetla=False):
         super().__init__(input_features, output_features, bias)
         self.weight = FP4Params(self.weight.data,
                                 requires_grad=False,
-                                quantized=False, _shape=None, qtype=qtype)
+                                quantized=False, _shape=None, qtype=qtype,
+                                enable_xetla=enable_xetla)
         self.in_len = input_features
         self.out_len = output_features
         self.weight_shape = (self.out_len, self.in_len)
@@ -454,6 +519,7 @@ class LowBitLinear(nn.Linear):
         self.conver_to_half = conver_to_half
         self.mp_group = mp_group
         self.compute_dtype = None  # only for training
+        self.enable_xetla = enable_xetla
 
     def forward(self, x: torch.Tensor):
         # Due to inconsistent training status in some models like Baichuan-7b-Chat,
@@ -510,6 +576,9 @@ class LowBitLinear(nn.Linear):
                     result = linear_q4_0.forward_new(x_2d, self.weight.data,
                                                      self.weight.qtype,
                                                      input_seq_size)
+            elif self.enable_xetla:
+                x_2d = x_2d.half()
+                result = linear_q4_0.mm_int4(x_2d, self.weight.data)
             else:
                 # inference path
                 # current workaround to reduce first token latency of fp32 input

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -358,6 +358,7 @@ class _BaseAutoModelClass:
         embedding_qtype = kwargs.pop("embedding_qtype", None)
         if embedding_qtype is not None:
             embedding_qtype = ggml_tensor_qtype[embedding_qtype]
+        enable_xetla = kwargs.pop("enable_xetla", False)
         _args = copy.deepcopy(args)
         _kwargs = copy.deepcopy(kwargs)
         awq_config = None
@@ -421,7 +422,8 @@ class _BaseAutoModelClass:
                                      cpu_embedding=cpu_embedding, lightweight_bmm=lightweight_bmm,
                                      torch_dtype=kwargs.get("torch_dtype", 'auto'),
                                      imatrix_data=imatrix_data,
-                                     embedding_qtype=embedding_qtype)
+                                     embedding_qtype=embedding_qtype,
+                                     enable_xetla=enable_xetla,)
         model.config.update({"bigdl_transformers_low_bit": q_k})
 
         # enable tie_word_embeddings for MPT

--- a/python/llm/src/bigdl/llm/transformers/models/baichuan2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/baichuan2.py
@@ -73,7 +73,7 @@ def baichuan_mlp_forward(
 ) -> torch.Tensor:
     x_2d = x.view(-1, x.shape[-1])
     qtype = getattr(self.gate_proj, "qtype", None)
-    if mlp_fusion_check(x_2d, qtype, self.training):
+    if mlp_fusion_check(x_2d, qtype, self.training) and not self.down_proj.enable_xetla:
         import linear_q4_0
         if not x_2d.is_contiguous():
             x_2d = x_2d.contiguous()

--- a/python/llm/src/bigdl/llm/transformers/models/mistral.py
+++ b/python/llm/src/bigdl/llm/transformers/models/mistral.py
@@ -140,6 +140,7 @@ def mistral_attention_forward(
                                                 use_fuse_rope,
                                                 enough_kv_room,
                                                 bsz * q_len)
+    decoding_fast_path = decoding_fast_path and not self.q_proj.enable_xetla
 
     if decoding_fast_path:
         hidden_states = hidden_states.view(1, -1)
@@ -288,6 +289,7 @@ def mistral_attention_forward_4_36(
                                                 use_fuse_rope,
                                                 enough_kv_room,
                                                 bsz * q_len)
+    decoding_fast_path = decoding_fast_path and not self.q_proj.enable_xetla
 
     if decoding_fast_path:
         hidden_states = hidden_states.view(1, -1)

--- a/python/llm/src/bigdl/llm/transformers/models/mixtral.py
+++ b/python/llm/src/bigdl/llm/transformers/models/mixtral.py
@@ -153,6 +153,7 @@ def mixtral_attention_forward(
                                                 use_fuse_rope,
                                                 enough_kv_room,
                                                 bsz * q_len)
+    decoding_fast_path = decoding_fast_path and not self.q_proj.enable_xetla
 
     if decoding_fast_path:
         hidden_states = hidden_states.view(1, -1)
@@ -330,7 +331,7 @@ def mixtral_mlp_forward(
     routing_weights
 ) -> torch.Tensor:
     qtype = getattr(self.w1, "qtype", None)
-    if mlp_fusion_check(x, qtype, self.training):
+    if mlp_fusion_check(x, qtype, self.training) and not self.w1.enable_xetla:
         import linear_q4_0
         return self.w2(linear_q4_0.mlp_forward_xpu(
             x, self.w1.weight.data, self.w3.weight.data,

--- a/python/llm/src/bigdl/llm/transformers/models/qwen.py
+++ b/python/llm/src/bigdl/llm/transformers/models/qwen.py
@@ -285,7 +285,7 @@ def core_attn(self, query, key, value, causal_mask=None, attention_mask=None, he
 def qwen_mlp_forward(self, x: torch.Tensor) -> torch.Tensor:
     x_2d = x.view(-1, x.shape[-1])
     qtype = getattr(self.w1, "qtype", None)
-    if mlp_fusion_check(x_2d, qtype, self.training):
+    if mlp_fusion_check(x_2d, qtype, self.training) and not self.w1.enable_xetla:
         import linear_q4_0
         if not x_2d.is_contiguous():
             x_2d = x_2d.contiguous()


### PR DESCRIPTION
## Description

Use experimental mm_int4 implementation based on xetla to enhance batch inference

### 1. Why the change?

Enhance performance for batch inference

### 2. User API changes
Added `enable_xetla` to `from_pretrained`, currently only support `sym_int4`.
```python
    model = AutoModelForCausalLM.from_pretrained(model_path,
                                                 load_in_low_bit='sym_int4',
                                                 trust_remote_code=True,
                                                 use_cache=True,
                                                 torch_dtype=torch.float16,
                                                 enable_xetla=False,
                                                 )
```

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

1. added `enable_xetla` to `from_pretrained`
2. if `enable_xetla` is set to `True`, when `model.to("xpu")` is called, function `q4_0_xpu_transpose` will be applied to all `LowBitLinear` weights.
3. if `enable_xetla` is set to `True`, `LowBitLinear` will use `linear_q4_0.mm_int4` to compute result.

### 4. How to test?
manually tested on llama-7b and llama-13b

### 5. New dependencies

xetla is introduced in llm.cpp
