### PR TITLE
[WebUI] Add prompt format and stopping words for Qwen

### DIFF
--- a/python/llm/example/Text-Generation-WebUI/modules/callbacks.py
+++ b/python/llm/example/Text-Generation-WebUI/modules/callbacks.py
@@ -43,14 +43,13 @@ class _StopEverythingStoppingCriteria(transformers.StoppingCriteria):
 
 class StopWordsCriteria(transformers.StoppingCriteria):
     """Custom `StoppingCriteria` which checks if all generated functions in the batch are completed."""
-    def __init__(self, input_length, stop_words, tokenizer):
-        self.input_length = input_length
+    def __init__(self, stop_words, tokenizer):
         self.stop_words = stop_words
         self.tokenizer = tokenizer
 
     def __call__(self, input_ids, scores, **kwargs):
         """Returns true if all generated sequences contain any of the end-of-function strings."""
-        texts =  [self.tokenizer.decode(input_ids[-1][-1]) for ids in input_ids]
+        texts =  [self.tokenizer.decode(input_ids[-1][-1])]
         dones = [any(stop_word in texts for stop_word in self.stop_words)]
         return all(dones)
 

--- a/python/llm/example/Text-Generation-WebUI/modules/callbacks.py
+++ b/python/llm/example/Text-Generation-WebUI/modules/callbacks.py
@@ -50,8 +50,8 @@ class StopWordsCriteria(transformers.StoppingCriteria):
 
     def __call__(self, input_ids, scores, **kwargs):
         """Returns true if all generated sequences contain any of the end-of-function strings."""
-        texts =  [ self.tokenizer.decode(ids[self.input_length:]) for ids in input_ids ]
-        dones = [ any(stop_word in text for stop_word in self.stop_words) for text in texts ]
+        texts =  [self.tokenizer.decode(ids[-1]) for ids in input_ids]
+        dones = [any(stop_word in texts for stop_word in self.stop_words)]
         return all(dones)
 
 

--- a/python/llm/example/Text-Generation-WebUI/modules/callbacks.py
+++ b/python/llm/example/Text-Generation-WebUI/modules/callbacks.py
@@ -50,7 +50,7 @@ class StopWordsCriteria(transformers.StoppingCriteria):
 
     def __call__(self, input_ids, scores, **kwargs):
         """Returns true if all generated sequences contain any of the end-of-function strings."""
-        texts =  [self.tokenizer.decode(ids[-1]) for ids in input_ids]
+        texts =  [self.tokenizer.decode(input_ids[-1][-1]) for ids in input_ids]
         dones = [any(stop_word in texts for stop_word in self.stop_words)]
         return all(dones)
 

--- a/python/llm/example/Text-Generation-WebUI/modules/callbacks.py
+++ b/python/llm/example/Text-Generation-WebUI/modules/callbacks.py
@@ -41,6 +41,20 @@ class _StopEverythingStoppingCriteria(transformers.StoppingCriteria):
         return shared.stop_everything
 
 
+class StopWordsCriteria(transformers.StoppingCriteria):
+    """Custom `StoppingCriteria` which checks if all generated functions in the batch are completed."""
+    def __init__(self, input_length, stop_words, tokenizer):
+        self.input_length = input_length
+        self.stop_words = stop_words
+        self.tokenizer = tokenizer
+
+    def __call__(self, input_ids, scores, **kwargs):
+        """Returns true if all generated sequences contain any of the end-of-function strings."""
+        texts =  [ self.tokenizer.decode(ids[self.input_length:]) for ids in input_ids ]
+        dones = [ any(stop_word in text for stop_word in self.stop_words) for text in texts ]
+        return all(dones)
+
+
 class Stream(transformers.StoppingCriteria):
     def __init__(self, callback_func=None):
         self.callback_func = callback_func

--- a/python/llm/example/Text-Generation-WebUI/modules/callbacks.py
+++ b/python/llm/example/Text-Generation-WebUI/modules/callbacks.py
@@ -49,9 +49,8 @@ class StopWordsCriteria(transformers.StoppingCriteria):
 
     def __call__(self, input_ids, scores, **kwargs):
         """Returns true if all generated sequences contain any of the end-of-function strings."""
-        texts =  [self.tokenizer.decode(input_ids[-1][-1])]
-        dones = [any(stop_word in texts for stop_word in self.stop_words)]
-        return all(dones)
+        text =  self.tokenizer.decode(input_ids[-1][-1])
+        return text in self.stop_words
 
 
 class Stream(transformers.StoppingCriteria):

