### PR TITLE
Fix convert_forward recursive submodule issue

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/convert.py
+++ b/python/llm/src/bigdl/llm/transformers/convert.py
@@ -669,7 +669,7 @@ def convert_bigdl_other_module(model, dtype):
                 module.to(dtype)
 
 
-def convert_forward(m, target_m, new_forward, replace_sub_module = True):
+def convert_forward(m, target_m, new_forward, replace_sub_module=True):
     for _, sub_m in m.named_children():
         if isinstance(sub_m, target_m):
             bound_method = new_forward.__get__(sub_m, sub_m.__class__)


### PR DESCRIPTION
## Description

Not every model needs recursive convert_forward on its submodule, otherwise strange behavior of model appears due to repeated setattr.

Add a parameter to specify whether submodule needs to recursively converted in conver_forward, default to True. Qwen1.5 (qwen2) is an example of False.

### 1. Why the change?

#10354 

### 2. User API changes

no

### 3. Summary of the change 

as above

### 4. How to test?
- [ ] N/A
- [x] Unit test
- [x] Application test
- [ ] Document test
- [ ] ...
