### PR TITLE
LLM serving xpu memory opt

### DIFF
--- a/python/llm/src/bigdl/llm/serving/model_worker.py
+++ b/python/llm/src/bigdl/llm/serving/model_worker.py
@@ -256,6 +256,8 @@ class ModelWorker(BaseModelWorker):
                 self.context_len,
                 self.stream_interval,
             ):
+                if self.device == "xpu":
+                    torch.xpu.empty_cache()
                 ret = {
                     "text": output["text"],
                     "error_code": 0,


### PR DESCRIPTION
## Description

The current implementation tends to result in out-of-memory errors. Add `empty cache` to free up memory.

### 1. Why the change?

<!-- Provide the related github issue link if available -->

### 2. User API changes

<!-- Describe API changes (i.e., how users will use the feature) if any; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 3. Summary of the change 

<!-- Provide the design for the implementation; -->
<!-- alternatively, provide a link to the github issue for the design -->

### 4. How to test?
- [x] local test