### PR TITLE
LLM: support models hosted by modelscope

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -124,16 +124,26 @@ class _BaseAutoModelClass:
         :param imatrix: str value, represent filename of importance matrix pretrained on
             specific datasets for use with the improved quantization methods recently
             added to llama.cpp.
+        :param model_hub: str value, options are ``'huggingface'`` and ``'modelscope'``,
+            specify the model hub. Default to be ``'huggingface'``.
         :return: a model instance
         """
         pretrained_model_name_or_path = kwargs.get("pretrained_model_name_or_path", None) \
             if len(args) == 0 else args[0]
-        try:
+        model_hub = kwargs.pop("model_hub", "huggingface")
+        invalidInputError(model_hub in ["huggingface", "modelscope"],
+                          "The parameter `model_hub` is supposed to be `huggingface` or "
+                          f"`modelscope`, but got {model_hub}.")
+        if model_hub == "huggingface":
+            config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
+        elif model_hub == "modelscope":
+            warnings.warn("The model hub is specified to be modelscope, "
+                          "please make sure you have installed it.")
             import modelscope
+            from modelscope.utils.hf_util import get_wrapped_class
+            cls.HF_Model = get_wrapped_class(cls.HF_Model)
             from .utils import get_modelscope_hf_config
             config_dict, _ = get_modelscope_hf_config(pretrained_model_name_or_path)
-        except ImportError:
-            config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
         bigdl_transformers_low_bit = config_dict.pop("bigdl_transformers_low_bit", False)
         invalidInputError(not bigdl_transformers_low_bit,
                           f"Detected model is a low-bit({bigdl_transformers_low_bit}) model, "
@@ -402,6 +412,8 @@ class _BaseAutoModelClass:
         :param pretrained_model_name_or_path: str value, Path to load the optimized model ckpt.
         :param optimize_model: boolean value, Whether to further optimize the low_bit llm model.
                                Default to be True.
+        :param model_hub: str value, options are ``'huggingface'`` and ``'modelscope'``,
+                          specify the model hub. Default to be ``'huggingface'``.
 
         :return: a model instance
         """
@@ -426,6 +438,10 @@ class _BaseAutoModelClass:
         lightweight_bmm = kwargs.pop("lightweight_bmm", False)
         # Autofactory
         trust_remote_code = kwargs.pop("trust_remote_code", None)
