### PR TITLE
[Dependabot]: upgrade org.apache.zookeeper:zookeeper

### DIFF
--- a/scala/dllib/pom.xml
+++ b/scala/dllib/pom.xml
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.7.2</version>
+            <version>3.9.2</version>
             <scope>${spark-scope}</scope>
             <exclusions>
                 <exclusion>

--- a/scala/orca/pom.xml
+++ b/scala/orca/pom.xml
@@ -55,7 +55,7 @@
         <dependency>
             <groupId>org.apache.zookeeper</groupId>
             <artifactId>zookeeper</artifactId>
-            <version>3.7.2</version>
+            <version>3.9.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
 to 3.9.2

## Description

<!-- For small changes (<=3 files and <=50 lines of codes in the source folder), -->
<!-- you may remove Sections 1-4 below and just provide a simple description here -->

### 1. Why the change?

Upgrade org.apache.zookeeper:zookeeper to 3.9.2 to fix Dependabot issues.
https://github.com/intel-analytics/BigDL/security/dependabot/2892
https://github.com/intel-analytics/BigDL/security/dependabot/2893
