### PR TITLE
Add upper bound for dllib numpy version

### DIFF
--- a/python/dllib/src/setup.py
+++ b/python/dllib/src/setup.py
@@ -102,7 +102,7 @@ def setup_package():
         packages=get_bigdl_packages(),
         scripts=scripts,
         install_requires=[
-            'numpy>=1.19.5', 'pyspark=='+PYSPARK_VERSION , 'conda-pack==0.3.1',
+            'numpy>=1.19.5,<=1.26.4', 'pyspark=='+PYSPARK_VERSION , 'conda-pack==0.3.1',
             'six>=1.10.0', 'bigdl-core==2.4.0.dev0'],
         dependency_links=['https://d3kbcqa49mib13.cloudfront.net/spark-2.0.0-bin-hadoop2.7.tgz'],
         include_package_data=True,


### PR DESCRIPTION
fix the failure of numpy versions