### PR TITLE
use fused qkv forward in qwen2

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -292,7 +292,8 @@ def llama_attention_forward_4_31_quantized(
                                                                          tmp_cache_k, tmp_cache_v,
                                                                          self.q_proj.weight.qtype,
                                                                          0,
-                                                                         self.head_dim)
+                                                                         self.head_dim,
+                                                                         self.rotary_emb.base,)
     else:
         query_states = self.q_proj(hidden_states)
         key_states = self.k_proj(hidden_states)
@@ -478,7 +479,8 @@ def llama_attention_forward_4_31_original(
                                                                          cache_k, cache_v,
                                                                          self.q_proj.weight.qtype,
                                                                          kv_seq_len,
-                                                                         self.head_dim)
+                                                                         self.head_dim,
+                                                                         self.rotary_emb.base,)
         kv_seq_len += 1
 
     else:
@@ -715,7 +717,9 @@ def llama_attention_selective_batching_forward_4_31(
                                                                          past_k, past_v,
                                                                          self.q_proj.weight.qtype,
                                                                          kv_seq_len,
-                                                                         self.head_dim)
+                                                                         self.head_dim,
+                                                                         self.rotary_emb.base,
+                                                                         )
         kv_seq_len += 1
     else:
         if self.config.pretraining_tp > 1:
@@ -893,7 +897,8 @@ def llama_attention_forward_4_36(
                                                                          cache_k, cache_v,
                                                                          self.q_proj.weight.qtype,
                                                                          kv_seq_len,
-                                                                         self.head_dim)
+                                                                         self.head_dim,
+                                                                         self.rotary_emb.base,)
         kv_seq_len += 1
         # update past_key_value's seem_tokens and kv caches.
         if self.layer_idx == 0:

--- a/python/llm/src/bigdl/llm/transformers/models/mixtral.py
+++ b/python/llm/src/bigdl/llm/transformers/models/mixtral.py
@@ -168,7 +168,8 @@ def mixtral_attention_forward(
                                                                          cache_k, cache_v,
                                                                          self.q_proj.weight.qtype,
                                                                          kv_seq_len,
-                                                                         self.head_dim)
+                                                                         self.head_dim,
+                                                                         self.rotary_emb.base,)
         kv_seq_len += 1
         # update past_key_value's seem_tokens and kv caches.
         if self.layer_idx == 0:

--- a/python/llm/src/bigdl/llm/transformers/models/qwen2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/qwen2.py
@@ -253,7 +253,7 @@ def qwen2_attention_forward_origin(
     qtype = getattr(self.q_proj, "qtype", None)
     qtype_check = qtype in [SYM_INT4, FP8E5]
     decoding_fast_path = (qtype_check and use_fuse_rope
-                          and enough_kv_room and bsz * q_len == 1) and True
+                          and enough_kv_room and bsz * q_len == 1)
     if decoding_fast_path:
         hidden_states = hidden_states.view(1, -1)
         cache_k = past_key_value.key_cache[self.layer_idx]

