### PR TITLE
Fix pad_token_id issue in Phi-2 example

### DIFF
--- a/python/llm/example/CPU/HF-Transformers-AutoModels/Model/phi-2/generate.py
+++ b/python/llm/example/CPU/HF-Transformers-AutoModels/Model/phi-2/generate.py
@@ -60,6 +60,7 @@ if __name__ == '__main__':
         # it is important to set `use_cache=True` explicitly in the `generate` function
         # to obtain optimal performance with BigDL-LLM INT4 optimizations
 
+        model.generation_config.pad_token_id = model.generation_config.eos_token_id
         # Note that phi-2 uses GenerationConfig to enable 'use_cache'
         output = model.generate(input_ids, do_sample=False, max_new_tokens=args.n_predict, generation_config = generation_config)
 

--- a/python/llm/example/CPU/PyTorch-Models/Model/phi-2/generate.py
+++ b/python/llm/example/CPU/PyTorch-Models/Model/phi-2/generate.py
@@ -52,6 +52,7 @@ if __name__ == '__main__':
     with torch.inference_mode():
         prompt = PHI_2_V1_PROMPT_FORMAT.format(prompt=args.prompt)
         input_ids = tokenizer.encode(prompt, return_tensors="pt")
+        model.generation_config.pad_token_id = model.generation_config.eos_token_id
         st = time.time()
         output = model.generate(input_ids, max_new_tokens=args.n_predict, generation_config = generation_config)
         end = time.time()

--- a/python/llm/example/GPU/HF-Transformers-AutoModels/Model/phi-2/generate.py
+++ b/python/llm/example/GPU/HF-Transformers-AutoModels/Model/phi-2/generate.py
@@ -59,6 +59,7 @@ if __name__ == '__main__':
         prompt = PHI2_PROMPT_FORMAT.format(prompt=args.prompt)
         input_ids = tokenizer.encode(prompt, return_tensors="pt").to('xpu')
 
+        model.generation_config.pad_token_id = model.generation_config.eos_token_id
         # ipex model needs a warmup, then inference time can be accurate
         output = model.generate(input_ids,
                                 max_new_tokens=args.n_predict,

--- a/python/llm/example/GPU/PyTorch-Models/Model/phi-2/generate.py
+++ b/python/llm/example/GPU/PyTorch-Models/Model/phi-2/generate.py
@@ -55,7 +55,8 @@ if __name__ == '__main__':
     with torch.inference_mode():
         prompt = PHI_2_V1_PROMPT_FORMAT.format(prompt=args.prompt)
         input_ids = tokenizer.encode(prompt, return_tensors="pt").to('xpu')
-        
+
+        model.generation_config.pad_token_id = model.generation_config.eos_token_id
         # ipex model needs a warmup, then inference time can be accurate
         output = model.generate(input_ids, do_sample=False, max_new_tokens=args.n_predict, generation_config = generation_config)
         # start inference


### PR DESCRIPTION
In latest Phi-2 model, it add eos_token_id , but doesn't add pad_token_id. Therefore it would cause error: https://github.com/analytics-zoo/nano/issues/1139

Fix the problem by `model.generation_config.pad_token_id = model.generation_config.eos_token_id`