### PR TITLE
LLM: Reduce speculative _ipex_optimize_model memory use

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -662,7 +662,6 @@ def replace_func(m, target_m, func_name, new_func):
 
 
 def _optimize_ipex(model):
-    import intel_extension_for_pytorch as ipex
     from intel_extension_for_pytorch.transformers.optimize import model_convert_reference
     from transformers.modeling_attn_mask_utils import AttentionMaskConverter
     from bigdl.llm.transformers.convert_ipex import (
@@ -694,7 +693,6 @@ def _optimize_ipex(model):
         # baichuan2
         rms_classes.append(type(model.model.layers[0].input_layernorm))
 
-    model = ipex.optimize(model.eval(), dtype=torch.bfloat16, inplace=True).eval()
     _ipex_optimize_model(model, rms_classes)
     return _ipex_jit(model)
 

--- a/python/llm/src/bigdl/llm/transformers/convert_ipex.py
+++ b/python/llm/src/bigdl/llm/transformers/convert_ipex.py
@@ -41,6 +41,10 @@ from intel_extension_for_pytorch.transformers.optimize import (
     lowering_class_cpu,
     convert_class,
 )
+from intel_extension_for_pytorch.cpu._auto_kernel_selection import (
+    _enable_tpp,
+    _using_tpp,
+)
 
 
 def _ipex_optimize_rmsnorm(_model, supported_classes):
@@ -69,7 +73,7 @@ def _ipex_optimize_decoder(model):
             supported_mlp_class,
             _IPEXDecoderLayerCPU,
             model.config,
-            tpp=False,
+            tpp=True if _using_tpp() else False,
             woq=False,
         )
 
@@ -87,13 +91,13 @@ def _ipex_optimize_attention(model):
             supported_mha_class,
             _IPEXAttentionCPU,
             model.config,
-            tpp=False,
+            tpp=True if _using_tpp() else False,
             woq=False,
         )
 
 
 def _ipex_optimize_model(model, rms_classes):
-
+    _enable_tpp()
     _ipex_optimize_rmsnorm(model, rms_classes)
     _ipex_optimize_attention(model)
     _ipex_optimize_decoder(model)

--- a/python/llm/src/bigdl/llm/transformers/convert_ipex.py
+++ b/python/llm/src/bigdl/llm/transformers/convert_ipex.py
@@ -98,6 +98,8 @@ def _ipex_optimize_attention(model):
 
 def _ipex_optimize_model(model, rms_classes):
     _enable_tpp()
+    import intel_extension_for_pytorch as ipex
+    ipex.optimize(model.eval(), dtype=torch.bfloat16, inplace=True).eval()
     _ipex_optimize_rmsnorm(model, rms_classes)
     _ipex_optimize_attention(model)
     _ipex_optimize_decoder(model)


### PR DESCRIPTION
## Description
LLM: Reduce speculative _ipex_optimize_model memory use.
Qwen72b 1k-128: 600GB -> 450GB.
Llama2-13b 1k-128: 90GB->60GB.

But the ipex always make the memory usage double，even thought we set the config inplace=True.
Qwen72b with ipex bf16 1k-128: 450GB
Qwen72b with bigdl bf16 1k-128: 300GB
<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [ ] N/A
- [ ] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...

### 5. New dependencies

<!-- If no new dependency is introduced, remove this section -->

- [ ] New Python dependencies
       - Dependency1 
       - Dependency2
       - ...
- [ ] New Java/Scala dependencies and their license
       - Dependency1 and license1
       - Dependency2 and license2
       - ...