+        model_hub = kwargs.pop("model_hub", "huggingface")
+        invalidInputError(model_hub in ["huggingface", "modelscope"],
+                          "The parameter `model_hub` is supposed to be `huggingface` or "
+                          f"`modelscope`, but got {model_hub}.")
         kwargs_orig = copy.deepcopy(kwargs)
 
         config, kwargs = AutoConfig.from_pretrained(
@@ -447,12 +463,16 @@ class _BaseAutoModelClass:
         torch_dtype = kwargs.pop("torch_dtype", "auto")
         sharded_metadata = None
 
-        try:
+        if model_hub == "huggingface":
+            config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
+        elif model_hub == "modelscope":
+            warnings.warn("The model hub is specified to be modelscope, "
+                          "please make sure you have installed it.")
             import modelscope
+            from modelscope.utils.hf_util import get_wrapped_class
+            cls.HF_Model = get_wrapped_class(cls.HF_Model)
             from .utils import get_modelscope_hf_config
             config_dict, _ = get_modelscope_hf_config(pretrained_model_name_or_path)
-        except ImportError:
-            config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
         bigdl_transformers_low_bit = config_dict.pop("bigdl_transformers_low_bit", False)
         bigdl_lcmu_enabled = config_dict.pop("bigdl_lcmu_enabled", True)
 
@@ -609,21 +629,11 @@ class _BaseAutoModelClass:
 
 
 class AutoModelForCausalLM(_BaseAutoModelClass):
-    try:
-        import modelscope
-        from modelscope import AutoModelForCausalLM
-        HF_Model = modelscope.AutoModelForCausalLM
-    except ImportError:
-        HF_Model = transformers.AutoModelForCausalLM
+    HF_Model = transformers.AutoModelForCausalLM
 
 
 class AutoModel(_BaseAutoModelClass):
-    try:
-        import modelscope
-        from modelscope import AutoModel
-        HF_Model = modelscope.AutoModel
-    except ImportError:
-        HF_Model = transformers.AutoModel
+    HF_Model = transformers.AutoModel
 
 
 class AutoModelForSpeechSeq2Seq(_BaseAutoModelClass):
@@ -631,21 +641,11 @@ class AutoModelForSpeechSeq2Seq(_BaseAutoModelClass):
 
 
 class AutoModelForSeq2SeqLM(_BaseAutoModelClass):
-    try:
-        import modelscope
-        from modelscope import AutoModelForSeq2SeqLM
-        HF_Model = modelscope.AutoModelForSeq2SeqLM
-    except ImportError:
-        HF_Model = transformers.AutoModelForSeq2SeqLM
+    HF_Model = transformers.AutoModelForSeq2SeqLM
 
 
 class AutoModelForSequenceClassification(_BaseAutoModelClass):
-    try:
-        import modelscope
-        from modelscope import AutoModelForSequenceClassification
-        HF_Model = modelscope.AutoModelForSequenceClassification
-    except ImportError:
-        HF_Model = transformers.AutoModelForSequenceClassification
+    HF_Model = transformers.AutoModelForSequenceClassification
 
 
 class AutoModelForMaskedLM(_BaseAutoModelClass):
@@ -665,9 +665,4 @@ class AutoModelForMultipleChoice(_BaseAutoModelClass):
 
 
 class AutoModelForTokenClassification(_BaseAutoModelClass):
-    try:
-        import modelscope
-        from modelscope import AutoModelForTokenClassification
-        HF_Model = modelscope.AutoModelForTokenClassification
-    except ImportError:
-        HF_Model = transformers.AutoModelForTokenClassification
+    HF_Model = transformers.AutoModelForTokenClassification

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -137,8 +137,6 @@ class _BaseAutoModelClass:
         if model_hub == "huggingface":
             config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
         elif model_hub == "modelscope":
-            warnings.warn("The model hub is specified to be modelscope, "
-                          "please make sure you have installed it.")
             import modelscope
             from modelscope.utils.hf_util import get_wrapped_class
             cls.HF_Model = get_wrapped_class(cls.HF_Model)
@@ -412,8 +410,6 @@ class _BaseAutoModelClass:
         :param pretrained_model_name_or_path: str value, Path to load the optimized model ckpt.
         :param optimize_model: boolean value, Whether to further optimize the low_bit llm model.
                                Default to be True.
-        :param model_hub: str value, options are ``'huggingface'`` and ``'modelscope'``,
-                          specify the model hub. Default to be ``'huggingface'``.
 
         :return: a model instance
         """
@@ -438,10 +434,6 @@ class _BaseAutoModelClass:
         lightweight_bmm = kwargs.pop("lightweight_bmm", False)
         # Autofactory
         trust_remote_code = kwargs.pop("trust_remote_code", None)
-        model_hub = kwargs.pop("model_hub", "huggingface")
-        invalidInputError(model_hub in ["huggingface", "modelscope"],
-                          "The parameter `model_hub` is supposed to be `huggingface` or "
-                          f"`modelscope`, but got {model_hub}.")
         kwargs_orig = copy.deepcopy(kwargs)
 
         config, kwargs = AutoConfig.from_pretrained(
@@ -463,16 +455,7 @@ class _BaseAutoModelClass:
         torch_dtype = kwargs.pop("torch_dtype", "auto")
         sharded_metadata = None
 
-        if model_hub == "huggingface":
-            config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
-        elif model_hub == "modelscope":
-            warnings.warn("The model hub is specified to be modelscope, "
-                          "please make sure you have installed it.")
-            import modelscope
-            from modelscope.utils.hf_util import get_wrapped_class
-            cls.HF_Model = get_wrapped_class(cls.HF_Model)
-            from .utils import get_modelscope_hf_config
-            config_dict, _ = get_modelscope_hf_config(pretrained_model_name_or_path)
+        config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
         bigdl_transformers_low_bit = config_dict.pop("bigdl_transformers_low_bit", False)
         bigdl_lcmu_enabled = config_dict.pop("bigdl_lcmu_enabled", True)
 

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -128,7 +128,12 @@ class _BaseAutoModelClass:
         """
         pretrained_model_name_or_path = kwargs.get("pretrained_model_name_or_path", None) \
             if len(args) == 0 else args[0]
-        config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
+        try:
+            import modelscope
+            from .utils import get_modelscope_hf_config
+            config_dict, _ = get_modelscope_hf_config(pretrained_model_name_or_path)
+        except ImportError:
+            config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
         bigdl_transformers_low_bit = config_dict.pop("bigdl_transformers_low_bit", False)
         invalidInputError(not bigdl_transformers_low_bit,
                           f"Detected model is a low-bit({bigdl_transformers_low_bit}) model, "
@@ -442,7 +447,12 @@ class _BaseAutoModelClass:
         torch_dtype = kwargs.pop("torch_dtype", "auto")
         sharded_metadata = None
 
-        config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
+        try:
+            import modelscope
+            from .utils import get_modelscope_hf_config
+            config_dict, _ = get_modelscope_hf_config(pretrained_model_name_or_path)
+        except ImportError:
+            config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
         bigdl_transformers_low_bit = config_dict.pop("bigdl_transformers_low_bit", False)
         bigdl_lcmu_enabled = config_dict.pop("bigdl_lcmu_enabled", True)
 
@@ -599,11 +609,21 @@ class _BaseAutoModelClass:
 
 
 class AutoModelForCausalLM(_BaseAutoModelClass):
-    HF_Model = transformers.AutoModelForCausalLM
+    try:
+        import modelscope
+        from modelscope import AutoModelForCausalLM
+        HF_Model = modelscope.AutoModelForCausalLM
+    except ImportError:
+        HF_Model = transformers.AutoModelForCausalLM
 
 
 class AutoModel(_BaseAutoModelClass):
-    HF_Model = transformers.AutoModel
+    try:
+        import modelscope
+        from modelscope import AutoModel
+        HF_Model = modelscope.AutoModel
+    except ImportError:
+        HF_Model = transformers.AutoModel
 
 
 class AutoModelForSpeechSeq2Seq(_BaseAutoModelClass):
@@ -611,11 +631,21 @@ class AutoModelForSpeechSeq2Seq(_BaseAutoModelClass):
 
 
 class AutoModelForSeq2SeqLM(_BaseAutoModelClass):
-    HF_Model = transformers.AutoModelForSeq2SeqLM
+    try:
+        import modelscope
+        from modelscope import AutoModelForSeq2SeqLM
+        HF_Model = modelscope.AutoModelForSeq2SeqLM
+    except ImportError:
+        HF_Model = transformers.AutoModelForSeq2SeqLM
 
 
 class AutoModelForSequenceClassification(_BaseAutoModelClass):
-    HF_Model = transformers.AutoModelForSequenceClassification
+    try:
+        import modelscope
+        from modelscope import AutoModelForSequenceClassification
+        HF_Model = modelscope.AutoModelForSequenceClassification
+    except ImportError:
+        HF_Model = transformers.AutoModelForSequenceClassification
 
 
 class AutoModelForMaskedLM(_BaseAutoModelClass):
@@ -635,4 +665,9 @@ class AutoModelForMultipleChoice(_BaseAutoModelClass):
 
 
 class AutoModelForTokenClassification(_BaseAutoModelClass):
-    HF_Model = transformers.AutoModelForTokenClassification
+    try:
+        import modelscope
+        from modelscope import AutoModelForTokenClassification
+        HF_Model = modelscope.AutoModelForTokenClassification
+    except ImportError:
+        HF_Model = transformers.AutoModelForTokenClassification

--- a/python/llm/src/bigdl/llm/transformers/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/utils.py
@@ -43,7 +43,7 @@ import os
 from transformers.modeling_utils import _add_variant
 from bigdl.llm.ggml.quantize import ggml_tensor_qtype
 from ..utils.common import invalidInputError
-from typing import Union
+from typing import Union, Optional
 import torch
 from torch import nn
 import logging
@@ -258,3 +258,19 @@ def get_cur_qtype_and_imatrix(qtype, full_module_name, imatrix_data):
         cur_qtype = qtype
 
     return cur_qtype, cur_imatrix
+
+
+def get_modelscope_hf_config(model_id_or_path: str,
+                             revision: Optional[str] = None):
+    # Read hf config dictionary from modelscope hub or local path
+    from modelscope.utils.constant import ModelFile
+    from modelscope.hub.file_download import model_file_download
+    from modelscope.utils.config import Config
+    if not os.path.exists(model_id_or_path):
+        local_path = model_file_download(
+            model_id_or_path, ModelFile.CONFIG, revision=revision)
+    elif os.path.isdir(model_id_or_path):
+        local_path = os.path.join(model_id_or_path, ModelFile.CONFIG)
+    elif os.path.isfile(model_id_or_path):
+        local_path = model_id_or_path
+    return Config._file2dict(local_path)


### PR DESCRIPTION
## Description

To support models hosted by https://github.com/modelscope/modelscope

### 2. User API changes

- New parameter `model_hub` is added to `from_pretrained` to specify model hub, options are `'huggingface'` and `'modelscope'`, default to be `'huggingface'`.
- No changes are needed for `load_low_bit`.

If users want to use models from modelscope hub, they could specify `model_hub=modelscope` to load and optimize model.
```python
import torch
import time
from bigdl.llm.transformers import AutoModel
from modelscope import AutoTokenizer

model_path = "ZhipuAI/chatglm3-6b"
model = AutoModel.from_pretrained(model_path,
                                  load_in_4bit=True,
                                  trust_remote_code=True,
                                  model_hub='modelscope')

tokenizer = AutoTokenizer.from_pretrained(model_path,
                                          trust_remote_code=True)

with torch.inference_mode():
    prompt = "晚上睡不着怎么办"
    input_ids = tokenizer.encode(prompt, return_tensors="pt")
    output = model.generate(input_ids,
                            max_new_tokens=32)
    output_str = tokenizer.decode(output[0], skip_special_tokens=True)
    print(output_str)
```


### 4. How to test?
- [x] Unit test
- [x] Local test (More details of verification will be listed in https://github.com/analytics-zoo/nano/issues/1037)
