### PR TITLE
Fix fschat DEP version error

### DIFF
--- a/docker/llm/serving/cpu/docker/model_adapter.py.patch
+++ b/docker/llm/serving/cpu/docker/model_adapter.py.patch
@@ -1,11 +1,11 @@
---- model_adapter.py.old	2024-01-24 01:56:23.903144335 +0000
-+++ model_adapter.py	2024-01-24 01:59:22.605062765 +0000
-@@ -1346,15 +1346,17 @@
+--- model_adapter.py.old        2024-03-05 15:08:47.169275336 +0800
++++ model_adapter.py    2024-03-05 15:10:13.434703674 +0800
+@@ -1690,15 +1690,17 @@
          )
          # NOTE: if you use the old version of model file, please remove the comments below
          # config.use_flash_attn = False
--        config.fp16 = True
-+        # config.fp16 = True
+-        self.float_set(config, "fp16")
++        # self.float_set(config, "fp16")
          generation_config = GenerationConfig.from_pretrained(
              model_path, trust_remote_code=True
          )

--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -53,7 +53,7 @@ CONVERT_DEP = ['numpy >= 1.22', 'torch',
                'transformers == 4.31.0', 'sentencepiece', 'tokenizers == 0.13.3',
                # TODO: Support accelerate 0.22.0
                'accelerate == 0.21.0', 'tabulate']
-SERVING_DEP = ['fschat[model_worker, webui] == 0.2.28', 'protobuf']
+SERVING_DEP = ['fschat[model_worker, webui] == 0.2.36', 'protobuf']
 windows_binarys = [
     "llama.dll",
     "gptneox.dll",


### PR DESCRIPTION
## Description

Old versions of gradio_web_server.py and openai_api_server.py will conflict with the new versions of gradio and pydantic. 
We should use the latest version of `fschat`.

### 2. User API changes
None

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->
In this line:
https://github.com/intel-analytics/BigDL/blob/90be0f947b6a6c4b5925a96cc6bf9fdc610832f6/docker/llm/serving/cpu/docker/Dockerfile#L15
We install `fschat` with:
https://github.com/intel-analytics/BigDL/blob/90be0f947b6a6c4b5925a96cc6bf9fdc610832f6/python/llm/setup.py#L56
So update with latest version.


