### PR TITLE
[LLM] Provide an interface used for loading model on the `Fastchat` side

### DIFF
--- a/python/llm/src/bigdl/llm/utils/load.py
+++ b/python/llm/src/bigdl/llm/utils/load.py
@@ -15,6 +15,8 @@
 #
 
 import torch
+import warnings
+
 from bigdl.llm.transformers import AutoModelForCausalLM, AutoModel
 from transformers import AutoTokenizer, GPTJForCausalLM, LlamaTokenizer
 
@@ -30,8 +32,9 @@ def load_model(
     """Load a model using BigDL LLM backend."""
     if low_bit == "bf16":
         if "chatglm" in model_path.lower():
-            print("Currently pytorch do not support bfloat16 on cpu for chatglm models.")
-            return
+            warnings.warn(
+                "Currently pytorch do not support bfloat16 on cpu for chatglm models."
+            )
         model = AutoModelForCausalLM.from_pretrained(
             model_path, trust_remote_code=True, torch_dtype=torch.bfloat16,
             use_cache=True

--- a/python/llm/src/bigdl/llm/utils/load.py
+++ b/python/llm/src/bigdl/llm/utils/load.py
@@ -1,0 +1,202 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from fastchat.model.model_adapter import register_model_adapter, BaseModelAdapter, ChatGLMAdapter
+from fastchat.modules.gptq import GptqConfig, load_gptq_quantized
+import accelerate
+from fastchat.modules.awq import AWQConfig, load_awq_quantized
+from fastchat.model.model_adapter import (
+    get_model_adapter,
+    raise_warning_for_incompatible_cpu_offloading_configuration,
+)
+from fastchat.model.monkey_patch_non_inplace import (
+    replace_llama_attn_with_non_inplace_operations,
+)
+from fastchat.constants import CPU_ISA
+from fastchat.utils import get_gpu_memory
+import torch
+import warnings
+from transformers import AutoTokenizer
+from typing import Dict, List, Optional
+import math
+import psutil
+from bigdl.llm.utils.common import invalidInputError
+
+
+def load_model_base(self, model_path: str, from_pretrained_kwargs: dict):
+    revision = from_pretrained_kwargs.get("revision", "main")
+    print("Customized bigdl-llm loader")
+    tokenizer = AutoTokenizer.from_pretrained(
+        model_path,
+        use_fast=self.use_fast_tokenizer,
+        revision=revision,
+    )
+    from bigdl.llm.transformers import AutoModelForCausalLM
+    model = AutoModelForCausalLM.from_pretrained(
+        model_path, low_cpu_mem_usage=True, **from_pretrained_kwargs
+    )
+    return model, tokenizer
+
+def load_model(
+    model_path: str,
+    device: str = "cuda",
+    num_gpus: int = 1,
+    max_gpu_memory: Optional[str] = None,
+    load_8bit: bool = False,
+    cpu_offloading: bool = False,
+    gptq_config: Optional[GptqConfig] = None,
+    awq_config: Optional[AWQConfig] = None,
+    revision: str = "main",
+    debug: bool = False,
+):
+    """Load a model from Hugging Face."""
+    # get model adapter
+    adapter = get_model_adapter(model_path)
+
+    # Handle device mapping
+    cpu_offloading = raise_warning_for_incompatible_cpu_offloading_configuration(
+        device, load_8bit, cpu_offloading
+    )
+    if device == "cpu":
+        kwargs = {"torch_dtype": "auto"}
+        if CPU_ISA in ["avx512_bf16", "amx"]:
+            try:
+                import intel_extension_for_pytorch as ipex
+
+                kwargs = {"torch_dtype": torch.bfloat16}
+            except ImportError:
+                warnings.warn(
+                    "Intel Extension for PyTorch is not installed, "
+                    "it can be installed to accelerate cpu inference"
+                )
+    elif device == "cuda":
+        kwargs = {"torch_dtype": torch.float16}
+        if num_gpus != 1:
+            kwargs["device_map"] = "auto"
+            if max_gpu_memory is None:
+                kwargs[
+                    "device_map"
+                ] = "sequential"  # This is important for not the same VRAM sizes
+                available_gpu_memory = get_gpu_memory(num_gpus)
+                kwargs["max_memory"] = {
+                    i: str(int(available_gpu_memory[i] * 0.85)) + "GiB"
+                    for i in range(num_gpus)
+                }
+            else:
+                kwargs["max_memory"] = {
+                    i: max_gpu_memory for i in range(num_gpus)}
+    elif device == "mps":
+        kwargs = {"torch_dtype": torch.float16}
+        # Avoid bugs in mps backend by not using in-place operations.
+        replace_llama_attn_with_non_inplace_operations()
+    elif device == "xpu":
+        kwargs = {}
+        # Try to load ipex, while it looks unused, it links into torch for xpu support
+        try:
+            import intel_extension_for_pytorch as ipex
+        except ImportError:
+            warnings.warn(
+                "Intel Extension for PyTorch is not installed, but is required for xpu inference."
+            )
+    else:
+        invalidInputError(False, f"Invalid device: {device}")
+
+    if cpu_offloading:
+        # raises an error on incompatible platforms
+        from transformers import BitsAndBytesConfig
+
+        if "max_memory" in kwargs:
+            kwargs["max_memory"]["cpu"] = (
+                str(math.floor(psutil.virtual_memory().available / 2**20)) + "Mib"
+            )
+        kwargs["quantization_config"] = BitsAndBytesConfig(
+            load_in_8bit_fp32_cpu_offload=cpu_offloading
+        )
+        kwargs["load_in_8bit"] = load_8bit
+    elif load_8bit:
+        if num_gpus != 1:
+            warnings.warn(
+                "8-bit quantization is not supported for multi-gpu inference."
+            )
+        else:
+            model, tokenizer = adapter.load_compress_model(
+                model_path=model_path,
+                device=device,
+                torch_dtype=kwargs["torch_dtype"],
+                revision=revision,
+            )
+            if debug:
+                print(model)
+            return model, tokenizer
+    elif awq_config and awq_config.wbits < 16:
+        invalidInputError(awq_config.wbits != 4,
+                          "Currently we only support 4-bit inference for AWQ.")
+        model, tokenizer = load_awq_quantized(model_path, awq_config, device)
+        if num_gpus != 1:
+            device_map = accelerate.infer_auto_device_map(
+                model,
+                max_memory=kwargs["max_memory"],
+                no_split_module_classes=[
+                    "OPTDecoderLayer",
+                    "LlamaDecoderLayer",
+                    "BloomBlock",
+                    "MPTBlock",
+                    "DecoderLayer",
+                ],
+            )
+            model = accelerate.dispatch_model(
+                model, device_map=device_map, offload_buffers=True
+            )
+        else:
+            model.to(device)
+        return model, tokenizer
+    elif gptq_config and gptq_config.wbits < 16:
+        model, tokenizer = load_gptq_quantized(model_path, gptq_config)
+        if num_gpus != 1:
+            device_map = accelerate.infer_auto_device_map(
+                model,
+                max_memory=kwargs["max_memory"],
+                no_split_module_classes=["LlamaDecoderLayer"],
+            )
+            model = accelerate.dispatch_model(
+                model, device_map=device_map, offload_buffers=True
+            )
+        else:
+            model.to(device)
+        return model, tokenizer
+    kwargs["revision"] = revision
+
+    # Load model
+    model, tokenizer = adapter.load_model(model_path, kwargs)
+
+    if (
+        device == "cpu"
+        and kwargs["torch_dtype"] is torch.bfloat16
+        and CPU_ISA is not None
+    ):
+        model = ipex.optimize(model, dtype=kwargs["torch_dtype"])
+
+    if (device == "cuda" and num_gpus == 1 and not cpu_offloading) or device in (
+        "mps",
+        "xpu",
+    ):
+        model.to(device)
+
+    if debug:
+        print(model)
+
+    return model, tokenizer
+

--- a/python/llm/src/bigdl/llm/utils/load.py
+++ b/python/llm/src/bigdl/llm/utils/load.py
@@ -25,7 +25,6 @@ def load_model(
     model_path: str,
     device: str = "cpu",
     low_bit: str = 'sym_int4',
-    bigdl_optimize: bool = False,
     debug: bool = False,
 ):
     """Load a model using BigDL LLM backend."""
@@ -56,27 +55,6 @@ def load_model(
             else AutoTokenizer
         )
         tokenizer = tokenizer_cls.from_pretrained(model_path, trust_remote_code=True)
-    elif bigdl_optimize:
-        from bigdl.llm import optimize_model
-        model_cls = (
-            AutoModelForCausalLM if any(id in model_path.lower() for id in LLAMA_IDS)
-            else AutoModel
-        )
-        model = model_cls.from_pretrained(
-            model_path, torch_dtype='auto', low_cpu_mem_usage=True
-        ).eval()
-        model = optimize_model(model, low_bit=low_bit)
-        tokenizer_cls = (
-            LlamaTokenizer if any(id in model_path.lower() for id in LLAMA_IDS)
-            else AutoTokenizer
-        )
-        tokenizer = tokenizer_cls.from_pretrained(model_path, trust_remote_code=True)
-
-        if device == "xpu":
-            import intel_extension_for_pytorch as ipex
-            model = model.to('xpu')
-            if isinstance(model, GPTJForCausalLM):
-                model = ipex.optimize(model.eval(), inplace=True)
     else:
         if "chatglm" in model_path.lower():
             model = AutoModel.from_pretrained(

--- a/python/llm/src/bigdl/llm/utils/load.py
+++ b/python/llm/src/bigdl/llm/utils/load.py
@@ -1,3 +1,19 @@
+#
+# Copyright 2016 The BigDL Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 import torch
 from bigdl.llm.transformers import AutoModelForCausalLM, AutoModel
 from transformers import AutoTokenizer, GPTJForCausalLM, LlamaTokenizer

--- a/python/llm/src/bigdl/llm/utils/load.py
+++ b/python/llm/src/bigdl/llm/utils/load.py
@@ -15,9 +15,9 @@
 #
 
 import torch
-import warnings
 
 from bigdl.llm.transformers import AutoModelForCausalLM, AutoModel
+from bigdl.llm.utils.common import invalidInputError
 from transformers import AutoTokenizer, GPTJForCausalLM, LlamaTokenizer
 
 LLAMA_IDS = ['llama', 'vicuna', 'merged-baize']
@@ -32,9 +32,9 @@ def load_model(
     """Load a model using BigDL LLM backend."""
     if low_bit == "bf16":
         if "chatglm" in model_path.lower():
-            warnings.warn(
-                "Currently pytorch do not support bfloat16 on cpu for chatglm models."
-            )
+            invalidInputError(
+                False,
+                "Currently pytorch do not support bfloat16 on cpu for chatglm models.")
         model = AutoModelForCausalLM.from_pretrained(
             model_path, trust_remote_code=True, torch_dtype=torch.bfloat16,
             use_cache=True

--- a/python/llm/src/bigdl/llm/utils/load.py
+++ b/python/llm/src/bigdl/llm/utils/load.py
@@ -31,26 +31,49 @@ def load_model(
     """Load a model using BigDL LLM backend."""
     if low_bit == "bf16":
         if "chatglm" in model_path.lower():
-            print("Currently pytorch do not support bfloat16 on cpu for chatglm models. Will skip it")
+            print("Currently pytorch do not support bfloat16 on cpu for chatglm models.")
             return
-        model = AutoModelForCausalLM.from_pretrained(model_path, trust_remote_code=True, torch_dtype=torch.bfloat16,
-                                                     use_cache=True)
-        tokenizer_cls = LlamaTokenizer if any(llama_id in model_path.lower() for llama_id in LLAMA_IDS) else AutoTokenizer
+        model = AutoModelForCausalLM.from_pretrained(
+            model_path, trust_remote_code=True, torch_dtype=torch.bfloat16,
+            use_cache=True
+        )
+        tokenizer_cls = (
+            LlamaTokenizer if any(llama_id in model_path.lower() for llama_id in LLAMA_IDS)
+            else AutoTokenizer
+        )
         tokenizer = tokenizer_cls.from_pretrained(model_path, trust_remote_code=True)
     elif low_bit == "fp16" and device == "xpu":
         import intel_extension_for_pytorch as ipex
-        model_cls = AutoModelForCausalLM if any(llama_id in model_path.lower() for llama_id in LLAMA_IDS) else AutoModel
-        model = model_cls.from_pretrained(model_path, trust_remote_code=True, use_cache=True).to('xpu')
-        tokenizer_cls = LlamaTokenizer if any(llama_id in model_path.lower() for llama_id in LLAMA_IDS) else AutoTokenizer
+        model_cls = (
+            AutoModelForCausalLM if any(id in model_path.lower() for id in LLAMA_IDS)
+            else AutoModel
+        )
+        model = model_cls.from_pretrained(
+            model_path, trust_remote_code=True, use_cache=True
+        ).to('xpu')
+        tokenizer_cls = (
+            LlamaTokenizer if any(id in model_path.lower() for id in LLAMA_IDS)
+            else AutoTokenizer
+        )
         tokenizer = tokenizer_cls.from_pretrained(model_path, trust_remote_code=True)
     elif low_bit == "sym_int4":
         if "chatglm" in model_path.lower():
-            model = AutoModel.from_pretrained(model_path, load_in_low_bit=low_bit, trust_remote_code=True, torch_dtype='auto').eval()
+            model = AutoModel.from_pretrained(
+                model_path, load_in_low_bit=low_bit, trust_remote_code=True, torch_dtype='auto'
+            ).eval()
         else:
-            model_cls = AutoModelForCausalLM if any(llama_id in model_path.lower() for llama_id in LLAMA_IDS) else AutoModel
-            model = model_cls.from_pretrained(model_path, load_in_low_bit=low_bit, trust_remote_code=True, use_cache=True).eval()
+            model_cls = (
+                AutoModelForCausalLM if any(id in model_path.lower() for id in LLAMA_IDS)
+                else AutoModel
+            )
+            model = model_cls.from_pretrained(
+                model_path, load_in_low_bit=low_bit, trust_remote_code=True, use_cache=True
+            ).eval()
 
-        tokenizer_cls = LlamaTokenizer if any(llama_id in model_path.lower() for llama_id in LLAMA_IDS) else AutoTokenizer
+        tokenizer_cls = (
+            LlamaTokenizer if any(id in model_path.lower() for id in LLAMA_IDS)
+            else AutoTokenizer
+        )
         tokenizer = tokenizer_cls.from_pretrained(model_path, trust_remote_code=True)
 
         if device == "xpu":
@@ -60,12 +83,20 @@ def load_model(
                 model = ipex.optimize(model.eval(), inplace=True)
     elif bigdl_optimize:
         from bigdl.llm import optimize_model
-        model_cls = AutoModelForCausalLM if any(llama_id in model_path.lower() for llama_id in LLAMA_IDS) else AutoModel
-        model = model_cls.from_pretrained(model_path, torch_dtype='auto', low_cpu_mem_usage=True).eval()
+        model_cls = (
+            AutoModelForCausalLM if any(id in model_path.lower() for id in LLAMA_IDS)
+            else AutoModel
+        )
+        model = model_cls.from_pretrained(
+            model_path, torch_dtype='auto', low_cpu_mem_usage=True
+        ).eval()
         model = optimize_model(model, low_bit=low_bit)
-        tokenizer_cls = LlamaTokenizer if any(llama_id in model_path.lower() for llama_id in LLAMA_IDS) else AutoTokenizer
+        tokenizer_cls = (
+            LlamaTokenizer if any(id in model_path.lower() for id in LLAMA_IDS)
+            else AutoTokenizer
+        )
         tokenizer = tokenizer_cls.from_pretrained(model_path, trust_remote_code=True)
-        
+
         if device == "xpu":
             import intel_extension_for_pytorch as ipex
             model = model.to('xpu')
@@ -74,5 +105,5 @@ def load_model(
 
     if debug:
         print(model)
-    
+
     return model, tokenizer

--- a/python/llm/src/bigdl/llm/utils/load.py
+++ b/python/llm/src/bigdl/llm/utils/load.py
@@ -1,202 +1,62 @@
-#
-# Copyright 2016 The BigDL Authors.
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-#
-
-from fastchat.model.model_adapter import register_model_adapter, BaseModelAdapter, ChatGLMAdapter
-from fastchat.modules.gptq import GptqConfig, load_gptq_quantized
-import accelerate
-from fastchat.modules.awq import AWQConfig, load_awq_quantized
-from fastchat.model.model_adapter import (
-    get_model_adapter,
-    raise_warning_for_incompatible_cpu_offloading_configuration,
-)
-from fastchat.model.monkey_patch_non_inplace import (
-    replace_llama_attn_with_non_inplace_operations,
-)
-from fastchat.constants import CPU_ISA
-from fastchat.utils import get_gpu_memory
 import torch
-import warnings
-from transformers import AutoTokenizer
-from typing import Dict, List, Optional
-import math
-import psutil
-from bigdl.llm.utils.common import invalidInputError
+from bigdl.llm.transformers import AutoModelForCausalLM, AutoModel
+from transformers import AutoTokenizer, GPTJForCausalLM, LlamaTokenizer
 
+LLAMA_IDS = ['llama', 'vicuna', 'merged-baize']
 
-def load_model_base(self, model_path: str, from_pretrained_kwargs: dict):
-    revision = from_pretrained_kwargs.get("revision", "main")
-    print("Customized bigdl-llm loader")
-    tokenizer = AutoTokenizer.from_pretrained(
-        model_path,
-        use_fast=self.use_fast_tokenizer,
-        revision=revision,
-    )
-    from bigdl.llm.transformers import AutoModelForCausalLM
-    model = AutoModelForCausalLM.from_pretrained(
-        model_path, low_cpu_mem_usage=True, **from_pretrained_kwargs
-    )
-    return model, tokenizer
 
 def load_model(
     model_path: str,
-    device: str = "cuda",
-    num_gpus: int = 1,
-    max_gpu_memory: Optional[str] = None,
-    load_8bit: bool = False,
-    cpu_offloading: bool = False,
-    gptq_config: Optional[GptqConfig] = None,
-    awq_config: Optional[AWQConfig] = None,
-    revision: str = "main",
+    device: str = "cpu",
+    low_bit: str = 'sym_int4',
+    bigdl_optimize: bool = False,
     debug: bool = False,
 ):
-    """Load a model from Hugging Face."""
-    # get model adapter
-    adapter = get_model_adapter(model_path)
+    """Load a model using BigDL LLM backend."""
+    if low_bit == "bf16":
+        if "chatglm" in model_path.lower():
+            print("Currently pytorch do not support bfloat16 on cpu for chatglm models. Will skip it")
+            return
+        model = AutoModelForCausalLM.from_pretrained(model_path, trust_remote_code=True, torch_dtype=torch.bfloat16,
+                                                     use_cache=True)
+        tokenizer_cls = LlamaTokenizer if any(llama_id in model_path.lower() for llama_id in LLAMA_IDS) else AutoTokenizer
+        tokenizer = tokenizer_cls.from_pretrained(model_path, trust_remote_code=True)
+    elif low_bit == "fp16" and device == "xpu":
+        import intel_extension_for_pytorch as ipex
+        model_cls = AutoModelForCausalLM if any(llama_id in model_path.lower() for llama_id in LLAMA_IDS) else AutoModel
+        model = model_cls.from_pretrained(model_path, trust_remote_code=True, use_cache=True).to('xpu')
+        tokenizer_cls = LlamaTokenizer if any(llama_id in model_path.lower() for llama_id in LLAMA_IDS) else AutoTokenizer
+        tokenizer = tokenizer_cls.from_pretrained(model_path, trust_remote_code=True)
+    elif low_bit == "sym_int4":
+        if "chatglm" in model_path.lower():
+            model = AutoModel.from_pretrained(model_path, load_in_low_bit=low_bit, trust_remote_code=True, torch_dtype='auto').eval()
+        else:
+            model_cls = AutoModelForCausalLM if any(llama_id in model_path.lower() for llama_id in LLAMA_IDS) else AutoModel
+            model = model_cls.from_pretrained(model_path, load_in_low_bit=low_bit, trust_remote_code=True, use_cache=True).eval()
 
-    # Handle device mapping
-    cpu_offloading = raise_warning_for_incompatible_cpu_offloading_configuration(
-        device, load_8bit, cpu_offloading
-    )
-    if device == "cpu":
-        kwargs = {"torch_dtype": "auto"}
-        if CPU_ISA in ["avx512_bf16", "amx"]:
-            try:
-                import intel_extension_for_pytorch as ipex
+        tokenizer_cls = LlamaTokenizer if any(llama_id in model_path.lower() for llama_id in LLAMA_IDS) else AutoTokenizer
+        tokenizer = tokenizer_cls.from_pretrained(model_path, trust_remote_code=True)
 
-                kwargs = {"torch_dtype": torch.bfloat16}
-            except ImportError:
-                warnings.warn(
-                    "Intel Extension for PyTorch is not installed, "
-                    "it can be installed to accelerate cpu inference"
-                )
-    elif device == "cuda":
-        kwargs = {"torch_dtype": torch.float16}
-        if num_gpus != 1:
-            kwargs["device_map"] = "auto"
-            if max_gpu_memory is None:
-                kwargs[
-                    "device_map"
-                ] = "sequential"  # This is important for not the same VRAM sizes
-                available_gpu_memory = get_gpu_memory(num_gpus)
-                kwargs["max_memory"] = {
-                    i: str(int(available_gpu_memory[i] * 0.85)) + "GiB"
-                    for i in range(num_gpus)
-                }
-            else:
-                kwargs["max_memory"] = {
-                    i: max_gpu_memory for i in range(num_gpus)}
-    elif device == "mps":
-        kwargs = {"torch_dtype": torch.float16}
-        # Avoid bugs in mps backend by not using in-place operations.
-        replace_llama_attn_with_non_inplace_operations()
-    elif device == "xpu":
-        kwargs = {}
-        # Try to load ipex, while it looks unused, it links into torch for xpu support
-        try:
+        if device == "xpu":
             import intel_extension_for_pytorch as ipex
-        except ImportError:
-            warnings.warn(
-                "Intel Extension for PyTorch is not installed, but is required for xpu inference."
-            )
-    else:
-        invalidInputError(False, f"Invalid device: {device}")
-
-    if cpu_offloading:
-        # raises an error on incompatible platforms
-        from transformers import BitsAndBytesConfig
-
-        if "max_memory" in kwargs:
-            kwargs["max_memory"]["cpu"] = (
-                str(math.floor(psutil.virtual_memory().available / 2**20)) + "Mib"
-            )
-        kwargs["quantization_config"] = BitsAndBytesConfig(
-            load_in_8bit_fp32_cpu_offload=cpu_offloading
-        )
-        kwargs["load_in_8bit"] = load_8bit
-    elif load_8bit:
-        if num_gpus != 1:
-            warnings.warn(
-                "8-bit quantization is not supported for multi-gpu inference."
-            )
-        else:
-            model, tokenizer = adapter.load_compress_model(
-                model_path=model_path,
-                device=device,
-                torch_dtype=kwargs["torch_dtype"],
-                revision=revision,
-            )
-            if debug:
-                print(model)
-            return model, tokenizer
-    elif awq_config and awq_config.wbits < 16:
-        invalidInputError(awq_config.wbits != 4,
-                          "Currently we only support 4-bit inference for AWQ.")
-        model, tokenizer = load_awq_quantized(model_path, awq_config, device)
-        if num_gpus != 1:
-            device_map = accelerate.infer_auto_device_map(
-                model,
-                max_memory=kwargs["max_memory"],
-                no_split_module_classes=[
-                    "OPTDecoderLayer",
-                    "LlamaDecoderLayer",
-                    "BloomBlock",
-                    "MPTBlock",
-                    "DecoderLayer",
-                ],
-            )
-            model = accelerate.dispatch_model(
-                model, device_map=device_map, offload_buffers=True
-            )
-        else:
-            model.to(device)
-        return model, tokenizer
-    elif gptq_config and gptq_config.wbits < 16:
-        model, tokenizer = load_gptq_quantized(model_path, gptq_config)
-        if num_gpus != 1:
-            device_map = accelerate.infer_auto_device_map(
-                model,
-                max_memory=kwargs["max_memory"],
-                no_split_module_classes=["LlamaDecoderLayer"],
-            )
-            model = accelerate.dispatch_model(
-                model, device_map=device_map, offload_buffers=True
-            )
-        else:
-            model.to(device)
-        return model, tokenizer
-    kwargs["revision"] = revision
-
-    # Load model
-    model, tokenizer = adapter.load_model(model_path, kwargs)
-
-    if (
-        device == "cpu"
-        and kwargs["torch_dtype"] is torch.bfloat16
-        and CPU_ISA is not None
-    ):
-        model = ipex.optimize(model, dtype=kwargs["torch_dtype"])
-
-    if (device == "cuda" and num_gpus == 1 and not cpu_offloading) or device in (
-        "mps",
-        "xpu",
-    ):
-        model.to(device)
+            model = model.to('xpu')
+            if isinstance(model, GPTJForCausalLM):
+                model = ipex.optimize(model.eval(), inplace=True)
+    elif bigdl_optimize:
+        from bigdl.llm import optimize_model
+        model_cls = AutoModelForCausalLM if any(llama_id in model_path.lower() for llama_id in LLAMA_IDS) else AutoModel
+        model = model_cls.from_pretrained(model_path, torch_dtype='auto', low_cpu_mem_usage=True).eval()
+        model = optimize_model(model, low_bit=low_bit)
+        tokenizer_cls = LlamaTokenizer if any(llama_id in model_path.lower() for llama_id in LLAMA_IDS) else AutoTokenizer
+        tokenizer = tokenizer_cls.from_pretrained(model_path, trust_remote_code=True)
+        
+        if device == "xpu":
+            import intel_extension_for_pytorch as ipex
+            model = model.to('xpu')
+            if isinstance(model, GPTJForCausalLM):
+                model = ipex.optimize(model.eval(), inplace=True)
 
     if debug:
         print(model)
-
+    
     return model, tokenizer
-


### PR DESCRIPTION
## Description

Similar to https://github.com/lm-sys/FastChat/pull/2888, we can provide an example implementation for worker that extends the [BaseModelWorker](https://github.com/lm-sys/FastChat/blob/main/fastchat/serve/base_model_worker.py#L27), which should override the following three methods:

    def generate_stream_gate(self, params):
        raise NotImplementedError

    def generate_gate(self, params):
        raise NotImplementedError

    def get_embeddings(self, params):
        raise NotImplementedError
After that, we can provide a bigdl_worker and a documentation on how to use it.

The controller and worker communicates through a set of interfaces, you can check this at here https://github.com/lm-sys/FastChat/blob/main/fastchat/serve/base_model_worker.py#L196. Therefore, if bigdl_worker can successfully implement these interfaces, we can integrate BigDL-LLM into FastChat.


### 1. Why the change?

<!-- Provide the related github issue link if available -->
Similar to https://github.com/lm-sys/FastChat/blob/main/fastchat/serve/mlx_worker.py#L33, we can provide a interface at BigDL side that provide the functionalities of loading models so that we can keep the code at FastChat side stable.

User will start the controller normally, but use like python3 -m fastchat.serve.bigdl_worker --model-names "bigdl-models" --model-path lmsys/vicuna-7b-v1.5 to start the worker.
### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->
```python
from bigdl.llm.utils import load_model
```
### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
Provide an interface used for loading model on the `Fastchat` side
### 4. How to test?
- [ ] Unit test
- [ ] Application test
.

### 5. New dependencies
None
