### PR TITLE
First token lm_head optimization

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -312,6 +312,10 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                     if new_linear is not None:
                         if not module.training:
                             new_linear.eval()
+                        if name == "lm_head" and model_type in ["gptj", "llama"]:
+                            print("Replacing new lm_head")
+                            from bigdl.llm.transformers.low_bit_linear import LmHeadLinear
+                            new_linear = LmHeadLinear(new_linear)
                         model._modules[name] = new_linear
                         has_been_replaced = True
                         # Force requires grad to False to avoid unexpected errors

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -211,11 +211,11 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
             if (not any(key in ".".join(current_key_name) for key in modules_to_not_convert) and
                     not isinstance(module, LowBitLinear)):
                 in_features, out_features, mp_group = linear_args
-                lm_head = False
+                optimize_lm_head = False
                 if name == "lm_head":
                     from bigdl.llm.transformers.utils import get_optimize_lm_head
                     if model_type in ["gptj", "llama"] and get_optimize_lm_head():
-                        lm_head = True
+                        optimize_lm_head = True
                 with init_empty_weights():
                     new_linear = None
                     is_gptq = is_auto_gptq_available() and isinstance(module, QuantLinearCudaOld)
@@ -230,7 +230,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                             bias=has_bias,
                             mp_group=mp_group,
                             enable_xetla=enable_xetla,
-                            lm_head=lm_head
+                            optimize_lm_head=optimize_lm_head
                         )
                         device = module.qweight.data.device
                         invalidInputError(device.type != "meta",
@@ -259,7 +259,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                             module.bias is not None,
                             mp_group=mp_group,
                             enable_xetla=enable_xetla,
-                            lm_head=lm_head
+                            optimize_lm_head=optimize_lm_head
                         )
                         cur_qtype, cur_imatrix = get_cur_qtype_and_imatrix(qtype,
                                                                            full_module_name,
@@ -287,7 +287,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                             out_features,
                             module.bias is not None,
                             mp_group=mp_group,
-                            lm_head=lm_head
+                            optimize_lm_head=optimize_lm_head
                         )
                         device = module.weight.data.device
                         from bigdl.llm.transformers.utils import get_ipex_version
@@ -309,7 +309,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                             out_features,
                             module.bias is not None,
                             mp_group=mp_group,
-                            lm_head=lm_head
+                            optimize_lm_head=optimize_lm_head
                         )
                         device = module.weight.data.device
                         # convert here

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -211,6 +211,11 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
             if (not any(key in ".".join(current_key_name) for key in modules_to_not_convert) and
                     not isinstance(module, LowBitLinear)):
                 in_features, out_features, mp_group = linear_args
+                lm_head = False
+                if name == "lm_head":
+                    from bigdl.llm.transformers.utils import get_optimize_lm_head
+                    if model_type in ["gptj", "llama"] and get_optimize_lm_head():
+                        lm_head = True
                 with init_empty_weights():
                     new_linear = None
                     is_gptq = is_auto_gptq_available() and isinstance(module, QuantLinearCudaOld)
@@ -225,6 +230,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                             bias=has_bias,
                             mp_group=mp_group,
                             enable_xetla=enable_xetla,
+                            lm_head=lm_head
                         )
                         device = module.qweight.data.device
                         invalidInputError(device.type != "meta",
@@ -253,6 +259,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                             module.bias is not None,
                             mp_group=mp_group,
                             enable_xetla=enable_xetla,
+                            lm_head=lm_head
                         )
                         cur_qtype, cur_imatrix = get_cur_qtype_and_imatrix(qtype,
                                                                            full_module_name,
@@ -280,6 +287,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                             out_features,
                             module.bias is not None,
                             mp_group=mp_group,
+                            lm_head=lm_head
                         )
                         device = module.weight.data.device
                         from bigdl.llm.transformers.utils import get_ipex_version
@@ -301,6 +309,7 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                             out_features,
                             module.bias is not None,
                             mp_group=mp_group,
+                            lm_head=lm_head
                         )
                         device = module.weight.data.device
                         # convert here
@@ -312,10 +321,6 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                     if new_linear is not None:
                         if not module.training:
                             new_linear.eval()
-                        if name == "lm_head" and model_type in ["gptj", "llama"]:
-                            print("Replacing new lm_head")
-                            from bigdl.llm.transformers.low_bit_linear import LmHeadLinear
-                            new_linear = LmHeadLinear(new_linear)
                         model._modules[name] = new_linear
                         has_been_replaced = True
                         # Force requires grad to False to avoid unexpected errors

--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -213,8 +213,8 @@ def _replace_with_low_bit_linear(model, qtype, modules_to_not_convert=None,
                 in_features, out_features, mp_group = linear_args
                 optimize_lm_head = False
                 if name == "lm_head":
-                    from bigdl.llm.transformers.utils import get_optimize_lm_head
-                    if model_type in ["gptj", "llama"] and get_optimize_lm_head():
+                    if model_type in ["gptj", "llama"] and os.environ.get("BIGDL_OPTIMIZE_LM_HEAD",
+                                                                          None) == "1":
                         optimize_lm_head = True
                 with init_empty_weights():
                     new_linear = None

--- a/python/llm/src/bigdl/llm/transformers/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/utils.py
@@ -168,19 +168,6 @@ def get_ipex_version():
     return _ipex_version
 
 
-_optimize_lm_head = None
-
-
-def get_optimize_lm_head():
-    global _optimize_lm_head
-    if _optimize_lm_head is None:
-        if os.environ.get("BIGDL_OPTIMIZE_LM_HEAD", None) is not None:
-            _optimize_lm_head = (os.environ["BIGDL_OPTIMIZE_LM_HEAD"] == "1")
-        else:
-            _optimize_lm_head = False
-    return _optimize_lm_head
-
-
 def get_xpu_device_type(x):
     if x.device.type != "xpu":
         return x.device.type

--- a/python/llm/src/bigdl/llm/transformers/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/utils.py
@@ -168,6 +168,18 @@ def get_ipex_version():
     return _ipex_version
 
 
+_optimize_lm_head = None
+
+def get_optimize_lm_head():
+    global _optimize_lm_head
+    if _optimize_lm_head is None:
+        if os.environ.get("BIGDL_OPTIMIZE_LM_HEAD", None) is not None:
+            _optimize_lm_head = (os.environ["BIGDL_OPTIMIZE_LM_HEAD"] == "1")
+        else:
+            _optimize_lm_head = False
+    return _optimize_lm_head
+
+
 def get_xpu_device_type(x):
     if x.device.type != "xpu":
         return x.device.type

--- a/python/llm/src/bigdl/llm/transformers/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/utils.py
@@ -170,6 +170,7 @@ def get_ipex_version():
 
 _optimize_lm_head = None
 
+
 def get_optimize_lm_head():
     global _optimize_lm_head
     if _optimize_lm_head is None:


### PR DESCRIPTION
## Description

Optimize the first token lm_head latency & memory usage.

### 1. Why the change?

Optimize the first token lm_head latency & memory usage.

### 2. User API changes

export BIGDL_OPTIMIZE_LM_HEAD=1 to use this optimization for llama & gptj.

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [x] local test cpu
- [x] local test gpu
