### PR TITLE
LLM: support speecht5_tts

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -238,6 +238,9 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                             new_linear._parameters['bias'] = nn.Parameter(module.bias.data)\
                                 .to(device)
                     elif qtype not in [ggml_tensor_qtype["fp16"], ggml_tensor_qtype["bf16"]]:
+                        if in_features % 64 != 0:
+                            # now our kernel requires in_features is a multiple of 64
+                            continue
                         new_linear = LowBitLinear(
                             in_features,
                             out_features,

--- a/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
+++ b/python/llm/src/bigdl/llm/transformers/low_bit_linear.py
@@ -478,7 +478,11 @@ class LowBitLinear(nn.Linear):
             if x_2d.is_contiguous() is False:
                 x_2d = x_2d.contiguous()
 
-            input_seq_size = x_shape[1]
+            if len(x_shape) == 3:
+                input_seq_size = x_shape[1]
+            elif len(x_shape) < 3:
+                input_seq_size = 1
+
             if is_training:
                 # training path
                 if x_2d.requires_grad:

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -619,6 +619,3 @@ class AutoModelForMultipleChoice(_BaseAutoModelClass):
 
 class AutoModelForTokenClassification(_BaseAutoModelClass):
     HF_Model = transformers.AutoModelForTokenClassification
-
-class AutoModelForTextToSpeech(_BaseAutoModelClass):
-    HF_Model = transformers.AutoModelForTextToSpeech   

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -619,3 +619,6 @@ class AutoModelForMultipleChoice(_BaseAutoModelClass):
 
 class AutoModelForTokenClassification(_BaseAutoModelClass):
     HF_Model = transformers.AutoModelForTokenClassification
+
+class AutoModelForTextToSpeech(_BaseAutoModelClass):
+    HF_Model = transformers.AutoModelForTextToSpeech   


### PR DESCRIPTION
## Description


### 1. Why the change?

To support speecht5_xxs in bigdl-llm GPU.

### 2. User API changes

now running below code, speecht5_xxs can run on Intel GPUs by using bigdl-llm:
```python
import torch
import intel_extension_for_pytorch as ipex
from transformers import SpeechT5Processor, SpeechT5HifiGan, SpeechT5ForTextToSpeech
from datasets import load_dataset
import soundfile as sf
from datasets import load_dataset
import time

processor = SpeechT5Processor.from_pretrained("microsoft/speecht5_tts")
model = SpeechT5ForTextToSpeech.from_pretrained("microsoft/speecht5_tts")
vocoder = SpeechT5HifiGan.from_pretrained("microsoft/speecht5_hifigan")

from bigdl.llm import optimize_model
model = optimize_model(model, modules_to_not_convert=["speech_decoder_postnet.feat_out",
                                                      "speech_decoder_postnet.prob_out"]) 
model = model.to('xpu')

inputs = processor(text="Hello, my dog is cute.", return_tensors="pt").to('xpu')

# load xvector containing speaker's voice characteristics from a dataset
embeddings_dataset = load_dataset("Matthijs/cmu-arctic-xvectors",
                                  split="validation")
speaker_embeddings = torch.tensor(embeddings_dataset[7306]["xvector"]).unsqueeze(0)

# wamrup 
speech = model.generate_speech(inputs["input_ids"].to('xpu'), speaker_embeddings.to('xpu'), vocoder=vocoder.to('xpu'))

st1 = time.perf_counter()
speech = model.generate_speech(inputs["input_ids"].to('xpu'), speaker_embeddings.to('xpu'), vocoder=vocoder.to('xpu'))
st2 = time.perf_counter()

sf.write("speech_bigdl.wav", speech.to('cpu').numpy(), samplerate=16000)
```

### 3. Summary of the change 

- Fix shape logic in GPU code
- Skip quantizing Lineat layer which in_features is not multiple of 64, if we support this later, can remove this condition later
- Accuracy tunning, I found that skip quantizing `prob_out` / `feat_out` can provide better output audio

### 4. How to test?
- [x] Unit test
- [x] Local test of speecht5_tts on GPU

