### PR TITLE
LLM: fix mpt load_low_bit issue

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -362,7 +362,8 @@ class _BaseAutoModelClass:
                                      torch_dtype=kwargs.get("torch_dtype", 'auto'))
         model.config.update({"bigdl_transformers_low_bit": q_k})
 
-        # force enable tie_word_embeddings for MPT due to https://huggingface.co/mosaicml/mpt-7b-chat/blob/main/modeling_mpt.py#L232
+        # enable tie_word_embeddings for MPT
+        # refer to https://huggingface.co/mosaicml/mpt-7b-chat/blob/main/modeling_mpt.py#L232
         if model.config.architectures[0] != 'MPTForCausalLM':
             model.config.update({"tie_word_embeddings": False})
 

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -362,7 +362,7 @@ class _BaseAutoModelClass:
                                      torch_dtype=kwargs.get("torch_dtype", 'auto'))
         model.config.update({"bigdl_transformers_low_bit": q_k})
 
-        # disable tie_word_embeddings for MPT due to https://huggingface.co/mosaicml/mpt-7b-chat/blob/main/modeling_mpt.py#L232
+        # force enable tie_word_embeddings for MPT due to https://huggingface.co/mosaicml/mpt-7b-chat/blob/main/modeling_mpt.py#L232
         if model.config.architectures[0] != 'MPTForCausalLM':
             model.config.update({"tie_word_embeddings": False})
 

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -361,7 +361,10 @@ class _BaseAutoModelClass:
                                      cpu_embedding=cpu_embedding, lightweight_bmm=lightweight_bmm,
                                      torch_dtype=kwargs.get("torch_dtype", 'auto'))
         model.config.update({"bigdl_transformers_low_bit": q_k})
-        model.config.update({"tie_word_embeddings": False})
+
+        # disable tie_word_embeddings for MPT due to https://huggingface.co/mosaicml/mpt-7b-chat/blob/main/modeling_mpt.py#L232
+        if model.config.architectures[0] != 'MPTForCausalLM':
+            model.config.update({"tie_word_embeddings": False})
 
         # add save_low_bit to pretrained model dynamically
         import types


### PR DESCRIPTION
https://github.com/analytics-zoo/nano/issues/948

Enable `tie_word_embeddings` when save mpt model. Otherwise, mpt that saved with `save_low_bit` cannot run normally.

This may because [MPT model requires tie_word_embeddings=True](https://huggingface.co/mosaicml/mpt-7b-chat/blob/main/modeling_mpt.py#L232) while we [manually save this variable as False when saving low bit models](https://github.com/intel-analytics/BigDL/pull/8977/files).