### PR TITLE
LLM: fix device setting during saving optimized model

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -59,6 +59,7 @@ def save_low_bit(self, *args, **kwargs):
         delattr(self.config, "quantization_config")
         delattr(self.config, "_pre_quantization_dtype")
 
+    origin_device = self.device
     self.to('cpu')
 
     kwargs['safe_serialization'] = False
@@ -85,6 +86,8 @@ def save_low_bit(self, *args, **kwargs):
     load_keys = {"all_checkpoint_keys": list(self.state_dict().keys())}
     with open(os.path.join(args[0], "load_keys.json"), "w") as json_file:
         json.dump(load_keys, json_file)
+    if origin_device != 'cpu':
+        self.to(origin_device)
 
 
 class _BaseAutoModelClass:


### PR DESCRIPTION
## Description

During `save_low_bit`, model is directly moved to `cpu`. Therefore, exist `found at least two devices, cpu and xpu` error when running the following code:
```python
model = model.to('xpu')
model.save_low_bit(save_path)

input_ids = tokenizer.encode(prompt, return_tensors="pt").to('xpu')
output = model.generate(input_ids, max_new_tokens=32)
```

### 3. Summary of the change 

- Fix device setting of `save_low_bit` 

### 4. How to test?
- [x] Unit test
- [x] Local test
