### PR TITLE
Separate llmcpp build of linux and windows

### DIFF
--- a/.github/actions/llm/download-llm-binary/action.yml
+++ b/.github/actions/llm/download-llm-binary/action.yml
@@ -11,14 +11,14 @@ runs:
       run: |
         rm -rf python/llm/llm-binary || true
         mkdir -p python/llm/llm-binary
-        mv linux-avx2/* python/llm/llm-binary/
-        mv linux-avx512/* python/llm/llm-binary/
-        mv linux-avxvnni/* python/llm/llm-binary/
-        mv linux-avx/* python/llm/llm-binary/
-        mv linux-amx/* python/llm/llm-binary/
-        mv windows-avx2/* python/llm/llm-binary/
-        mv windows-avx-vnni/* python/llm/llm-binary/
-        mv windows-avx/* python/llm/llm-binary/
+        mv linux-avx2/* python/llm/llm-binary/ || true
+        mv linux-avx512/* python/llm/llm-binary/ || true
+        mv linux-avxvnni/* python/llm/llm-binary/ || true
+        mv linux-avx/* python/llm/llm-binary/ || true
+        mv linux-amx/* python/llm/llm-binary/ || true
+        mv windows-avx2/* python/llm/llm-binary/ || true
+        mv windows-avx-vnni/* python/llm/llm-binary/ || true
+        mv windows-avx/* python/llm/llm-binary/ || true
         rm -rf linux-avx2 || true
         rm -rf linux-avx512 || true
         rm -rf linux-avxvnni || true

--- a/.github/actions/llm/download-llm-binary/action.yml
+++ b/.github/actions/llm/download-llm-binary/action.yml
@@ -1,6 +1,11 @@
 name: Download LLM binary files
 description: Download built binary files from github artifact
-
+inputs:
+  platform:
+    description: 'Platforms to built on'
+    default: 'Windows,Linux'
+    required: false
+    type: string
 runs:
   using: "composite"
   steps:
@@ -11,14 +16,18 @@ runs:
       run: |
         rm -rf python/llm/llm-binary || true
         mkdir -p python/llm/llm-binary
-        mv linux-avx2/* python/llm/llm-binary/ || true
-        mv linux-avx512/* python/llm/llm-binary/ || true
-        mv linux-avxvnni/* python/llm/llm-binary/ || true
-        mv linux-avx/* python/llm/llm-binary/ || true
-        mv linux-amx/* python/llm/llm-binary/ || true
-        mv windows-avx2/* python/llm/llm-binary/ || true
-        mv windows-avx-vnni/* python/llm/llm-binary/ || true
-        mv windows-avx/* python/llm/llm-binary/ || true
+        if ${{contains(inputs.platform, 'Linux')}}; then
+          mv linux-avx2/* python/llm/llm-binary/ 
+          mv linux-avx512/* python/llm/llm-binary/
+          mv linux-avxvnni/* python/llm/llm-binary/
+          mv linux-avx/* python/llm/llm-binary/
+          mv linux-amx/* python/llm/llm-binary/
+        fi
+        if ${{contains(inputs.platform, 'Windows')}}; then
+          mv windows-avx2/* python/llm/llm-binary/ || true
+          mv windows-avx-vnni/* python/llm/llm-binary/ || true
+          mv windows-avx/* python/llm/llm-binary/ || true
+        fi
         rm -rf linux-avx2 || true
         rm -rf linux-avx512 || true
         rm -rf linux-avxvnni || true

--- a/.github/actions/llm/download-llm-binary/action.yml
+++ b/.github/actions/llm/download-llm-binary/action.yml
@@ -24,9 +24,9 @@ runs:
           mv linux-amx/* python/llm/llm-binary/
         fi
         if ${{contains(inputs.platform, 'Windows')}}; then
-          mv windows-avx2/* python/llm/llm-binary/ || true
-          mv windows-avx-vnni/* python/llm/llm-binary/ || true
-          mv windows-avx/* python/llm/llm-binary/ || true
+          mv windows-avx2/* python/llm/llm-binary/
+          mv windows-avx-vnni/* python/llm/llm-binary/
+          mv windows-avx/* python/llm/llm-binary/
         fi
         rm -rf linux-avx2 || true
         rm -rf linux-avx512 || true

--- a/.github/workflows/llm-binary-build.yml
+++ b/.github/workflows/llm-binary-build.yml
@@ -40,14 +40,14 @@ on:
         type: string
       platform:
         description: 'Platforms to built on'
-        default: '["Windows", "Linux"]'
+        default: 'Windows,Linux'
         required: false
         type: string
     
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   check-linux-avxvnni-artifact:
-    if: contains(${{ fromJson(inputs.platform) }}, 'Linux')
+    if: ${{contains(inputs.platform, 'Linux')}}
     runs-on: ubuntu-latest
     outputs:
       if-exists: ${{steps.check_artifact.outputs.exists}}
@@ -160,7 +160,7 @@ jobs:
           conda remove -n python311 --all -y
 
   check-linux-avx512-artifact:
-    if: contains(${{ fromJson(inputs.platform) }}, 'Linux')
+    if: ${{contains(inputs.platform, 'Linux')}}
     runs-on: ubuntu-latest
     outputs:
       if-exists: ${{steps.check_artifact.outputs.exists}}
@@ -261,7 +261,7 @@ jobs:
           conda remove -n python39 --all -y
 
   check-linux-amx-artifact:
-    if: contains(${{ fromJson(inputs.platform) }}, 'Linux')
+    if: ${{contains(inputs.platform, 'Linux')}}
     runs-on: ubuntu-latest
     outputs:
       if-exists: ${{steps.check_artifact.outputs.exists}}
@@ -332,7 +332,7 @@ jobs:
           conda remove -n python39 --all -y
           
   check-windows-avx2-artifact:
-    if: contains(${{ fromJson(inputs.platform) }}, 'Windows')
+    if: ${{contains(inputs.platform, 'Windows')}}
     runs-on: ubuntu-latest
     outputs:
       if-exists: ${{steps.check_artifact.outputs.exists}}
@@ -377,7 +377,7 @@ jobs:
             build/Release
 
   check-windows-avx-vnni-artifact:
-    if: contains(${{ fromJson(inputs.platform) }}, 'Windows')
+    if: ${{contains(inputs.platform, 'Windows')}}
     runs-on: ubuntu-latest
     outputs:
       if-exists: ${{steps.check_artifact.outputs.exists}}
@@ -487,7 +487,7 @@ jobs:
             release
 
   check-windows-avx-artifact:
-    if: contains(${{ fromJson(inputs.platform) }}, 'Windows')
+    if: ${{contains(inputs.platform, 'Windows')}}
     runs-on: ubuntu-latest
     outputs:
       if-exists: ${{steps.check_artifact.outputs.exists}}

--- a/.github/workflows/llm-binary-build.yml
+++ b/.github/workflows/llm-binary-build.yml
@@ -26,6 +26,11 @@ on:
         default: ''
         required: false
         type: string
+      platform:
+        description: 'Platforms to built on'
+        default: '["Windows", "Linux"]'
+        required: false
+        type: string
   workflow_call:
     inputs:
       llmcpp-ref:
@@ -33,10 +38,16 @@ on:
         default: ''
         required: false
         type: string
-
+      platform:
+        description: 'Platforms to built on'
+        default: '["Windows", "Linux"]'
+        required: false
+        type: string
+    
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   check-linux-avxvnni-artifact:
+    if: contains(${{ fromJson(inputs.platform) }}, 'Linux')
     runs-on: ubuntu-latest
     outputs:
       if-exists: ${{steps.check_artifact.outputs.exists}}
@@ -149,6 +160,7 @@ jobs:
           conda remove -n python311 --all -y
 
   check-linux-avx512-artifact:
+    if: contains(${{ fromJson(inputs.platform) }}, 'Linux')
     runs-on: ubuntu-latest
     outputs:
       if-exists: ${{steps.check_artifact.outputs.exists}}
@@ -249,6 +261,7 @@ jobs:
           conda remove -n python39 --all -y
 
   check-linux-amx-artifact:
+    if: contains(${{ fromJson(inputs.platform) }}, 'Linux')
     runs-on: ubuntu-latest
     outputs:
       if-exists: ${{steps.check_artifact.outputs.exists}}
@@ -319,6 +332,7 @@ jobs:
           conda remove -n python39 --all -y
           
   check-windows-avx2-artifact:
+    if: contains(${{ fromJson(inputs.platform) }}, 'Windows')
     runs-on: ubuntu-latest
     outputs:
       if-exists: ${{steps.check_artifact.outputs.exists}}
@@ -363,6 +377,7 @@ jobs:
             build/Release
 
   check-windows-avx-vnni-artifact:
+    if: contains(${{ fromJson(inputs.platform) }}, 'Windows')
     runs-on: ubuntu-latest
     outputs:
       if-exists: ${{steps.check_artifact.outputs.exists}}
@@ -472,6 +487,7 @@ jobs:
             release
 
   check-windows-avx-artifact:
+    if: contains(${{ fromJson(inputs.platform) }}, 'Windows')
     runs-on: ubuntu-latest
     outputs:
       if-exists: ${{steps.check_artifact.outputs.exists}}

--- a/.github/workflows/llm-c-evaluation.yml
+++ b/.github/workflows/llm-c-evaluation.yml
@@ -34,6 +34,8 @@ on:
 jobs:
   llm-cpp-build:
     uses: ./.github/workflows/llm-binary-build.yml
+    with:
+      platform: 'Linux'
   # Set the testing matrix based on the event (schedule, PR, or manual dispatch)
   set-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/llm-c-evaluation.yml
+++ b/.github/workflows/llm-c-evaluation.yml
@@ -112,6 +112,8 @@ jobs:
 
       - name: Download llm binary
         uses: ./.github/actions/llm/download-llm-binary
+        with:
+          platform: 'Linux'
 
       - name: Run LLM install (all) test
         uses: ./.github/actions/llm/setup-llm-env

--- a/.github/workflows/llm-harness-evaluation.yml
+++ b/.github/workflows/llm-harness-evaluation.yml
@@ -134,6 +134,8 @@ jobs:
 
       - name: Download llm binary
         uses: ./.github/actions/llm/download-llm-binary
+        with:
+          platform: 'Linux'
 
       - name: Run LLM install (all) test
         uses: ./.github/actions/llm/setup-llm-env

--- a/.github/workflows/llm-harness-evaluation.yml
+++ b/.github/workflows/llm-harness-evaluation.yml
@@ -43,7 +43,7 @@ jobs:
   llm-cpp-build:
     uses: ./.github/workflows/llm-binary-build.yml
     with:
-      platform: '["Linux"]'
+      platform: 'Linux'
   # Set the testing matrix based on the event (schedule, PR, or manual dispatch)
   set-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/llm-harness-evaluation.yml
+++ b/.github/workflows/llm-harness-evaluation.yml
@@ -42,6 +42,8 @@ on:
 jobs:
   llm-cpp-build:
     uses: ./.github/workflows/llm-binary-build.yml
+    with:
+      platform: '["Linux"]'
   # Set the testing matrix based on the event (schedule, PR, or manual dispatch)
   set-matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/llm-ppl-evaluation.yml
+++ b/.github/workflows/llm-ppl-evaluation.yml
@@ -42,6 +42,8 @@ on:
 jobs:
   llm-cpp-build:
     uses: ./.github/workflows/llm-binary-build.yml
+    with:
+      platform: 'Linux'
   set-matrix:
     runs-on: ubuntu-latest
     outputs:

--- a/.github/workflows/llm-ppl-evaluation.yml
+++ b/.github/workflows/llm-ppl-evaluation.yml
@@ -130,6 +130,8 @@ jobs:
 
       - name: Download llm binary
         uses: ./.github/actions/llm/download-llm-binary
+        with:
+          platform: 'Linux'
 
       - name: Run LLM install (all) test
         uses: ./.github/actions/llm/setup-llm-env

--- a/.github/workflows/llm_tests_for_stable_version_on_arc.yml
+++ b/.github/workflows/llm_tests_for_stable_version_on_arc.yml
@@ -23,7 +23,8 @@ on:
 jobs:
   llm-cpp-build:
     uses: ./.github/workflows/llm-binary-build.yml
-
+    with:
+          platform: 'Linux'
   llm-perf-regression-test-on-arc:
     needs: llm-cpp-build
     strategy:

--- a/.github/workflows/llm_tests_for_stable_version_on_arc.yml
+++ b/.github/workflows/llm_tests_for_stable_version_on_arc.yml
@@ -24,7 +24,7 @@ jobs:
   llm-cpp-build:
     uses: ./.github/workflows/llm-binary-build.yml
     with:
-          platform: 'Linux'
+      platform: 'Linux'
   llm-perf-regression-test-on-arc:
     needs: llm-cpp-build
     strategy:
@@ -61,6 +61,8 @@ jobs:
 
       - name: Download llm binary
         uses: ./.github/actions/llm/download-llm-binary
+        with:
+          platform: 'Linux'
 
       - name: Run LLM install (all) test
         uses: ./.github/actions/llm/setup-llm-env


### PR DESCRIPTION
## Description

Linux and windows build of llmcpp sometimes is time-consuming to wait for available runners, and sometimes fails. To accelerate it, separate two platforms and build target platform only to reduce building time a little bit.
