### PR TITLE
Skip rescale rwkv linear when load_low_bit

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -393,6 +393,9 @@ class _BaseAutoModelClass:
                 model.config.update({"bigdl_lcmu_enabled": False})
 
         model = model.to("cpu")
+        # rwkv model linear layers has been rescaled
+        if model.config.model_type == "rwkv":
+            model.layers_are_rescaled = True
         model = ggml_convert_low_bit(model, qtype, optimize_model,
                                      modules_to_not_convert=modules_to_not_convert,
                                      cpu_embedding=cpu_embedding, lightweight_bmm=lightweight_bmm,

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -393,9 +393,6 @@ class _BaseAutoModelClass:
                 model.config.update({"bigdl_lcmu_enabled": False})
 
         model = model.to("cpu")
-        # rwkv model linear layers has been rescaled
-        if model.config.model_type == "rwkv":
-            model.layers_are_rescaled = True
         model = ggml_convert_low_bit(model, qtype, optimize_model,
                                      modules_to_not_convert=modules_to_not_convert,
                                      cpu_embedding=cpu_embedding, lightweight_bmm=lightweight_bmm,
@@ -563,6 +560,10 @@ class _BaseAutoModelClass:
                 model = model_class(config, *model_args, **kwargs)
         else:
             model = model_class(config, *model_args, **kwargs)
+
+        # rwkv model linear layers has been rescaled
+        if model.config.model_type == "rwkv":
+            model.layers_are_rescaled = True
 
         # Loading args may differ based on their usage
         quant_device = "meta" if bigdl_lcmu_enabled else "cpu"


### PR DESCRIPTION
## Description

The saved weights has been rescaled so we can skip this when we load again.

https://github.com/intel-analytics/BigDL/issues/10161