### PR TITLE
[LLM] Add quantize_kv optimization for yuan2 model

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -1196,13 +1196,14 @@ def _optimize_post(model, lightweight_bmm=False):
         modeling_module_name = model.__class__.__module__
         module = importlib.import_module(modeling_module_name)
         from bigdl.llm.transformers.models.yuan import yuan_attention_forward
-        from bigdl.llm.transformers.models.yuan import yuan_mlp_forward
+        # from bigdl.llm.transformers.models.yuan import yuan_mlp_forward
         convert_forward(model,
                         module.YuanAttention,
                         yuan_attention_forward
                         )
-        convert_forward(model,
-                        module.YuanMLP,
-                        yuan_mlp_forward
-                        )
+        # disable able mlp_forward for quantize_kv on mtl.
+        # convert_forward(model,
+        #                 module.YuanMLP,
+        #                 yuan_mlp_forward
+        #                 )
     return model

--- a/python/llm/src/bigdl/llm/transformers/models/yuan.py
+++ b/python/llm/src/bigdl/llm/transformers/models/yuan.py
@@ -223,7 +223,7 @@ def yuan_attention_forward_quantized(
             past_key_value = (key_states, value_states, inference_hidden_states_memory)
 
     else:
-        k_cache, v_cache, inference_hidden_states_memory = past_key_value
+        k_cache, v_cache, _ = past_key_value
         key_states, value_states = append_fp8_kv_cache(k_cache, v_cache,
                                                        key_states, value_states)
         past_key_value = (key_states, value_states, inference_hidden_states_memory)

--- a/python/llm/src/bigdl/llm/transformers/models/yuan.py
+++ b/python/llm/src/bigdl/llm/transformers/models/yuan.py
@@ -147,7 +147,7 @@ def yuan_attention_forward(
     output_attentions: bool = False,
     use_cache: bool = False,
 ) -> Tuple[torch.Tensor, Optional[torch.Tensor], Optional[Tuple[torch.Tensor]]]:
-    if use_quantize_kv_cache(self.q_proj, hidden_states):
+    if use_quantize_kv_cache(self.merged_qk_proj, hidden_states):
         forward_function = yuan_attention_forward_quantized
     else:
         forward_function = yuan_attention_forward_origin

--- a/python/llm/src/bigdl/llm/transformers/models/yuan.py
+++ b/python/llm/src/bigdl/llm/transformers/models/yuan.py
@@ -190,7 +190,7 @@ def yuan_attention_forward_quantized(
     if use_cache:
         if is_first_step:
             if q_len >= 2:
-                inference_hidden_states_memory = hidden_states[ :, -2:, :]
+                inference_hidden_states_memory = hidden_states[:, -2:, :]
             else:
                 inference_hidden_states_memory[:, :, :] = 0
                 inference_hidden_states_memory[:, -1:, :] = hidden_states[:, -1:, :]
@@ -209,7 +209,7 @@ def yuan_attention_forward_quantized(
     qk_states = torch.cat([query_states, key_states], dim=-1)
     qk_states = qk_states.view(bsz, q_len, self.num_heads,
                                int(qk_states.shape[-1]//self.num_heads))
-    (query_states, key_states) =  torch.chunk(qk_states, 2, dim=-1)
+    (query_states, key_states) = torch.chunk(qk_states, 2, dim=-1)
     query_states = query_states.transpose(1, 2)
     key_states = key_states.transpose(1, 2)
 


### PR DESCRIPTION
## Description
Add quantize_kv to optimize the performance of yuan2 model on MTL. 

### 1. Why the change?
The generation performance of the Yuan2 model on GPU needs to be optimized.

### 2. User API changes
N/A

### 3. Summary of the change 
Add quantize_kv.

### 4. How to test?
- [x] Application test

