### PR TITLE
WebUI quickstart: add instruct chat mode and tested models

### DIFF
--- a/docs/readthedocs/source/doc/LLM/Quickstart/webui_quickstart.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/webui_quickstart.md
@@ -124,7 +124,7 @@ To shut down the WebUI server, use **Ctrl+C** in the **Anaconda Prompt** termina
 
 
 ## 5. Advanced Usage
-### Using Instruct Chat Mode
+### Using Instruct mode for Chat
 Instruction-following models are models that are fine-tuned with specific prompt formats. 
 For these models, you should ideally use the `instruct` chat mode.
 Under this mode, the model receives user prompts that are formatted according to prompt formats it was trained with.
@@ -145,10 +145,11 @@ In this case, go to `Parameters` tab and then `Instruction template` tab.
 
 You can verify and edit the loaded instruction template in the `Instruction template` field.
 You can also manually select an instruction template from `Saved instruction templates` and click `load` to load it into `Instruction template`.
-You can add custom template files to this list in `/instruction-templates/` folder.
+You can add custom template files to this list in `/instruction-templates/` [folder](https://github.com/intel-analytics/text-generation-webui/tree/bigdl-llm/instruction-templates).
 <!-- For instance, the automatically loaded instruction template for `chatGLM3` model is incorrect, and you should manually select the `chatGLM3` instruction template. -->
 
 ### Tested models
+We have tested the following models with `bigdl-llm` using Text Generation WebUI.
 
 | Model | Notes |
 |-------|-------|

--- a/docs/readthedocs/source/doc/LLM/Quickstart/webui_quickstart.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/webui_quickstart.md
@@ -123,6 +123,43 @@ Enter prompts into the textbox at the bottom and press the **Generate** button t
 To shut down the WebUI server, use **Ctrl+C** in the **Anaconda Prompt** terminal where the WebUI Server is runing, then close your browser tab.
 
 
+## 5. Advanced Usage
+### Using Instruct Chat Mode
+Instruction-following models are models that are fine-tuned with specific prompt formats. 
+<!-- Models with names that contain `instruct` or `chat` could be instruction-following models. -->
+For these models, you should ideally use the `instruct` chat mode.
+Under this mode, the model receives user prompts that are formatted according to prompt formats it was trained with.
+
+To use `instruct` chat mode, select `chat` tab, scroll down the page, and then select `instruct` under `Mode`.
+
+<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_chat_mode_instruct.png">
+  <img src="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_chat_mode_instruct.png" width=100%; />
+</a>
+
+When a model is loaded, its corresponding instruction template, which contains prompt formatting, is automatically loaded.
+
+If chat responses are poor, the loaded instruction template might be incorrect.
+In this case, go to `Parameters` tab and then `Instruction template` tab.
+
+<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_instruction_template.png">
+  <img src="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_instruction_template.png" width=100%; />
+</a>
+
+You can verify and edit the loaded instruction template in the `Instruction template` field.
+You can also manually select an instruction template from `Saved instruction templates` and click `load` to load it into `Instruction template`.
+You can add custom template files to this list in `/instruction-templates/` folder.
+<!-- For instance, the automatically loaded instruction template for `chatGLM3` model is incorrect, and you should manually select the `chatGLM3` instruction template. -->
+
+### Tested models
+|Models|Notes|
+|------|-----|
+| llama-2-7b-chat-hf |     |
+| chatglm3-6b | For Instruct chat mode, manually load 'ChatGLM3' template      |
+| Mistral-7B-v0.1 |     |
+| Falcon-7b-instruct-with-patch     |     |
+| qwen-7B-Chat   | For Instruct chat mode, manually load 'Qwen' template      |
+
+
 ## Troubleshooting
 
 ### Potentially slower first response

--- a/docs/readthedocs/source/doc/LLM/Quickstart/webui_quickstart.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/webui_quickstart.md
@@ -155,8 +155,7 @@ You can add custom template files to this list in `/instruction-templates/` fold
 | llama-2-7b-chat-hf |          |
 | chatglm3-6b        | Manually load ChatGLM3 template for Instruct chat mode |
 | Mistral-7B-v0.1    |          |
-| Falcon-7b-instruct-with-patch |     |
-| qwen-7B-Chat       | Manually load Qwen template for Instruct chat mode |
+| qwen-7B-Chat       |          |
 
 
 ## Troubleshooting

--- a/docs/readthedocs/source/doc/LLM/Quickstart/webui_quickstart.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/webui_quickstart.md
@@ -6,7 +6,7 @@ This quickstart guide walks you through setting up and using the [Text Generatio
 
 A preview of the WebUI in action is shown below:
 
-<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_chat.png">
+<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_chat.png" target="_blank">
   <img src="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_chat.png" width=100%; />
 </a>
 
@@ -71,7 +71,7 @@ In **Anaconda Prompt** with the conda environment `llm` activated, navigate to t
 ### Access the WebUI
 Upon successful launch, URLs to access the WebUI will be displayed in the terminal as shown below. Open the provided local URL in your browser to interact with the WebUI. 
 
-<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_launch_server.png">
+<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_launch_server.png" target="_blank">
   <img src="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_launch_server.png" width=100%; />
 </a>
 
@@ -81,13 +81,13 @@ Upon successful launch, URLs to access the WebUI will be displayed in the termin
 
 Place Huggingface models in `C:\text-generation-webui\models` by either copying locally or downloading via the WebUI. To download, navigate to the **Model** tab, enter the model's huggingface id (for instance, `microsoft/phi-1_5`) in the **Download model or LoRA** section, and click **Download**, as illustrated below. 
 
-<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_download_model.png">
+<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_download_model.png" target="_blank">
   <img src="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_download_model.png" width=100%; />
 </a>
 
 After copying or downloading the models, click on the blue **refresh** button to update the **Model** drop-down menu. Then, choose your desired model from the newly updated list.  
 
-<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_select_model.png">
+<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_select_model.png" target="_blank">
   <img src="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_select_model.png" width=100%; />
 </a>
 
@@ -97,7 +97,7 @@ Default settings are recommended for most users. Click **Load** to activate the 
 
 If everything goes well, you will get a message as shown below.
 
-<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_load_model_success.png">
+<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_load_model_success.png" target="_blank">
   <img src="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_load_model_success.png" width=100%; />
 </a>
 
@@ -107,7 +107,7 @@ In the **Chat** tab, start new conversations with **New chat**.
 
 Enter prompts into the textbox at the bottom and press the **Generate** button to receive responses.
 
-<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_chat.png">
+<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_chat.png" target="_blank">
   <img src="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_chat.png" width=100%; />
 </a>
 
@@ -124,14 +124,14 @@ To shut down the WebUI server, use **Ctrl+C** in the **Anaconda Prompt** termina
 
 
 ## 5. Advanced Usage
-### Using Instruct mode for Chat
+### Using Instruct mode
 Instruction-following models are models that are fine-tuned with specific prompt formats. 
 For these models, you should ideally use the `instruct` chat mode.
 Under this mode, the model receives user prompts that are formatted according to prompt formats it was trained with.
 
 To use `instruct` chat mode, select `chat` tab, scroll down the page, and then select `instruct` under `Mode`.
 
-<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_chat_mode_instruct.png">
+<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_chat_mode_instruct.png" target="_blank">
   <img src="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_chat_mode_instruct.png" width=100%; />
 </a>
 
@@ -139,7 +139,7 @@ When a model is loaded, its corresponding instruction template, which contains p
 If chat responses are poor, the loaded instruction template might be incorrect.
 In this case, go to `Parameters` tab and then `Instruction template` tab.
 
-<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_instruction_template.png">
+<a href="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_instruction_template.png" target="_blank">
   <img src="https://llm-assets.readthedocs.io/en/latest/_images/webui_quickstart_instruction_template.png" width=100%; />
 </a>
 

--- a/docs/readthedocs/source/doc/LLM/Quickstart/webui_quickstart.md
+++ b/docs/readthedocs/source/doc/LLM/Quickstart/webui_quickstart.md
@@ -126,7 +126,6 @@ To shut down the WebUI server, use **Ctrl+C** in the **Anaconda Prompt** termina
 ## 5. Advanced Usage
 ### Using Instruct Chat Mode
 Instruction-following models are models that are fine-tuned with specific prompt formats. 
-<!-- Models with names that contain `instruct` or `chat` could be instruction-following models. -->
 For these models, you should ideally use the `instruct` chat mode.
 Under this mode, the model receives user prompts that are formatted according to prompt formats it was trained with.
 
@@ -137,7 +136,6 @@ To use `instruct` chat mode, select `chat` tab, scroll down the page, and then s
 </a>
 
 When a model is loaded, its corresponding instruction template, which contains prompt formatting, is automatically loaded.
-
 If chat responses are poor, the loaded instruction template might be incorrect.
 In this case, go to `Parameters` tab and then `Instruction template` tab.
 
@@ -151,13 +149,14 @@ You can add custom template files to this list in `/instruction-templates/` fold
 <!-- For instance, the automatically loaded instruction template for `chatGLM3` model is incorrect, and you should manually select the `chatGLM3` instruction template. -->
 
 ### Tested models
-|Models|Notes|
-|------|-----|
-| llama-2-7b-chat-hf |     |
-| chatglm3-6b | For Instruct chat mode, manually load 'ChatGLM3' template      |
-| Mistral-7B-v0.1 |     |
-| Falcon-7b-instruct-with-patch     |     |
-| qwen-7B-Chat   | For Instruct chat mode, manually load 'Qwen' template      |
+
+| Model | Notes |
+|-------|-------|
+| llama-2-7b-chat-hf |          |
+| chatglm3-6b        | Manually load ChatGLM3 template for Instruct chat mode |
+| Mistral-7B-v0.1    |          |
+| Falcon-7b-instruct-with-patch |     |
+| qwen-7B-Chat       | Manually load Qwen template for Instruct chat mode |
 
 
 ## Troubleshooting


### PR DESCRIPTION
## Description

For WebUI quickstart, add a section for using instruct chat mode and instruction templates, and a section for tested models.

### 4. How to test?
https://chtanch-docs.readthedocs.io/en/webui-doc/doc/LLM/Quickstart/webui_quickstart.html