### PR TITLE
Optimize speculative decoding PVC memory usage

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/models/llama.py
+++ b/python/llm/src/bigdl/llm/transformers/models/llama.py
@@ -633,6 +633,7 @@ def llama_attention_forward_4_31_original(
             cache_v = past_key_value[1]
             if not enough_kv_room:
                 # allocate new
+                print("origin extend")
                 new_cache_k, new_cache_v = extend_kv_cache(
                     bsz,
                     self.num_key_value_heads,  # Support GQA
@@ -773,6 +774,7 @@ def llama_attention_selective_batching_forward_4_31(
         past_v = past_key_value[0][1]
         kv_seq_len = past_k.shape[-2]
         if not enough_kv_room:
+            print("origin extend")
             new_cache_k, new_cache_v = extend_kv_cache(1,
                                                        self.num_key_value_heads,  # Support GQA
                                                        self.head_dim,
@@ -838,6 +840,7 @@ def llama_attention_selective_batching_forward_4_31(
                 current_kv_len = past_k.shape[-2] + 1
                 if not enough_kv_room:
                     # allocate new
+                    print("origin extend")
                     new_cache_k, new_cache_v = extend_kv_cache(1,
                                                                self.num_key_value_heads,
                                                                self.head_dim,
@@ -1294,6 +1297,7 @@ def llama_attention_forward_4_36_original(
 
                 if not enough_kv_room:
                     # allocate new
+                    print("origin extend")
                     new_c_k, new_c_v = extend_kv_cache(bsz,
                                                        self.num_key_value_heads,  # Support GQA
                                                        self.head_dim,

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -52,7 +52,6 @@ def init_kv_cache(batch_size, num_heads, head_dim, current_length, max_length, d
 
 def extend_kv_cache(batch_size, num_heads, head_dim, current_length, max_length, dtype, device):
     # empty cache to reduce gpu memory
-    print("origin extend")
     if device.type == 'xpu':
         torch.xpu.empty_cache()
     return init_kv_cache(batch_size, num_heads, head_dim, current_length, max_length, dtype, device)

--- a/python/llm/src/bigdl/llm/transformers/models/utils.py
+++ b/python/llm/src/bigdl/llm/transformers/models/utils.py
@@ -52,6 +52,7 @@ def init_kv_cache(batch_size, num_heads, head_dim, current_length, max_length, d
 
 def extend_kv_cache(batch_size, num_heads, head_dim, current_length, max_length, dtype, device):
     # empty cache to reduce gpu memory
+    print("origin extend")
     if device.type == 'xpu':
         torch.xpu.empty_cache()
     return init_kv_cache(batch_size, num_heads, head_dim, current_length, max_length, dtype, device)

--- a/python/llm/src/bigdl/llm/transformers/speculative.py
+++ b/python/llm/src/bigdl/llm/transformers/speculative.py
@@ -567,6 +567,9 @@ def speculative_generate(self,
 
     self.clear_benchmarks()
 
+    if self.device.type == 'xpu':
+        torch.xpu.empty_cache()
+
     # Example:
     # Target model forward for the first token
     # Step 1. target_model(prompt) -> a
@@ -627,7 +630,7 @@ def speculative_generate(self,
             else:
                 past_key_values, extend_kv = _check_and_extend_kv_cache(past_key_values,
                                                                         max_step_draft,
-                                                                        max_new_tokens - max_new_tokens + 40)
+                                                                        max_new_tokens - step + 40)
                 draft_past_key_values = past_key_values
             draft_generate_ids[:, 0] = current_input_ids
             draft_prob_list = []

--- a/python/llm/src/bigdl/llm/transformers/speculative.py
+++ b/python/llm/src/bigdl/llm/transformers/speculative.py
@@ -26,6 +26,8 @@ import copy
 import logging
 import warnings
 import inspect
+import version
+import transformers
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 from transformers import top_k_top_p_filtering, GenerationConfig, \
     LogitsProcessorList, StoppingCriteriaList
@@ -365,7 +367,68 @@ def _update_past_key_values_storage_cpu(self, past_key_values, past_key_values_s
                     delta_past_key.to(torch.float32)
                 past_key_values_storage[i][1][:, :, size:size1, :] = \
                     delta_past_value.to(torch.float32)
+                
 
+def _check_and_extend_kv_cache_4_31(past_key_values, max_step_draft, kv_alloc_block_len=256):
+    from bigdl.llm.transformers.models.utils import is_enough_kv_cache_room_4_31, \
+        extend_kv_cache
+    enough_kv_room = is_enough_kv_cache_room_4_31(past_key_value=past_key_values[0],
+                                                  seq_len=max_step_draft)
+    device = past_key_values[0][0].device
+    if not enough_kv_room:
+        past_key_values = list(past_key_values)
+        bsz, num_heads, current_seq_len, head_dim = past_key_values[0][0].shape
+        for i in range(len(past_key_values)):
+            cache_k = past_key_values[i][0]
+            new_cache_k, new_cache_v = extend_kv_cache(
+                    bsz,
+                    num_heads,  # Support GQA
+                    head_dim,
+                    cache_k.size(2),
+                    current_seq_len + max_step_draft + kv_alloc_block_len,
+                    dtype=cache_k.dtype,
+                    device=device
+                )
+            new_cache_k[:] = cache_k
+            new_cache_v[:] = past_key_values[i][1]
+            past_key_values[i] = (new_cache_k, new_cache_v)
+    return past_key_values, not enough_kv_room
+
+
+def _check_and_extend_kv_cache_4_36(past_key_values, max_step_draft, kv_alloc_block_len=256):
+    from bigdl.llm.transformers.models.utils import is_enough_kv_cache_room_4_36, \
+        extend_kv_cache
+    
+    enough_kv_room = is_enough_kv_cache_room_4_36(past_key_value=past_key_values,
+                                                  idx=0,
+                                                  seq_len=max_step_draft)
+    if not enough_kv_room:
+        past_k_cache = past_key_values.key_cache
+        past_v_cache = past_key_values.value_cache
+        device = past_k_cache[0].device
+        bsz, num_heads, current_seq_len, head_dim = past_k_cache.shape
+        for i in range(len(past_k_cache)):
+            cache_k = past_k_cache[i]
+            cache_v = past_v_cache[i]
+            new_cache_k, new_cache_v = extend_kv_cache(
+                    bsz,
+                    num_heads,  # Support GQA
+                    head_dim,
+                    cache_k.size(2),
+                    current_seq_len + max_step_draft + kv_alloc_block_len,
+                    dtype=cache_k.dtype,
+                    device=device
+                )
+            new_cache_k[:] = cache_k
+            new_cache_v[:] = cache_v
+            past_key_values.key_cache[i] = new_cache_k
+            past_key_values.value_cache[i] = new_cache_v
+    return past_key_values, not enough_kv_room
+
+
+_check_and_extend_kv_cache = _check_and_extend_kv_cache_4_31 \
+    if version.parse(transformers.__version__) >= version.parse("4.36.0") \
+        else _check_and_extend_kv_cache_4_36
 
 @torch.no_grad()
 def speculative_generate(self,
@@ -562,6 +625,9 @@ def speculative_generate(self,
                                                        past_key_values_storage,  _enable_ipex)
                 original_draft_past_key_values = draft_past_key_values
             else:
+                past_key_values, extend_kv = _check_and_extend_kv_cache(past_key_values,
+                                                                        max_step_draft,
+                                                                        max_new_tokens - max_new_tokens + 40)
                 draft_past_key_values = past_key_values
             draft_generate_ids[:, 0] = current_input_ids
             draft_prob_list = []
@@ -742,6 +808,9 @@ def speculative_generate(self,
                 output_ids = greedy(logits)
             if self.device.type == 'xpu':
                 torch.xpu.synchronize()
+                if extend_kv:
+                    torch.xpu.empty_cache()
+                print(f"verify memory: {torch.xpu.memory.memory_reserved() / (1024**3)}")
             toc = time.time()
             self.verify_time.append(toc - tic)
             self.generate_time.append(self.draft_time[-1] + self.verify_time[-1])

--- a/python/llm/src/bigdl/llm/transformers/speculative.py
+++ b/python/llm/src/bigdl/llm/transformers/speculative.py
@@ -24,10 +24,8 @@ import time
 import os
 import copy
 import logging
-import warnings
-import inspect
-import version
 import transformers
+from packaging import version
 from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional, Tuple, Union
 from transformers import top_k_top_p_filtering, GenerationConfig, \
     LogitsProcessorList, StoppingCriteriaList
@@ -376,6 +374,7 @@ def _check_and_extend_kv_cache_4_31(past_key_values, max_step_draft, kv_alloc_bl
                                                   seq_len=max_step_draft)
     device = past_key_values[0][0].device
     if not enough_kv_room:
+        print("extending....")
         past_key_values = list(past_key_values)
         bsz, num_heads, current_seq_len, head_dim = past_key_values[0][0].shape
         for i in range(len(past_key_values)):
@@ -403,6 +402,7 @@ def _check_and_extend_kv_cache_4_36(past_key_values, max_step_draft, kv_alloc_bl
                                                   idx=0,
                                                   seq_len=max_step_draft)
     if not enough_kv_room:
+        print("extending....")
         past_k_cache = past_key_values.key_cache
         past_v_cache = past_key_values.value_cache
         device = past_k_cache[0].device
@@ -426,9 +426,9 @@ def _check_and_extend_kv_cache_4_36(past_key_values, max_step_draft, kv_alloc_bl
     return past_key_values, not enough_kv_room
 
 
-_check_and_extend_kv_cache = _check_and_extend_kv_cache_4_31 \
+_check_and_extend_kv_cache = _check_and_extend_kv_cache_4_36 \
     if version.parse(transformers.__version__) >= version.parse("4.36.0") \
-        else _check_and_extend_kv_cache_4_36
+        else _check_and_extend_kv_cache_4_31
 
 @torch.no_grad()
 def speculative_generate(self,


### PR DESCRIPTION
## Description

Optimize speculative decoding PVC memory usage.

### 3. Summary of the change 

1. Call empty_cache when necessary.
2. Fix the draft&verify model repetitive `extend kv cache` issue to save memory.

### 4. How to test?
- [ ] local test (llama, mistral, gptj, baichuan, qwen, chatglm)

