### PR TITLE
LLM: basic support for q2k

### DIFF
--- a/python/llm/src/bigdl/llm/ggml/quantize.py
+++ b/python/llm/src/bigdl/llm/ggml/quantize.py
@@ -41,7 +41,8 @@ ggml_tensor_qtype = {"sym_int4": 2,   # q4_0 in ggml
                      "fp8": 19,           # fp8 in e5m2 format
                      "bf16": 20,
                      "iq2_xxs": 21,
-                     "iq2_xs": 22}
+                     "iq2_xs": 22,
+                     "q2_k": 23}
 
 _llama_quantize_type = {"q4_0": 2,
                         "q4_1": 3,

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -271,10 +271,11 @@ class _BaseAutoModelClass:
                 else:
                     kwargs["pretraining_tp"] = 1
             q_k = load_in_low_bit if load_in_low_bit else "sym_int4"
+            imatrix_file = kwargs.pop("imatrix", None)
             if q_k in ["iq2_xxs", "iq2_xs"]:
-                imatrix_file = kwargs.pop("imatrix", None)
                 invalidInputError(imatrix_file is not None,
-                                  "For iq2_xxs and iq2_xs quantization, imatrix is needed.")
+                                "For iq2_xxs and iq2_xs quantization, imatrix is needed.")
+            if imatrix_file is not None:
                 imatrix_data = load_imatrix_data(imatrix_file)
                 kwargs['imatrix_data'] = imatrix_data
             model = cls.load_convert(q_k, optimize_model, *args, **kwargs)

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -274,7 +274,7 @@ class _BaseAutoModelClass:
             imatrix_file = kwargs.pop("imatrix", None)
             if q_k in ["iq2_xxs", "iq2_xs"]:
                 invalidInputError(imatrix_file is not None,
-                                "For iq2_xxs and iq2_xs quantization, imatrix is needed.")
+                                  "For iq2_xxs and iq2_xs quantization, imatrix is needed.")
             if imatrix_file is not None:
                 imatrix_data = load_imatrix_data(imatrix_file)
                 kwargs['imatrix_data'] = imatrix_data

--- a/python/llm/src/bigdl/llm/transformers/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/utils.py
@@ -225,7 +225,8 @@ def load_imatrix_data(imatrix_file):
 
 
 def get_cur_qtype_and_imatrix(qtype, full_module_name, imatrix_data):
-    if qtype in [ggml_tensor_qtype["iq2_xxs"], ggml_tensor_qtype["iq2_xs"]]:
+    if qtype in [ggml_tensor_qtype["iq2_xxs"], ggml_tensor_qtype["iq2_xs"],
+                 ggml_tensor_qtype["q2_k"]] and imatrix_data is not None:
         # For quantization which needs importance matrix
         # module name preprocess
         # full name maybe model.layers.31.self_attn.o_proj
@@ -253,11 +254,9 @@ def get_cur_qtype_and_imatrix(qtype, full_module_name, imatrix_data):
             if cur_module == 'v' or (cur_module == 'down' and int(layer) in [0, 1, 10, 11]) \
                     or new_module_name == 'lm_head':
                 cur_qtype = ggml_tensor_qtype['sym_int4']
+        return cur_qtype, cur_imatrix
     else:
-        cur_imatrix = None
-        cur_qtype = qtype
-
-    return cur_qtype, cur_imatrix
+        return qtype, None
 
 
 def get_modelscope_hf_config(model_id_or_path: str,


### PR DESCRIPTION
## Description

should merge after https://github.com/intel-analytics/llm.cpp/pull/235 .

### 1. Why the change?

Support basic q2k for better 2bit quantization support.

### 2. User API changes

- quantize without importance matrix

```python
from bigdl.llm.transformers import AutoModelForCausalLM
model_path = 'meta/Llama-2-7b-hf'
model = AutoModelForCausalLM.from_pretrained(model_path,
                                             load_in_low_bit='q2_k',
                                             optimize_model=False,
                                             trust_remote_code=True,
                                             use_cache=True,
                                             modules_to_not_convert=['lm_head'])
```

- quantize with importance matrix

```python
from bigdl.llm.transformers import AutoModelForCausalLM
model_path = 'meta/Llama-2-7b-hf'
model = AutoModelForCausalLM.from_pretrained(model_path,
                                             load_in_low_bit='q2_k',
                                             optimize_model=False,
                                             trust_remote_code=True,
                                             use_cache=True,
                                             modules_to_not_convert=['lm_head'],
                                             imatrix='imatrix/llama-v2-7b.imatrix')
```

### 3. Summary of the change 

- Support q2_K quantization on CPU and inference on GPU

### 4. How to test?
- [x] Local test
- [x] Unit test

