### PR TITLE
[Fix OpenSSF Pinned-Dependencies Issues]: GitHub-owned GitHubAction actions/checkout not pinned by hash

### DIFF
--- a/.github/workflows/BiWeekly_docker.yml
+++ b/.github/workflows/BiWeekly_docker.yml
@@ -24,7 +24,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}

--- a/.github/workflows/PR_validation.yml
+++ b/.github/workflows/PR_validation.yml
@@ -72,7 +72,7 @@ jobs:
       orca-example: ${{ steps.filter.outputs.orca-example }}
       ppml: ${{ steps.filter.outputs.ppml }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - uses: dorny/paths-filter@v2
         id: filter
         with:
@@ -168,7 +168,7 @@ jobs:
     runs-on: [ self-hosted, ubuntu-20.04-lts, CLX, AVX512, Ettenmoors ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: Set up JDK8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up maven
@@ -182,7 +182,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: Set up JDK8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up maven
@@ -196,7 +196,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: Set up JDK8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up maven
@@ -210,7 +210,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
         
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: Set up JDK8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up maven
@@ -229,7 +229,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -248,7 +248,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -267,7 +267,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -286,7 +286,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -305,7 +305,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -324,7 +324,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -343,7 +343,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -362,7 +362,7 @@ jobs:
     runs-on: [self-hosted, Gondolin-Ctx]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Setup env
       uses: ./.github/actions/orca/setup-env/setup-orca-ray-ctx-py37
     - name: Run Test
@@ -377,7 +377,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -396,7 +396,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: Set up JDK8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up maven
@@ -415,7 +415,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: Set up JDK8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up maven
@@ -434,7 +434,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -453,7 +453,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -472,7 +472,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -491,7 +491,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -510,7 +510,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -529,7 +529,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -548,7 +548,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -567,7 +567,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -586,7 +586,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven

--- a/.github/workflows/bigdl-core-release-pypi.yml
+++ b/.github/workflows/bigdl-core-release-pypi.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: [self-hosted, ubuntu-20.04-lts, Bree-core]
     needs: llm-cpp-build
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         repository: intel-analytics/BigDL-core
         ref: ${{ env.Branch }}

--- a/.github/workflows/bigdl-deploy-pypi-if-release-more-than-once-per-day.yml
+++ b/.github/workflows/bigdl-deploy-pypi-if-release-more-than-once-per-day.yml
@@ -23,7 +23,7 @@ jobs:
     # if: ${{ github.actor == 'Le-Zheng' }}
     needs: llm-cpp-build
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
 

--- a/.github/workflows/bigdl-llm-stable-release-pypi.yml
+++ b/.github/workflows/bigdl-llm-stable-release-pypi.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: [self-hosted, ubuntu-20.04-lts, Bree]
     needs: llm-cpp-build
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: set stable version
       env:
         DEFAULT_VERSION: '2.5.0b0'

--- a/.github/workflows/bigdl-release-docker.yml
+++ b/.github/workflows/bigdl-release-docker.yml
@@ -21,7 +21,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: set env
       env:
         DEFAULT_TAG: 'latest'

--- a/.github/workflows/bigdl-release-pypi.yml
+++ b/.github/workflows/bigdl-release-pypi.yml
@@ -16,7 +16,7 @@ jobs:
     # if: ${{ github.actor == 'Le-Zheng' }}
     needs: llm-cpp-build
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
 

--- a/.github/workflows/bigdl-release-scala.yml
+++ b/.github/workflows/bigdl-release-scala.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: [self-hosted, Bree]
     # if: ${{ github.actor == 'Le-Zheng' }}
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up Maven

--- a/.github/workflows/bigdl-release-tf-math-python-pypi.yml
+++ b/.github/workflows/bigdl-release-tf-math-python-pypi.yml
@@ -28,7 +28,7 @@ jobs:
     runs-on: [self-hosted, ubuntu-20.04-lts, Bree-core]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
 

--- a/.github/workflows/chronos-example-python-spark31.yml
+++ b/.github/workflows/chronos-example-python-spark31.yml
@@ -35,7 +35,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up JDK 8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up Maven

--- a/.github/workflows/chronos-howto-guides-python-spark31.yml
+++ b/.github/workflows/chronos-howto-guides-python-spark31.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up JDK 8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up Maven
@@ -84,7 +84,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up JDK 8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up Maven

--- a/.github/workflows/chronos-nb-python-spark31.yml
+++ b/.github/workflows/chronos-nb-python-spark31.yml
@@ -26,7 +26,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up JDK 8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up Maven
@@ -82,7 +82,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up JDK 8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up Maven
@@ -137,7 +137,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up JDK 8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up Maven
@@ -192,7 +192,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up JDK 8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up Maven
@@ -250,7 +250,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up JDK 8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up Maven
@@ -303,7 +303,7 @@ jobs:
   create-workflow-badge:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: create workflow badge
       if: ${{ always() }}
       uses: ./.github/actions/create-job-status-badge

--- a/.github/workflows/chronos-notebook-python-spark31.yml
+++ b/.github/workflows/chronos-notebook-python-spark31.yml
@@ -29,7 +29,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up JDK 8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up Maven

--- a/.github/workflows/chronos-prvn-python-spark31.yml
+++ b/.github/workflows/chronos-prvn-python-spark31.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up JDK 8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up Maven
@@ -91,7 +91,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up JDK 8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up Maven
@@ -145,7 +145,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up JDK 8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up Maven
@@ -199,7 +199,7 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up JDK 8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up Maven

--- a/.github/workflows/friesian-docker-build.yml
+++ b/.github/workflows/friesian-docker-build.yml
@@ -38,7 +38,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'serving-jar-package' || github.event.inputs.artifact == 'all' }}
     runs-on:  [self-hosted,alpha,Bree,ubuntu-20.04-lts]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
 
       - name: Set up JDK8
         uses: ./.github/actions/jdk-setup-action