--- a/python/llm/src/bigdl/llm/transformers/models/qwen2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/qwen2.py
@@ -223,7 +223,9 @@ def qwen2_attention_forward_quantized(
         attn_weights = None
 
     return attn_output, attn_weights, past_key_value
-
+from bigdl.llm.ggml.quantize import ggml_tensor_qtype
+SYM_INT4 = ggml_tensor_qtype["sym_int4"]
+FP8E5 = ggml_tensor_qtype["fp8_e5m2"]
 
 def qwen2_attention_forward_origin(
     self,
@@ -247,72 +249,104 @@ def qwen2_attention_forward_origin(
     device = hidden_states.device
 
     enough_kv_room = is_enough_kv_cache_room_4_36(past_key_value, self.layer_idx)
-
-    query_states = self.q_proj(hidden_states)
-    key_states = self.k_proj(hidden_states)
-    value_states = self.v_proj(hidden_states)
-
-    query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
-    key_states = \
-        key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-    value_states = \
-        value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
-
-    kv_seq_len = key_states.shape[-2]
-    if past_key_value is not None:
-        if self.layer_idx is None:
-            invalidInputError(
-                False,
-                "The cache structure has changed since version v4.36. "
-                f"If you are using {self.__class__.__name__} "
-                "for auto-regressive decoding with k/v caching, "
-                "please make sure to initialize the attention class with a layer index."
-            )
-        kv_seq_len += past_key_value.get_usable_length(kv_seq_len, self.layer_idx)
-    cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
-    if use_fuse_rope:
-        query_states, key_states = apply_rotary_pos_emb_cache_freq_xpu(query_states, key_states,
-                                                                       sin, cos, "qwen2",
-                                                                       position_ids)
-    else:
-        query_states, key_states = apply_rotary_pos_emb(query_states, key_states,
-                                                        cos, sin, position_ids)
-
-    if past_key_value is not None:
-        # update the number of seen tokens
+    qtype = getattr(self.q_proj, "qtype", None)
+    qtype_check = qtype in [SYM_INT4, FP8E5]
+    decoding_fast_path = (qtype_check and use_fuse_rope
+                          and enough_kv_room and bsz * q_len == 1) and True
+    if decoding_fast_path:
+        hidden_states = hidden_states.view(1, -1)
+        cache_k = past_key_value.key_cache[self.layer_idx]
+        cache_v = past_key_value.value_cache[self.layer_idx]
+        kv_seq_len = cache_k.shape[-2]
+        import linear_q4_0
+        query_states, key_states, value_states = linear_q4_0.forward_qkv(hidden_states,
+                                                                         self.q_proj.weight,
+                                                                         self.k_proj.weight,
+                                                                         self.v_proj.weight,
+                                                                         self.q_proj.bias,
+                                                                         self.k_proj.bias,
+                                                                         self.v_proj.bias,
+                                                                         position_ids,
+                                                                         cache_k, cache_v,
+                                                                         self.q_proj.weight.qtype,
+                                                                         kv_seq_len,
+                                                                         self.head_dim,
+                                                                         self.rotary_emb.base,
+                                                                         )
+        kv_seq_len += 1
         if self.layer_idx == 0:
-            past_key_value.seen_tokens += key_states.shape[-2]
+            past_key_value.seen_tokens = kv_seq_len
+        past_key_value.key_cache[self.layer_idx] = key_states
+        past_key_value.value_cache[self.layer_idx] = value_states
+        # print("fast path")
+    else:
 
-        if len(past_key_value.key_cache) <= self.layer_idx:
-            past_key_value.key_cache.append(key_states)
-            past_key_value.value_cache.append(value_states)
+        query_states = self.q_proj(hidden_states)
+        key_states = self.k_proj(hidden_states)
+        value_states = self.v_proj(hidden_states)
+
+        query_states = query_states.view(bsz, q_len, self.num_heads, self.head_dim).transpose(1, 2)
+        key_states = \
+            key_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+        value_states = \
+            value_states.view(bsz, q_len, self.num_key_value_heads, self.head_dim).transpose(1, 2)
+
+        kv_seq_len = key_states.shape[-2]
+        if past_key_value is not None:
+            if self.layer_idx is None:
+                invalidInputError(
+                    False,
+                    "The cache structure has changed since version v4.36. "
+                    f"If you are using {self.__class__.__name__} "
+                    "for auto-regressive decoding with k/v caching, "
+                    "please make sure to initialize the attention class with a layer index."
+                )
+            kv_seq_len += past_key_value.get_usable_length(kv_seq_len, self.layer_idx)
+        cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
+        if use_fuse_rope:
+            query_states, key_states = apply_rotary_pos_emb_cache_freq_xpu(query_states, key_states,
+                                                                        sin, cos, "qwen2",
+                                                                        position_ids)
         else:
-            cache_k = past_key_value.key_cache[self.layer_idx]
-            cache_v = past_key_value.value_cache[self.layer_idx]
+            query_states, key_states = apply_rotary_pos_emb(query_states, key_states,
+                                                            cos, sin, position_ids)
 
-            if not enough_kv_room:
-                # allocate new
-                new_c_k, new_c_v = extend_kv_cache(bsz,
-                                                   self.num_key_value_heads,  # Support GQA
-                                                   self.head_dim,
-                                                   cache_k.size(2),
-                                                   kv_seq_len + KV_CACHE_ALLOC_BLOCK_LENGTH,
-                                                   dtype=cache_k.dtype,
-                                                   device=device)
+        if past_key_value is not None:
+        # update the number of seen tokens
+            # update the number of seen tokens
+            if self.layer_idx == 0:
+                past_key_value.seen_tokens += key_states.shape[-2]
 
-                new_c_k[:] = cache_k
-                new_c_v[:] = cache_v
-                cache_k = new_c_k
-                cache_v = new_c_v
+            if len(past_key_value.key_cache) <= self.layer_idx:
+                past_key_value.key_cache.append(key_states)
+                past_key_value.value_cache.append(value_states)
+            else:
+                cache_k = past_key_value.key_cache[self.layer_idx]
+                cache_v = past_key_value.value_cache[self.layer_idx]
 
-            key_states, value_states = append_kv_cache(cache_k,
-                                                       cache_v,
-                                                       key_states,
-                                                       value_states)
+                if not enough_kv_room:
+                    # allocate new
+                    new_c_k, new_c_v = extend_kv_cache(bsz,
+                                                    self.num_key_value_heads,  # Support GQA
+                                                    self.head_dim,
+                                                    cache_k.size(2),
+                                                    kv_seq_len + KV_CACHE_ALLOC_BLOCK_LENGTH,
+                                                    dtype=cache_k.dtype,
+                                                    device=device)
 
-            # update past_key_value
-            past_key_value.key_cache[self.layer_idx] = key_states
-            past_key_value.value_cache[self.layer_idx] = value_states
+                    new_c_k[:] = cache_k
+                    new_c_v[:] = cache_v
+                    cache_k = new_c_k
+                    cache_v = new_c_v
+
+                key_states, value_states = append_kv_cache(cache_k,
+                                                        cache_v,
+                                                        key_states,
+                                                        value_states)
+
+                # update past_key_value
+                past_key_value.key_cache[self.layer_idx] = key_states
+                past_key_value.value_cache[self.layer_idx] = value_states
 
     # repeat k/v heads if n_kv_heads < n_heads
     key_states = repeat_kv(key_states, self.num_key_value_groups)

--- a/python/llm/src/bigdl/llm/transformers/models/qwen2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/qwen2.py
@@ -269,7 +269,7 @@ def qwen2_attention_forward_origin(
             past_key_value.seen_tokens = kv_seq_len
         past_key_value.key_cache[self.layer_idx] = key_states
         past_key_value.value_cache[self.layer_idx] = value_states
-        # print("fast path")
+
     else:
 
         query_states = self.q_proj(hidden_states)

--- a/python/llm/src/bigdl/llm/transformers/models/qwen2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/qwen2.py
@@ -259,7 +259,7 @@ def qwen2_attention_forward_origin(
         cache_v = past_key_value.value_cache[self.layer_idx]
         kv_seq_len = cache_k.shape[-2]
         import linear_q4_0
-        query_states, key_states, value_states = linear_q4_0.forward_qkv(hidden_states,
+        query_states, key_states, value_states = linear_q4_0.forward_qkv_bias(hidden_states,
                                                                          self.q_proj.weight,
                                                                          self.k_proj.weight,
                                                                          self.v_proj.weight,

--- a/python/llm/src/bigdl/llm/transformers/models/qwen2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/qwen2.py
@@ -294,9 +294,13 @@ def qwen2_attention_forward_origin(
                 )
             kv_seq_len += past_key_value.get_usable_length(kv_seq_len, self.layer_idx)
         cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
-        query_states, key_states = apply_rotary_pos_emb_cache_freq_xpu(query_states, key_states,
-                                                                       sin, cos, "qwen2",
-                                                                       position_ids)
+        if use_fuse_rope:
+            query_states, key_states = apply_rotary_pos_emb_cache_freq_xpu(query_states, key_states,
+                                                                        sin, cos, "qwen2",
+                                                                        position_ids)
+        else:
+            query_states, key_states = apply_rotary_pos_emb(query_states, key_states,
+                                                            cos, sin, position_ids)
 
         if past_key_value is not None:
         # update the number of seen tokens

--- a/python/llm/src/bigdl/llm/transformers/models/qwen2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/qwen2.py
@@ -296,14 +296,13 @@ def qwen2_attention_forward_origin(
         cos, sin = self.rotary_emb(value_states, seq_len=kv_seq_len)
         if use_fuse_rope:
             query_states, key_states = apply_rotary_pos_emb_cache_freq_xpu(query_states, key_states,
-                                                                        sin, cos, "qwen2",
-                                                                        position_ids)
+                                                                           sin, cos, "qwen2",
+                                                                           position_ids)
         else:
             query_states, key_states = apply_rotary_pos_emb(query_states, key_states,
                                                             cos, sin, position_ids)
 
         if past_key_value is not None:
-        # update the number of seen tokens
             # update the number of seen tokens
             if self.layer_idx == 0:
                 past_key_value.seen_tokens += key_states.shape[-2]


### PR DESCRIPTION
## Description

Adapt qwen2 to use fused qkv forward (with bias and customized rope base) to reduce single batch next token latency.

perf: https://github.com/analytics-zoo/nano/issues/1040#issuecomment-1955394183
