### PR TITLE
LLM: update setup.py to provide `cpp` option for Windows

### DIFF
--- a/python/llm/setup.py
+++ b/python/llm/setup.py
@@ -323,7 +323,7 @@ def setup_package():
                         "xpu-2-0": xpu_20_requires,
                         "xpu-2-1": xpu_21_requires,
                         "serving": serving_requires,
-                        "cpp": ["bigdl-core-cpp==" + VERSION + ";platform_system=='Linux'"]},
+                        "cpp": ["bigdl-core-cpp==" + VERSION]},
         classifiers=[
             'License :: OSI Approved :: Apache Software License',
             'Programming Language :: Python :: 3',


### PR DESCRIPTION
## Description

### 1. Why the change?

To provide `pip install --pre bigdl-llm[cpp]` support for Windows

### 2. User API changes

Suppose in Anaconda prompt in Windows
```bash
pip install --pre bigdl-llm[cpp]
init-llama-cpp.bat
call "C:\Program Files (x86)\Intel\oneAPI\setvars.bat"
main.exe ...
```

### 3. Summary of the change 
With https://github.com/intel-analytics/llm.cpp/pull/282 / https://github.com/intel-analytics/llm.cpp/pull/283 / https://github.com/intel-analytics/llm.cpp/pull/285, now we can provide llama-cpp support for Windows.
- update setup.py to provide `cpp` option for Windows

### 4. How to test?
- [ ] Unit test
