### PR TITLE
LLM: fix error of 'AI-ModelScope/phi-2' hosted by ModelScope hub

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -1071,7 +1071,8 @@ def _optimize_post(model, lightweight_bmm=False):
         convert_forward(model,
                         module.MixtralBLockSparseTop2MLP,
                         mixtral_mlp_forward)
-    elif model.config.model_type == "phi-msft":
+    elif model.config.model_type == "phi-msft" and \
+        hasattr(model.config, "num_local_experts"):
         modeling_module_name = model.__class__.__module__
         module = importlib.import_module(modeling_module_name)
         from bigdl.llm.transformers.models.phixtral import phixtral_moeblock_forward, \


### PR DESCRIPTION
## Description

In [ModelScope](https://modelscope.cn/models/AI-ModelScope/phi-2/file/view/master/config.json), `model_type` of `AI-ModelScope/phi-2` is `phi-msft`.
Then optimization for `phixtral` is applied to `phi-2` and will cause error. More details are in https://github.com/analytics-zoo/nano/issues/1140#issuecomment-1987534096


### 2. User API changes

N/A

### 4. How to test?
- [ ] Unit test
- [ ] Local test