@@ -63,7 +63,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'docker-build' || github.event.inputs.artifact == 'all' }}
     runs-on: [ self-hosted, Shire ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: set env
         run: |
           echo "TAG=${{github.event.inputs.tag||'latest'}}" >> $GITHUB_ENV

--- a/.github/workflows/license-scan.yml
+++ b/.github/workflows/license-scan.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: [self-hosted, Linux, Bree]
     steps:
     - name: "Checkout Code"
-      uses: actions/checkout@v3
+      uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
 
     - name: "Run FOSSA Scan"
       uses: fossas/fossa-action@main # Use a specific version if locking is preferred
@@ -84,7 +84,7 @@ jobs:
   create-workflow-badge:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: create workflow badge
       if: ${{ always() }}
       uses: ./.github/actions/create-job-status-badge

--- a/.github/workflows/llm-binary-build.yml
+++ b/.github/workflows/llm-binary-build.yml
@@ -67,7 +67,7 @@ jobs:
           conda create -n python310 python=3.10 -y
           conda remove -n python311 --all -y
           conda create -n python311 python=3.11 -y
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
         with:
           repository: "intel-analytics/llm.cpp"
           ref: ${{ inputs.llmcpp-ref }}
@@ -175,7 +175,7 @@ jobs:
           yum install -y gcc-toolset-11 cmake git
           conda remove -n python39 --all -y
           conda create -n python39 python=3.9 -y
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
         with:
           repository: "intel-analytics/llm.cpp"
           ref: ${{ inputs.llmcpp-ref }}
@@ -275,7 +275,7 @@ jobs:
           yum install -y gcc-toolset-11 cmake git
           conda remove -n python39 --all -y
           conda create -n python39 python=3.9 -y
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
         with:
           repository: "intel-analytics/llm.cpp"
           ref: ${{ inputs.llmcpp-ref }}
@@ -338,7 +338,7 @@ jobs:
         run: |
           echo "github_access_token=$env:GITHUB_ACCESS_TOKEN" >> $env:GITHUB_ENV
           echo "github_access_token=$env:GITHUB_ACCESS_TOKEN"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
         with:
           repository: "intel-analytics/llm.cpp"
           ref: ${{ inputs.llmcpp-ref }}
@@ -386,7 +386,7 @@ jobs:
         run: |
           echo "github_access_token=$env:GITHUB_ACCESS_TOKEN" >> $env:GITHUB_ENV
           echo "github_access_token=$env:GITHUB_ACCESS_TOKEN"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
         with:
           repository: "intel-analytics/llm.cpp"
           ref: ${{ inputs.llmcpp-ref }}
@@ -491,7 +491,7 @@ jobs:
         run: |
           echo "github_access_token=$env:GITHUB_ACCESS_TOKEN" >> $env:GITHUB_ENV
           echo "github_access_token=$env:GITHUB_ACCESS_TOKEN"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
         with:
           repository: "intel-analytics/llm.cpp"
           ref: ${{ inputs.llmcpp-ref }}

--- a/.github/workflows/llm-harness-evaluation.yml
+++ b/.github/workflows/llm-harness-evaluation.yml
@@ -117,7 +117,7 @@ jobs:
       ORIGIN_DIR: /mnt/disk1/models
       HARNESS_HF_HOME: /mnt/disk1/harness_home
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -204,7 +204,7 @@ jobs:
     needs: llm-harness-evalution
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:
@@ -231,7 +231,7 @@ jobs:
     needs: [set-matrix, llm-harness-evalution]
     runs-on: ["self-hosted", "llm", "accuracy1", "accuracy-nightly"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: Set up Python 3.9
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/llm-nightly-test.yml
+++ b/.github/workflows/llm-nightly-test.yml
@@ -68,7 +68,7 @@ jobs:
           echo "GPTNEOX_INT4_CKPT_PATH=${INT4_CKPT_DIR}/bigdl_llm_gptneox_q4_0.bin" >> "$GITHUB_ENV"
           echo "BLOOM_INT4_CKPT_PATH=${INT4_CKPT_DIR}/bigdl_llm_bloom_q4_0.bin" >> "$GITHUB_ENV"
           echo "STARCODER_INT4_CKPT_PATH=${INT4_CKPT_DIR}/bigdl_llm_starcoder_q4_0.bin" >> "$GITHUB_ENV"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/llm-ppl-evaluation.yml
+++ b/.github/workflows/llm-ppl-evaluation.yml
@@ -150,7 +150,7 @@ jobs:
       ORIGIN_DIR: /mnt/disk1/models
       DATASET_DIR: /mnt/disk1/datasets/THUDM___long_bench/
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/llm_example_tests.yml
+++ b/.github/workflows/llm_example_tests.yml
@@ -45,7 +45,7 @@ jobs:
     env:
       THREAD_NUM: 24
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/llm_performance_tests.yml
+++ b/.github/workflows/llm_performance_tests.yml
@@ -42,7 +42,7 @@ jobs:
       CSV_SAVE_PATH: ${{ github.event.schedule && '/mnt/disk1/nightly_perf_gpu/' || '/mnt/disk1/pr_perf_gpu/' }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -156,7 +156,7 @@ jobs:
       THREAD_NUM: 16
       ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -225,7 +225,7 @@ jobs:
       ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
       CSV_SAVE_PATH: ${{ github.event.schedule && 'D:/action-runners/nightly_perf_core_' || 'D:/action-runners/pr_perf_core_' }}${{ matrix.platform }}/
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -292,7 +292,7 @@ jobs:
     env:
       ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
 
       # TODO: Put the bigdl-llm related install process for win gpu into a action function
 

--- a/.github/workflows/llm_tests_for_stable_version_on_arc.yml
+++ b/.github/workflows/llm_tests_for_stable_version_on_arc.yml
@@ -38,7 +38,7 @@ jobs:
       CSV_SAVE_PATH: '/mnt/disk1/stable_version_perf_gpu/'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -160,7 +160,7 @@ jobs:
       CSV_SAVE_PATH: '/mnt/disk1/stable_version_stress_test_gpu/'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/llm_tests_for_stable_version_on_spr.yml
+++ b/.github/workflows/llm_tests_for_stable_version_on_spr.yml
@@ -36,7 +36,7 @@ jobs:
       THREAD_NUM: 16
       ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -94,7 +94,7 @@ jobs:
       THREAD_NUM: 16
       ANALYTICS_ZOO_ROOT: ${{ github.workspace }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/llm_unit_tests.yml
+++ b/.github/workflows/llm_unit_tests.yml
@@ -108,7 +108,7 @@ jobs:
           echo "BLOOM_INT4_CKPT_PATH=${INT4_CKPT_DIR}/bigdl_llm_bloom_7b_q4_0.bin" >> "$GITHUB_ENV"
           echo "STARCODER_INT4_CKPT_PATH=${INT4_CKPT_DIR}/bigdl_llm_santacoder_1b_q4_0.bin" >> "$GITHUB_ENV"
           echo "CHATGLM_INT4_CKPT_PATH=${INT4_CKPT_DIR}/chatglm2-6b-q4_0.bin" >> "$GITHUB_ENV"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -236,7 +236,7 @@ jobs:
           echo "WHISPER_TINY_ORIGIN_PATH=${ORIGIN_DIR}/whisper-tiny" >> "$GITHUB_ENV"
 
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/mac_nightly_test.yml
+++ b/.github/workflows/mac_nightly_test.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: [self-hosted, mac, macOS]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Run Test
       uses: ./.github/actions/mac/app/mac-python-apptest-part1
     - name: Create Job Badge
@@ -64,7 +64,7 @@ jobs:
     runs-on: [self-hosted, mac, macOS]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Run Test
       uses: ./.github/actions/mac/dllib/mac-dllib-scalatest-spark3
     - name: Create Job Badge
@@ -84,7 +84,7 @@ jobs:
     runs-on: [self-hosted, mac, macOS]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Run Test
       uses: ./.github/actions/mac/dllib/mac-dllib-python-exampletest-spark3
     - name: Create Job Badge
@@ -104,7 +104,7 @@ jobs:
     runs-on: [self-hosted, mac, macOS]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Run Test
       uses: ./.github/actions/mac/friesian/mac-friesian-python-ut-spark3
     - name: Create Job Badge
@@ -124,7 +124,7 @@ jobs:
     runs-on: [self-hosted, mac, macOS]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Run Test
       uses: ./.github/actions/mac/friesian/mac-friesian-python-ut-pip-spark3
     - name: Create Job Badge
@@ -144,7 +144,7 @@ jobs:
     runs-on: [self-hosted, mac, macOS]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Run Test
       uses: ./.github/actions/mac/friesian/mac-friesian-python-exampletest-tf2-spark3
     - name: Create Job Badge
@@ -164,7 +164,7 @@ jobs:
     runs-on: [self-hosted, mac, macOS]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Run Test
       uses: ./.github/actions/mac/friesian/mac-friesian-python-exampletest-tf2-pip-spark3
     - name: Create Job Badge
@@ -184,7 +184,7 @@ jobs:
     runs-on: [self-hosted, mac, macOS]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Run Test
       uses: ./.github/actions/mac/friesian/mac-friesian-python-exampletest-feature-tf1-spark3
     - name: Create Job Badge
@@ -204,7 +204,7 @@ jobs:
     runs-on: [self-hosted, mac, macOS]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Run Test
       uses: ./.github/actions/mac/friesian/mac-friesian-python-exampletest-feature-tf1-pip-spark3
     - name: Create Job Badge
@@ -224,7 +224,7 @@ jobs:
     runs-on: [self-hosted, mac, macOS]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Run Test
       uses: ./.github/actions/mac/orca/mac-orca-python-ut-spark3
     - name: Create Job Badge
@@ -244,7 +244,7 @@ jobs:
     runs-on: [self-hosted, mac, macOS]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Run Test
       uses: ./.github/actions/mac/orca/mac-orca-python-ut-ray-spark3
     - name: Create Job Badge
@@ -264,7 +264,7 @@ jobs:
     runs-on: [self-hosted, mac, macOS]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Run Test
       uses: ./.github/actions/mac/orca/mac-orca-python-exampletest-spark3
     - name: Create Job Badge
@@ -284,7 +284,7 @@ jobs:
     runs-on: [self-hosted, mac, macOS]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Run Test
       uses: ./.github/actions/mac/orca/mac-orca-python-exampletest-ray-spark3
     - name: Create Job Badge
@@ -303,7 +303,7 @@ jobs:
   create-workflow-badge:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: create workflow badge
       if: ${{ always() }}
       uses: ./.github/actions/create-job-status-badge

--- a/.github/workflows/manually_build.yml
+++ b/.github/workflows/manually_build.yml
@@ -65,7 +65,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -92,7 +92,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: docker login
         run: |
           docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -119,7 +119,7 @@ jobs:
     runs-on: [self-hosted, Shire]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -146,7 +146,7 @@ jobs:
     runs-on: [self-hosted, Shire]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -173,7 +173,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -200,7 +200,7 @@ jobs:
     runs-on: [self-hosted, Shire]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -226,7 +226,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-llm-serving-cpu' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -253,7 +253,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -280,7 +280,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-bigdl-llm-gramine-base' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -310,7 +310,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-bigdl-llm-gramine-ref' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -341,7 +341,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-deep-learning-gramine-base' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -372,7 +372,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-deep-learning-gramine-ref' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -404,7 +404,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-dl-serving-gramine-base' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -432,7 +432,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-dl-serving-gramine-ref' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -464,7 +464,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -605,7 +605,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -728,7 +728,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -762,7 +762,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: docker login
         run: |
           docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -796,7 +796,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -831,7 +831,7 @@ jobs:
     runs-on: [ self-hosted, Shire ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: docker login
         run: |
           docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -877,7 +877,7 @@ jobs:
     runs-on: [ self-hosted, Shire ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: docker login
         run: |
           docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -916,7 +916,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -950,7 +950,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-bigdl-llm-serving-tdx' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -981,7 +981,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-bigdl-llm-tdx' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -1008,7 +1008,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -1043,7 +1043,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker deploy kms-util
       run: |
         export IMAGE=intelanalytics/kms-utils
@@ -1068,7 +1068,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -1116,7 +1116,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker deploy pccs
       run: |
         export IMAGE=intelanalytics/pccs
@@ -1138,7 +1138,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-python-toolkit-base' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -1166,7 +1166,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-python-toolkit-ref' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -1200,7 +1200,7 @@ jobs:
     runs-on: [self-hosted, Shire]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -1382,7 +1382,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-machine-learning-base' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -1420,7 +1420,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-machine-learning-ref' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -1558,7 +1558,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-kms-base' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -1587,7 +1587,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-kms-reference' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -1618,7 +1618,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}
@@ -1645,7 +1645,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: docker login
       run: |
         docker login -u ${DOCKERHUB_USERNAME} -p ${DOCKERHUB_PASSWORD}

--- a/.github/workflows/manually_build_for_testing.yml
+++ b/.github/workflows/manually_build_for_testing.yml
@@ -62,7 +62,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -91,7 +91,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.sha }}
       - name: docker login
@@ -120,7 +120,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -149,7 +149,7 @@ jobs:
     runs-on: [self-hosted, Shire]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -178,7 +178,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -207,7 +207,7 @@ jobs:
     runs-on: [self-hosted, Shire]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -236,7 +236,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -265,7 +265,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -296,7 +296,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -330,7 +330,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -358,7 +358,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-bigdl-llm-gramine-base' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -390,7 +390,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-bigdl-llm-gramine-ref' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -423,7 +423,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-dl-serving-gramine-base' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -453,7 +453,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-dl-serving-gramine-ref' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -486,7 +486,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-deep-learning-gramine-base' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -517,7 +517,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-deep-learning-gramine-ref' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -552,7 +552,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -637,7 +637,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -705,7 +705,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -741,7 +741,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.sha }}
       - name: docker login
@@ -777,7 +777,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -813,7 +813,7 @@ jobs:
     runs-on: [ self-hosted, Shire ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
         with:
          ref: ${{ github.event.inputs.sha }}
       - name: docker login
@@ -859,7 +859,7 @@ jobs:
     runs-on: [ self-hosted, Shire ]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
         with:
           ref: ${{ github.event.inputs.sha }}
       - name: docker login
@@ -897,7 +897,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -933,7 +933,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -969,7 +969,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker deploy kms-util
@@ -996,7 +996,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker deploy pccs
@@ -1020,7 +1020,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-python-toolkit-base' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -1050,7 +1050,7 @@ jobs:
     if: ${{ github.event.inputs.artifact == 'bigdl-ppml-trusted-python-toolkit-ref' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Shire]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login
@@ -1084,7 +1084,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       with:
         ref: ${{ github.event.inputs.sha }}
     - name: docker login

--- a/.github/workflows/nano-nightly-test.yml
+++ b/.github/workflows/nano-nightly-test.yml
@@ -34,7 +34,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up Nano PyTorch Env
       uses: ./.github/actions/nano/setup-pytorch-env
       with:
@@ -67,7 +67,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up Nano Tensorflow Env
       uses: ./.github/actions/nano/setup-tensorflow-env
       with:
@@ -100,7 +100,7 @@ jobs:
         python-version: ["3.8"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up Nano PyTorch Env
       uses: ./.github/actions/nano/setup-pytorch-env
       with:
@@ -120,7 +120,7 @@ jobs:
         python-version: ["3.8"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up Nano Tensorflow Env
       uses: ./.github/actions/nano/setup-tensorflow-env
       with:
@@ -140,7 +140,7 @@ jobs:
         python-version: ["3.8"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up Nano PyTorch Env
       uses: ./.github/actions/nano/setup-pytorch-env
       with:
@@ -162,7 +162,7 @@ jobs:
         python-version: ["3.8"]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up Nano Tensorflow Env
       uses: ./.github/actions/nano/setup-tensorflow-env
       with:
@@ -178,7 +178,7 @@ jobs:
   create-workflow-badge:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: create workflow badge
       if: ${{ always() }}
       uses: ./.github/actions/create-job-status-badge

--- a/.github/workflows/nano_howto_guides_tests.yml
+++ b/.github/workflows/nano_howto_guides_tests.yml
@@ -36,7 +36,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -106,7 +106,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -166,7 +166,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/nano_notebooks_tests.yml
+++ b/.github/workflows/nano_notebooks_tests.yml
@@ -37,7 +37,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -146,7 +146,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -208,7 +208,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/nano_unit_tests_basic.yml
+++ b/.github/workflows/nano_unit_tests_basic.yml
@@ -32,7 +32,7 @@ jobs:
         os: ["ubuntu-20.04"]
         python-version: ["3.8"]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/nano_unit_tests_pytorch.yml
+++ b/.github/workflows/nano_unit_tests_pytorch.yml
@@ -39,7 +39,7 @@ jobs:
           "pytorch_20 neural-compressor==2.1 https://intel-extension-for-pytorch.s3.amazonaws.com/ipex_stable/cpu/oneccl_bind_pt-2.0.0%2Bcpu-cp38-cp38-linux_x86_64.whl",
           ]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -118,7 +118,7 @@ jobs:
           "pytorch_20 neural-compressor==2.1 https://intel-extension-for-pytorch.s3.amazonaws.com/ipex_stable/cpu/oneccl_bind_pt-2.0.0%2Bcpu-cp38-cp38-linux_x86_64.whl",
           ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
 
       - name: Run PyTorch unit tests(Ray)
         shell: bash
@@ -243,7 +243,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -294,7 +294,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/nano_unit_tests_tensorflow.yml
+++ b/.github/workflows/nano_unit_tests_tensorflow.yml
@@ -46,7 +46,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
@@ -112,7 +112,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: Install dependencies
         run: |
           sudo apt-get update && sudo apt-get install openmpi-bin openmpi-doc libopenmpi-dev

--- a/.github/workflows/nightly-build-example-tests-ppml.yaml
+++ b/.github/workflows/nightly-build-example-tests-ppml.yaml
@@ -38,7 +38,7 @@ jobs:
     runs-on: [self-hosted, SGX, Wilwarin]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: set variable
       env:
         DEFAULT_EXAMPLE: 'ALL'

--- a/.github/workflows/nightly_build.yml
+++ b/.github/workflows/nightly_build.yml
@@ -37,7 +37,7 @@ jobs:
     runs-on: [self-hosted, Bree]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
@@ -183,7 +183,7 @@ jobs:
     runs-on: [self-hosted, Shire]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: set env
       env:
         DEFAULT_TAG: 'latest'
@@ -313,7 +313,7 @@ jobs:
     runs-on: [self-hosted, Bree]
     needs: llm-cpp-build
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
 
@@ -365,7 +365,7 @@ jobs:
     runs-on: [self-hosted, Bree]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -490,7 +490,7 @@ jobs:
   create-workflow-badge:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: create workflow badge
       if: ${{ always() }}
       uses: ./.github/actions/create-job-status-badge

--- a/.github/workflows/nightly_test.yml
+++ b/.github/workflows/nightly_test.yml
@@ -103,7 +103,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Setup env
@@ -130,7 +130,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Setup env
@@ -157,7 +157,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Setup env
@@ -184,7 +184,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Setup env
@@ -211,7 +211,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Setup env
@@ -238,7 +238,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Setup env
@@ -265,7 +265,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Setup env
@@ -292,7 +292,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Setup env
@@ -319,7 +319,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Setup env
@@ -346,7 +346,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -375,7 +375,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -404,7 +404,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -433,7 +433,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -462,7 +462,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -491,7 +491,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -520,7 +520,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -549,7 +549,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -578,7 +578,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -607,7 +607,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -636,7 +636,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -665,7 +665,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -694,7 +694,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -723,7 +723,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -752,7 +752,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -781,7 +781,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -810,7 +810,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -839,7 +839,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -868,7 +868,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -897,7 +897,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -926,7 +926,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -955,7 +955,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -984,7 +984,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1013,7 +1013,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1042,7 +1042,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1072,7 +1072,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1101,7 +1101,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1130,7 +1130,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1159,7 +1159,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1188,7 +1188,7 @@ jobs:
     runs-on: [self-hosted, Gondolin-Ctx]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Setup env
       uses: ./.github/actions/orca/setup-env/setup-orca-ray-ctx-py37
     - name: Run Test
@@ -1213,7 +1213,7 @@ jobs:
     runs-on: [self-hosted, Gondolin-resources, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1242,7 +1242,7 @@ jobs:
     runs-on: [self-hosted, Vilvarin]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: set env
       env:
         DEFAULT_IMAGE: '10.239.45.10/arda/intelanalytics/bigdl-orca'
@@ -1272,7 +1272,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1296,7 +1296,7 @@ jobs:
     runs-on: [ self-hosted, ubuntu-20.04-lts, CLX, AVX512, Ettenmoors ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1320,7 +1320,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1344,7 +1344,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1373,7 +1373,7 @@ jobs:
     runs-on: [self-hosted, SGX, Wilwarin]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1407,7 +1407,7 @@ jobs:
     runs-on: [self-hosted, EDMM]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: Set up JDK8
         uses: ./.github/actions/jdk-setup-action
       - name: Set up maven
@@ -1441,7 +1441,7 @@ jobs:
     runs-on: [self-hosted, Vilvarin]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: set env
       env:
         DEFAULT_IMAGE: '10.239.45.10/arda/intelanalytics/bigdl-ppml-trusted-realtime-ml-scala-occlum'
@@ -1471,7 +1471,7 @@ jobs:
     runs-on: [self-hosted, Vilvarin-root]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: set env
       env:
         DEFAULT_IMAGE: '10.239.45.10/arda/intelanalytics/bigdl-ppml-trusted-realtime-ml-scala-occlum'
@@ -1502,7 +1502,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1531,7 +1531,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1560,7 +1560,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1589,7 +1589,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1618,7 +1618,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1647,7 +1647,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
     
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1676,7 +1676,7 @@ jobs:
     runs-on: [self-hosted, SGX, Wilwarin]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -1710,7 +1710,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up Maven
@@ -1739,7 +1739,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up Maven
@@ -1768,7 +1768,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up Maven
@@ -1797,7 +1797,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up Maven
@@ -1826,7 +1826,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up Maven
@@ -1855,7 +1855,7 @@ jobs:
     runs-on: [ self-hosted, Gondolin, ubuntu-20.04-lts ]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up Maven
@@ -1884,7 +1884,7 @@ jobs:
   create-workflow-badge:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: create workflow badge
       if: ${{ always() }}
       uses: ./.github/actions/create-job-status-badge

--- a/.github/workflows/performance-regression-test.yml
+++ b/.github/workflows/performance-regression-test.yml
@@ -21,12 +21,12 @@ jobs:
       # trigged by opening a PR which modifies this file or scheduling or commenting 'APRT' in a closed PR
       - name: checkout (open pr or schedule or closed pr comments)
         if: github.event.pull_request || github.event.schedule || github.event.issue.pull_request.merged_at
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
 
       # trigged by commenting 'APRT' in an opening PR
       - name: checkout (opening pr comments)
         if: github.event.issue.pull_request && !github.event.issue.pull_request.merged_at
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
         with:
           ref: ${{ format('refs/pull/{0}/merge', github.event.issue.number) }}
 

--- a/.github/workflows/python-style-check.yml
+++ b/.github/workflows/python-style-check.yml
@@ -36,7 +36,7 @@ jobs:
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # actions/checkout@v2
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -110,7 +110,7 @@ jobs:
     if: github.event.pull_request == ''
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: create workflow badge
       if: ${{ always() }}
       uses: ./.github/actions/create-job-status-badge

--- a/.github/workflows/scala-style-check.yml
+++ b/.github/workflows/scala-style-check.yml
@@ -30,7 +30,7 @@ jobs:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK 8
       uses: actions/setup-java@v3
       with:
@@ -80,7 +80,7 @@ jobs:
     if: github.event.pull_request == ''
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: create workflow badge
       if: ${{ always() }}
       uses: ./.github/actions/create-job-status-badge

--- a/.github/workflows/sdl_hadolint.yml
+++ b/.github/workflows/sdl_hadolint.yml
@@ -16,7 +16,7 @@ jobs:
   scan-dockerfile:
     runs-on: [self-hosted, SDL-TEST]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: "bigdl-k8s-dockerfile-scanning"
       run: |
         docker run --rm -i hadolint/hadolint < ./docker/bigdl-k8s/Dockerfile

--- a/.github/workflows/sdl_snyk_docker.yml
+++ b/.github/workflows/sdl_snyk_docker.yml
@@ -25,7 +25,7 @@ jobs:
   snyk-docker:
     runs-on: [self-hosted, SDL-TEST]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: set env
       run: |
         echo "IMAGE=${{inputs.snyk_image}}"

--- a/.github/workflows/sdl_snyk_python.yml
+++ b/.github/workflows/sdl_snyk_python.yml
@@ -27,7 +27,7 @@ jobs:
   snyk-python:
     runs-on: [self-hosted, SDL]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: set env
       run: |
         echo "SNYK_APITOKEN=${{inputs.snyk_apitoken}}"

--- a/.github/workflows/sdl_snyk_scala.yml
+++ b/.github/workflows/sdl_snyk_scala.yml
@@ -25,7 +25,7 @@ jobs:
   snyk-scala:
     runs-on: [self-hosted, SDL]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: "run Snyk test scan Spark 2.4.6"
       env: 
           no_proxy: snyk.devtools.intel.com, intel.com

--- a/.github/workflows/sdl_virus-malware.yml
+++ b/.github/workflows/sdl_virus-malware.yml
@@ -16,7 +16,7 @@ jobs:
   scan-virus:
     runs-on: [self-hosted, SDL]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: "virus-malware-scanning"
       run: |
         uvscan --RPTOBJECTS --RECURSIVE --UNZIP --HTML=scan-report.html --LOUD --SUMMARY --ANALYZE --PANALYZE .

--- a/.github/workflows/url-auto-merge.yml
+++ b/.github/workflows/url-auto-merge.yml
@@ -14,7 +14,7 @@ jobs:
   createPRandAutoMerge:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
         with:
           fetch-depth: 0
       - name: Update time

--- a/.github/workflows/url_check.yml
+++ b/.github/workflows/url_check.yml
@@ -14,7 +14,7 @@ jobs:
   checkDownloadURL:
     runs-on: [self-hosted, Gondolin, ubuntu-20.04-lts]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: Run a url check script
         run: |
             url_list=$(grep -wio "https://oss[0-9_a-zA-Z\/.\-]*" docs/readthedocs/source/doc/Orca/Overview/install.md)

--- a/.github/workflows/weekly_test.yml
+++ b/.github/workflows/weekly_test.yml
@@ -46,7 +46,7 @@ jobs:
     runs-on: [self-hosted, Vilvarin]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: set env
       env:
         DEFAULT_IMAGE: '10.239.45.10/arda/intelanalytics/bigdl-ppml-trusted-big-data-ml-scala-occlum'
@@ -76,7 +76,7 @@ jobs:
     runs-on: [self-hosted, EDMM]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
       - name: set env
         env:
           DEFAULT_IMAGE: '10.239.45.10/arda/intelanalytics/bigdl-ppml-trusted-big-data-ml-scala-occlum'
@@ -106,7 +106,7 @@ jobs:
     runs-on: [self-hosted, Vilvarin]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -140,7 +140,7 @@ jobs:
     runs-on: [self-hosted, Vilvarin]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -173,7 +173,7 @@ jobs:
     if: ${{ github.event.schedule || github.event.inputs.artifact == 'PPML-Spark-PySpark-Local-Sql-UT-On-Gramine' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, SGX, Wilwarin]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -206,7 +206,7 @@ jobs:
     if: ${{ github.event.schedule || github.event.inputs.artifact == 'PPML-Spark-K8S-TPC-H-On-Gramine' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Vilvarin]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -239,7 +239,7 @@ jobs:
     if: ${{ github.event.schedule || github.event.inputs.artifact == 'PPML-Spark-K8S-TPC-DS-On-Gramine' || github.event.inputs.artifact == 'all' }}
     runs-on: [self-hosted, Vilvarin]
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -274,7 +274,7 @@ jobs:
     runs-on: [self-hosted, SGX, Wilwarin]
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: Set up JDK8
       uses: ./.github/actions/jdk-setup-action
     - name: Set up maven
@@ -307,7 +307,7 @@ jobs:
   create-workflow-badge:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # actions/checkout@v3
     - name: create workflow badge
       if: ${{ always() }}
       uses: ./.github/actions/create-job-status-badge


### PR DESCRIPTION
## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

This submission fixes OpenSSF Pinned-Dependencies Issues: GitHub-owned GitHubAction **actions/checkout** not pinned by hash (for example https://github.com/intel-analytics/BigDL/security/code-scanning/346)

https://github.com/actions/checkout/releases/tag/v2
https://github.com/actions/checkout/releases/tag/v3