### PR TITLE
LLM: add empty cache in deepspeed autotp benchmark script

### DIFF
--- a/python/llm/dev/benchmark/all-in-one/run.py
+++ b/python/llm/dev/benchmark/all-in-one/run.py
@@ -1515,6 +1515,7 @@ def run_deepspeed_optimize_model_gpu(repo_id,
                 output = tokenizer.batch_decode(output_ids)
                 actual_out_len = output_ids.shape[1] - actual_in_len
                 print(output[0])
+                torch.xpu.empty_cache()
                 if i >= warm_up:
                     result[in_out].append([model.first_cost, model.rest_cost_mean, model.encoder_time,
                                            actual_in_len, actual_out_len, load_time])


### PR DESCRIPTION
## Description

Add `torch.xpu.empty_cache()` during every generation

### 4. How to test?
- [x] Unit test
- [x] Local test