--- a/python/llm/example/Text-Generation-WebUI/modules/text_generation.py
+++ b/python/llm/example/Text-Generation-WebUI/modules/text_generation.py
@@ -366,16 +366,12 @@ def generate_reply_HF(question, original_question, seed, state, stopping_strings
 
     if shared.model.config.model_type == "qwen":
         stopping_words = ["<|endoftext|>", "<|im_end|>", "<|im_start|>"]
-        generate_params['stopping_criteria'].append(StopWordsCriteria(len(input_ids[0]),
-                                                    stopping_words,
-                                                    shared.tokenizer))
+        generate_params['stopping_criteria'].append(StopWordsCriteria(stopping_words, shared.tokenizer))
 
     for st in state['custom_stopping_strings']:
         if type(st) is str:
             stopping_words = [item.strip().strip('"') for item in [state['custom_stopping_strings']][0].split(',')]
-            generate_params['stopping_criteria'].append(StopWordsCriteria(len(input_ids[0]),
-                                                        stopping_words,
-                                                        shared.tokenizer))
+            generate_params['stopping_criteria'].append(StopWordsCriteria(stopping_words, shared.tokenizer))
 
 
     # Logits processor

--- a/python/llm/example/Text-Generation-WebUI/modules/text_generation.py
+++ b/python/llm/example/Text-Generation-WebUI/modules/text_generation.py
@@ -11,7 +11,7 @@
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
-# limitations under the License.
+# limitations under the License. 
 
 # This file is adapted from
 # https://github.com/oobabooga/text-generation-webui/blob/main/modules/text_generation.py
@@ -35,7 +35,8 @@ import modules.shared as shared
 from modules.callbacks import (
     Iteratorize,
     Stream,
-    _StopEverythingStoppingCriteria
+    _StopEverythingStoppingCriteria,
+    StopWordsCriteria
 )
 from modules.extensions import apply_extensions
 from modules.grammar.grammar_utils import initialize_grammar
@@ -331,6 +332,19 @@ def generate_reply_HF(question, original_question, seed, state, stopping_strings
     if shared.args.deepspeed:
         generate_params.update({'synced_gpus': True})
 
+    #tune the prompt based on qwen
+    QWEN_PROMPT_FORMAT = """
+    <|im_start|>system
+    You are a helpful assistant.
+    <|im_end|>
+    <|im_start|>user
+    {prompt}
+    <|im_end|>
+    <|im_start|>assistant
+    """
+    if shared.model.config.model_type == "qwen":
+        question = QWEN_PROMPT_FORMAT.format(prompt=question)
+
     # Encode the input
     input_ids = encode(question, add_bos_token=state['add_bos_token'], truncation_length=get_max_prompt_length(state))
     output = input_ids[0]
@@ -346,10 +360,23 @@ def generate_reply_HF(question, original_question, seed, state, stopping_strings
         generate_params.update({'inputs_embeds': inputs_embeds})
 
     # Stopping criteria / eos token
+    generate_params['stopping_criteria'] = transformers.StoppingCriteriaList()
     eos_token_ids = [shared.tokenizer.eos_token_id] if shared.tokenizer.eos_token_id is not None else []
     generate_params['eos_token_id'] = eos_token_ids
-    generate_params['stopping_criteria'] = transformers.StoppingCriteriaList()
-    generate_params['stopping_criteria'].append(_StopEverythingStoppingCriteria())
+
+    if shared.model.config.model_type == "qwen":
+        stopping_words = ["<|endoftext|>", "<|im_end|>", "<|im_start|>"]
+        generate_params['stopping_criteria'].append(StopWordsCriteria(len(input_ids[0]),
+                                                    stopping_words,
+                                                    shared.tokenizer))
+
+    for st in state['custom_stopping_strings']:
+        if type(st) is str:
+            stopping_words = [item.strip().strip('"') for item in [state['custom_stopping_strings']][0].split(',')]
+            generate_params['stopping_criteria'].append(StopWordsCriteria(len(input_ids[0]),
+                                                        stopping_words,
+                                                        shared.tokenizer))
+
 
     # Logits processor
     processor = state.get('logits_processor', LogitsProcessorList([]))


### PR DESCRIPTION
## Description

This PR adds support for prompt format and stopping words to the Qwen model, enabling correct output on the webUI. It also introduces the ability to specify stopping words for other models through the `custom_stopping_words` option.

### 1. Why the change?

Qwen model requires a prompt format to generate output correctly, and it also needs stopping words to halt the output when generation is complete.

### 2. User API changes
N/A

### 3. Summary of the change 
- Add prompt format for Qwen
- Add stopping words for Qwen
- Add `StopWordsCriteria` class for users to set stopping words manually through `custom_stopping_words` option.

### 4. How to test?
- [x] Application test
