### PR TITLE
Fix(llm-cli): Ensure script exits after displaying help message

### DIFF
--- a/python/llm/src/ipex_llm/cli/llm-cli
+++ b/python/llm/src/ipex_llm/cli/llm-cli
@@ -62,8 +62,7 @@ while [[ $# -gt 0 ]]; do
   case "$1" in
   -h | --help)
     display_help
-    filteredArguments+=("'$1'")
-    shift
+    exit 0
     ;;
   -x | --model_family | --model-family)
     model_family="$2"

--- a/python/llm/test/cli/test_cli.py
+++ b/python/llm/test/cli/test_cli.py
@@ -1,0 +1,11 @@
+import subprocess
+import os
+
+def test_llm_cli_help_fix():
+    """
+    Tests that the llm-cli script exits gracefully after the fix.
+    """
+    cli_path = os.path.abspath(os.path.join(os.path.dirname(__file__), '../../src/ipex_llm/cli/llm-cli'))
+    result = subprocess.run([cli_path, "--help"], capture_output=True, text=True)
+    assert "Invalid model_family" not in result.stdout
+    assert result.returncode == 0


### PR DESCRIPTION
The `llm-cli` script did not exit after displaying the help message when run with the `-h` or `--help` flags. This caused the script to continue execution and display an "Invalid model_family" error.

This commit adds an `exit 0` command after the `display_help` function is called, ensuring that the script exits gracefully after printing the help message.

A new test case has been added to `python/llm/test/cli/test_cli.py` to verify that the fix is working correctly and to prevent future regressions.