### PR TITLE
LLM: add fp8 sdp for chatglm2/3

### DIFF
--- a/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
+++ b/python/llm/src/bigdl/llm/transformers/models/chatglm2.py
@@ -269,7 +269,8 @@ def chatglm2_quantized_attention_forward_8eb45c(
         v_cache = v_cache.permute(1, 2, 0, 3)
         # k_cache, v_cache's shape: [bs, n_kv_head, seq_len, head_dim]
 
-        k_cache, v_cache = append_fp8_kv_cache(k_cache, v_cache, key_layer, value_layer, new_layout=True)
+        k_cache, v_cache = append_fp8_kv_cache(k_cache, v_cache, key_layer, value_layer,
+                                               new_layout=True)
 
         if seq_len != 1:
             key, value = restore_fp8_kv_cache(k_cache, v_cache, query_layer.dtype)


### PR DESCRIPTION
## Description

### 1. Why the change?

optimize chatglm3-6b performance.

### 2. User API changes

No change.

### 3. Summary of the change 

- Fix runtime error of rms norm when int4+fp16+quan kv
- Add fp8 sdp for chatglm2/3

### 4. How to test?
- [x] Unit test
- [x] Local test

