### PR TITLE
LLM: Update ppl tests

### DIFF
--- a/python/llm/dev/benchmark/perplexity/README.md
+++ b/python/llm/dev/benchmark/perplexity/README.md
@@ -2,12 +2,19 @@
 Perplexity (PPL) is one of the most common metrics for evaluating language models. This benchmark implementation was from [transformers/perplexity](https://huggingface.co/docs/transformers/perplexity#perplexity-of-fixed-length-models) and [benchmark_patch_llm.py](https://github.com/insuhan/hyper-attn/blob/main/benchmark_patch_llm.py) 
 
 ## HOW TO RUN
-```python
-python run.py --model_path <path/to/model> --precisions sym_int4 fp4 mixed_fp4 sym_int8 fp8_e5m2 fp8_e4m3 mixed_fp8 --device xpu --datasets dataset_name --dataset_path <path/to/dataset> --language en
+```bash
+python run.py --model_path <path/to/model> --precisions sym_int4 fp4 mixed_fp4 sym_int8 fp8_e5m2 fp8_e4m3 mixed_fp8 --device xpu --datasets dataset_names --dataset_path <path/to/dataset> --language en
 ```
 A more specific example to run perplexity on Llama2-7B using the default English datasets:
-```python
-python run.py --model_path meta-llama/Llama-2-7b-chat-hf --precisions float16 sym_int4 --device xpu 
+```bash
+python run.py --model_path meta-llama/Llama-2-7b-chat-hf --precisions float16 sym_int4 --device xpu --language en
 ```
 
-> Note: If you want to test perplexity on your own dataset, please include both the `datasets` and `dataset_path` arguments in your command. We recommend using the `THUDM/LongBench` dataset for testing. If you want to test perplexity on pre-downloaded `THUDM/LongBench` dataset, please specify the `<path/to/LongBench>` in the `dataset_path` argument. The default testing datasets are English datasets, if you want to use the Chinese datasets, please specify in the `language` argument.
+> Note: We currently only support the `THUDM/LongBench` [dataset](https://github.com/THUDM/LongBench)
+
+- If you want to test model perplexity on a few selected datasets from the `LongBench` dataset, please use the format below.
+  ```bash
+  --datasets narrativeqa qasper ...
+  ```
+- The `language` argument will only take effect if `datasets` is `None`. The choices for this argument are `en, zh, all`, which stands for all the English datasets, all the Chinese datasets and all the datasets respectively during testing.
+- If you want to test perplexity on pre-downloaded datasets, please specify the `<path/to/dataset>` in the `dataset_path` argument in your command.

--- a/python/llm/dev/benchmark/perplexity/ppl.py
+++ b/python/llm/dev/benchmark/perplexity/ppl.py
@@ -28,17 +28,12 @@ class BigDLPPL:
         model_kwargs['optimize_model'] = model_kwargs.get('optimize_model', True)
         self.device = device
 
-        try:
-            if 'chatglm' in model_path.lower():
-                self.model = AutoModel.from_pretrained(model_path, **model_kwargs)
-            else:
-                self.model = AutoModelForCausalLM.from_pretrained(model_path, **model_kwargs)
-            self.model.to(device)
-        except RuntimeError:
-            torch.xpu.synchronize()
-            torch.xpu.empty_cache()
-            del self.model
-            gc.collect()
+        if 'chatglm' in model_path.lower():
+            self.model = AutoModel.from_pretrained(model_path, **model_kwargs)
+        else:
+            self.model = AutoModelForCausalLM.from_pretrained(model_path, **model_kwargs)
+        self.model.to(device)
+
 
     def perplexity_hf(self, encoded_texts):
         self.model.eval()

--- a/python/llm/dev/benchmark/perplexity/run.py
+++ b/python/llm/dev/benchmark/perplexity/run.py
@@ -22,7 +22,6 @@ from transformers import AutoTokenizer
 
 from ppl import BigDLPPL
 from bigdl.llm.ggml.quantize import ggml_tensor_qtype
-from bigdl.llm.transformers import AutoModelForCausalLM, AutoModel
 
 import os
 
@@ -30,9 +29,9 @@ def get_arguments():
     parser = argparse.ArgumentParser()
     parser.add_argument("--seq_len", type=int, default=512)
     parser.add_argument("--model_path", required=True, type=str)
-    parser.add_argument("--datasets", required=False, type=str, default=None)
+    parser.add_argument("--datasets", required=False, type=str, default=None, nargs='*')
     parser.add_argument("--dataset_path", required=False, type=str, default=None)
-    parser.add_argument("--language", required=False, type=str, default="en")
+    parser.add_argument("--language", required=False, type=str, default="en", choices=['en', 'zh', 'all'])
     parser.add_argument("--precisions", required=False, type=str, default=None, nargs='+')
     parser.add_argument("--device", type=str, default="xpu")
     return parser.parse_args()
@@ -47,21 +46,26 @@ def main():
     tokenizer = AutoTokenizer.from_pretrained(args.model_path, trust_remote_code=True)
     tokenizer.model_max_length = args.seq_len
 
-    if args.datasets is None:
-        en_datasets = ["narrativeqa", "qasper", "multifieldqa_en", "hotpotqa", "2wikimqa", "musique", "gov_report", 
+    en_datasets = ["narrativeqa", "qasper", "multifieldqa_en", "hotpotqa", "2wikimqa", "musique", "gov_report", 
                        "qmsum", "multi_news",  "trec", "triviaqa", "samsum", "passage_count", "passage_retrieval_en"]
-        zh_datasets = ["multifieldqa_zh", "dureader", "vcsum", "lsht", "passage_retrieval_zh"]
+    zh_datasets = ["multifieldqa_zh", "dureader", "vcsum", "lsht", "passage_retrieval_zh"]
 
-        # The default testing datasets are English datasets
-        datasets = en_datasets if args.language == "en" else zh_datasets
-        dataset_all = []
-        for dataset_name in datasets:
-            data_ = load_dataset(os.path.join(args.dataset_path, dataset_name), split='test') if args.dataset_path \
-                    else load_dataset('THUDM/LongBench', f'{dataset_name}', split='test')
-            dataset_all.append(data_)
-        data = concatenate_datasets(dataset_all)
+    if args.datasets is None:
+        if args.language == 'en':
+            datasets = en_datasets
+        elif args.language == 'zh':
+            datasets = zh_datasets
+        else:
+            datasets = en_datasets + zh_datasets
     else:
-        data = load_dataset(args.dataset_path, split='test')
+        datasets = args.datasets
+
+    dataset_all = []
+    for dataset_name in datasets:
+        data_ = load_dataset(os.path.join(args.dataset_path, dataset_name), split='test') if args.dataset_path \
+                else load_dataset('THUDM/LongBench', f'{dataset_name}', split='test')
+        dataset_all.append(data_)
+    data = concatenate_datasets(dataset_all)
 
     encoded_texts = []
     pbar = tqdm(data)


### PR DESCRIPTION
Since the old testing code can't get normal perplexity results for `chatglm2`, we now instead employ a new method for calculating perplexity, which can obtain more reasonable results. The code is based on [benchmark_patch_llm.py](https://github.com/insuhan/hyper-attn/blob/main/benchmark_patch_llm.py)