### PR TITLE
Fix device_map bug by raise an error when using device_map=xpu

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -43,7 +43,7 @@ from .utils import extract_local_archive_file, \
     load_state_dict, \
     get_local_shard_files, load_imatrix_data
 from bigdl.llm.ggml.quantize import ggml_tensor_qtype
-from bigdl.llm.utils.common import invalidInputError, invalidOperationError
+from bigdl.llm.utils.common import invalidInputError
 from bigdl.llm.transformers.gguf.api import load_gguf_model
 import torch
 import warnings
@@ -145,11 +145,10 @@ class _BaseAutoModelClass:
         invalidInputError(model_hub in ["huggingface", "modelscope"],
                           "The parameter `model_hub` is supposed to be `huggingface` or "
                           f"`modelscope`, but got {model_hub}.")
-        if 'device_map' in kwargs and 'xpu' in kwargs['device_map']:
-            invalidOperationError(condition=0,
-                                  errMsg=("Please do not use 'device_map'"
-                                          "with 'xpu' value as an argument. "
-                                          "Use model.to('xpu') instead."))
+        invalidInputError(not ('device_map' in kwargs and 'xpu' in kwargs['device_map']),
+                          "Please do not use `device_map` "
+                          "with `xpu` value as an argument. "
+                          "Use model.to('xpu') instead.")
         if model_hub == "huggingface":
             config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
         elif model_hub == "modelscope":

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -145,6 +145,8 @@ class _BaseAutoModelClass:
         invalidInputError(model_hub in ["huggingface", "modelscope"],
                           "The parameter `model_hub` is supposed to be `huggingface` or "
                           f"`modelscope`, but got {model_hub}.")
+        if 'device_map' in kwargs and  'xpu' in kwargs['device_map']:
+            raise ValueError("Please do not use 'device_map' with 'xpu' value as an argument. Use model.to('xpu') instead.")
         if model_hub == "huggingface":
             config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
         elif model_hub == "modelscope":

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -145,7 +145,7 @@ class _BaseAutoModelClass:
         invalidInputError(model_hub in ["huggingface", "modelscope"],
                           "The parameter `model_hub` is supposed to be `huggingface` or "
                           f"`modelscope`, but got {model_hub}.")
-        if 'device_map' in kwargs and  'xpu' in kwargs['device_map']:
+        if 'device_map' in kwargs and 'xpu' in kwargs['device_map']:
             invalidOperationError(condition=0,
                                   errMsg=("Please do not use 'device_map'"
                                           "with 'xpu' value as an argument. "
@@ -414,7 +414,6 @@ class _BaseAutoModelClass:
             _load_pre()
             try:
                 model = cls.HF_Model.from_pretrained(*args, **kwargs)
-                
             except NotImplementedError:
                 logger.info("Failed to load models with `low_cpu_mem_usage` specified, "
                             "will fall to traditional load method with higher memory consumption.")

--- a/python/llm/src/bigdl/llm/transformers/model.py
+++ b/python/llm/src/bigdl/llm/transformers/model.py
@@ -43,7 +43,7 @@ from .utils import extract_local_archive_file, \
     load_state_dict, \
     get_local_shard_files, load_imatrix_data
 from bigdl.llm.ggml.quantize import ggml_tensor_qtype
-from bigdl.llm.utils.common import invalidInputError
+from bigdl.llm.utils.common import invalidInputError, invalidOperationError
 from bigdl.llm.transformers.gguf.api import load_gguf_model
 import torch
 import warnings
@@ -146,7 +146,10 @@ class _BaseAutoModelClass:
                           "The parameter `model_hub` is supposed to be `huggingface` or "
                           f"`modelscope`, but got {model_hub}.")
         if 'device_map' in kwargs and  'xpu' in kwargs['device_map']:
-            raise ValueError("Please do not use 'device_map' with 'xpu' value as an argument. Use model.to('xpu') instead.")
+            invalidOperationError(condition=0,
+                                  errMsg=("Please do not use 'device_map'"
+                                          "with 'xpu' value as an argument. "
+                                          "Use model.to('xpu') instead."))
         if model_hub == "huggingface":
             config_dict, _ = PretrainedConfig.get_config_dict(pretrained_model_name_or_path)
         elif model_hub == "modelscope":
@@ -411,6 +414,7 @@ class _BaseAutoModelClass:
             _load_pre()
             try:
                 model = cls.HF_Model.from_pretrained(*args, **kwargs)
+                
             except NotImplementedError:
                 logger.info("Failed to load models with `low_cpu_mem_usage` specified, "
                             "will fall to traditional load method with higher memory consumption.")


### PR DESCRIPTION
## Description
Currently, when using the `AutoModelForCausalLM.from_pretrained(device_map='xpu')` option, it leads to significantly higher memory consumption compared to calling the `model.to('xpu')` statement. The issue is located at https://github.com/intel-analytics/BigDL/blob/main/python/llm/src/bigdl/llm/transformers/model.py#L411.

The current workaround is to prohibit users from passing the `device_map='xpu'` parameter during `from_pretrained`.

